### PR TITLE
Fixed firstStartError and fixed notification of brainzplayer

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/presentation/features/brainzplayer/services/BrainzPlayerService.kt
+++ b/app/src/main/java/org/listenbrainz/android/presentation/features/brainzplayer/services/BrainzPlayerService.kt
@@ -7,7 +7,6 @@ import android.support.v4.media.MediaBrowserCompat
 import android.support.v4.media.MediaDescriptionCompat
 import android.support.v4.media.MediaMetadataCompat
 import android.support.v4.media.session.MediaSessionCompat
-import android.util.Log
 import androidx.media.MediaBrowserServiceCompat
 import com.google.android.exoplayer2.ExoPlayer
 import com.google.android.exoplayer2.Player

--- a/app/src/main/java/org/listenbrainz/android/presentation/features/brainzplayer/services/BrainzPlayerService.kt
+++ b/app/src/main/java/org/listenbrainz/android/presentation/features/brainzplayer/services/BrainzPlayerService.kt
@@ -108,7 +108,6 @@ class BrainzPlayerService: MediaBrowserServiceCompat() {
         mediaSessionConnector.setPlayer(exoPlayer)
         brainzPlayerEventListener = BrainzPlayerEventListener(this)
         exoPlayer.addListener(brainzPlayerEventListener)
-        brainzPlayerNotificationManager.showNotification(exoPlayer)
     }
 
     override fun onGetRoot(
@@ -124,8 +123,9 @@ class BrainzPlayerService: MediaBrowserServiceCompat() {
         parentId: String,
         result: Result<MutableList<MediaBrowserCompat.MediaItem>>
     ) {
+        result.detach()
         if (parentId == MEDIA_ROOT_ID) {
-            val resultSent = localMusicSource.whenReady { isInitialized ->
+            localMusicSource.whenReady { isInitialized ->
                 if (isInitialized) {
                     if (!isResultSent) {
                         result.sendResult(localMusicSource.asMediaItem())
@@ -138,9 +138,6 @@ class BrainzPlayerService: MediaBrowserServiceCompat() {
                 } else {
                     result.sendResult(mutableListOf())
                 }
-            }
-            if (!resultSent){
-                result.detach()
             }
         }else{
             result.sendResult(null)

--- a/app/src/main/java/org/listenbrainz/android/presentation/features/brainzplayer/services/notification/BrainzPlayerNotificationManager.kt
+++ b/app/src/main/java/org/listenbrainz/android/presentation/features/brainzplayer/services/notification/BrainzPlayerNotificationManager.kt
@@ -55,6 +55,10 @@ class BrainzPlayerNotificationManager(
     fun showNotification(player: Player) {
         notificationManager.setPlayer(player)
     }
+    
+    fun hideNotification() {
+        notificationManager.setPlayer(null)
+    }
 
     inner class DescriptionAdapter(private val mediaController: MediaControllerCompat) :
         PlayerNotificationManager.MediaDescriptionAdapter {


### PR DESCRIPTION
Fixed firstStartError which crashed the app on first ever launch.
Fixed notification player of BrainzPlayer. Now when the app is stopped, the notification player disappears. The player reappears when app is launched and play button is hit.