### PR TITLE
UI fixes : Fixed colors of some items to be according to theme.

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/presentation/features/brainzplayer/ui/album/AlbumScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/presentation/features/brainzplayer/ui/album/AlbumScreen.kt
@@ -100,9 +100,7 @@ private fun AlbumsList(
                         textAlign = TextAlign.Center,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
-                        color = colorResource(
-                            id = R.color.white
-                        )
+                        color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface
                     )
                     Text(
                         text = it.artist,
@@ -111,9 +109,7 @@ private fun AlbumsList(
                         textAlign = TextAlign.Center,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
-                        color = colorResource(
-                            id = R.color.white
-                        )
+                        color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface
                     )
                 }
             }

--- a/app/src/main/java/org/listenbrainz/android/presentation/features/brainzplayer/ui/artist/ArtistScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/presentation/features/brainzplayer/ui/artist/ArtistScreen.kt
@@ -98,9 +98,7 @@ private fun ArtistsScreen(
                         textAlign = TextAlign.Center,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
-                        color = colorResource(
-                            id = R.color.white
-                        )
+                        color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface
                     )
                 }
             }
@@ -123,7 +121,7 @@ fun OnArtistClickScreen(artistID: String, navHostController: NavHostController) 
                 text = "Albums by the Artist",
                 fontSize = 20.sp,
                 fontWeight = FontWeight.Bold,
-                color = colorResource(id = R.color.white)
+                color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface
             )
         }
         item {
@@ -174,7 +172,7 @@ fun OnArtistClickScreen(artistID: String, navHostController: NavHostController) 
                                 textAlign = TextAlign.Center,
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis,
-                                color = colorResource(id = R.color.white)
+                                color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface
                             )
                         }
                     }
@@ -187,7 +185,7 @@ fun OnArtistClickScreen(artistID: String, navHostController: NavHostController) 
                 text = "Songs by the Artist",
                 fontSize = 20.sp,
                 fontWeight = FontWeight.Bold,
-                color = colorResource(id = R.color.white)
+                color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface
             )
         }
         items(artistSongs){
@@ -220,11 +218,11 @@ fun OnArtistClickScreen(artistID: String, navHostController: NavHostController) 
                     Column(Modifier.padding(start = 10.dp)) {
                         androidx.compose.material.Text(
                             text = it.title,
-                            color = Color.White
+                            color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface
                         )
                         androidx.compose.material.Text(
                             text = it.artist,
-                            color = Color.White
+                            color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface
                         )
                     }
                 }

--- a/app/src/main/java/org/listenbrainz/android/presentation/features/brainzplayer/ui/playlist/PlaylistScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/presentation/features/brainzplayer/ui/playlist/PlaylistScreen.kt
@@ -74,7 +74,7 @@ fun PlaylistScreen(
                 Icon(imageVector = Icons.Rounded.Add, contentDescription = "")
             }
         },
-        containerColor = colorResource(id = R.color.app_bg)
+       // containerColor = colorResource(id = R.color.app_bg)
     ) {
         // Handling FAB button to add playlist
         if (isFABDialogVisible) {
@@ -89,7 +89,7 @@ fun PlaylistScreen(
                         text = "Add Playlist",
                         fontWeight = FontWeight.Bold,
                         fontSize = 20.sp,
-                        color = Color.Black
+                        color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface
                     )
                 },
                 text = {
@@ -113,7 +113,7 @@ fun PlaylistScreen(
                             text = "Add",
                             fontWeight = FontWeight.Bold,
                             fontSize = 20.sp,
-                            color = Color.Black
+                            color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface
                         )
                     }
                 },
@@ -126,7 +126,7 @@ fun PlaylistScreen(
                             text = "Dismiss",
                             fontWeight = FontWeight.Bold,
                             fontSize = 20.sp,
-                            color = Color.Black
+                            color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface
                         )
                     }
                 }
@@ -166,7 +166,7 @@ fun PlaylistScreen(
                             text = "Rename",
                             fontWeight = FontWeight.Bold,
                             fontSize = 20.sp,
-                            color = Color.Black
+                            color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface
                         )
                     }
                 },
@@ -180,7 +180,7 @@ fun PlaylistScreen(
                             text = "Dismiss",
                             fontWeight = FontWeight.Bold,
                             fontSize = 20.sp,
-                            color = Color.Black
+                            color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface
                         )
                     }
                 }
@@ -197,7 +197,7 @@ fun PlaylistScreen(
                         text = "Delete Playlist?",
                         fontWeight = FontWeight.Bold,
                         fontSize = 20.sp,
-                        color = Color.Black
+                        color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface
                     )
                 },
                 confirmButton = {
@@ -217,7 +217,7 @@ fun PlaylistScreen(
                             text = "Delete",
                             fontWeight = FontWeight.Bold,
                             fontSize = 20.sp,
-                            color = Color.Black
+                            color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface
                         )
                     }
                 },
@@ -231,7 +231,7 @@ fun PlaylistScreen(
                             text = "Dismiss",
                             fontWeight = FontWeight.Bold,
                             fontSize = 20.sp,
-                            color = Color.Black
+                            color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface
                         )
                     }
                 }
@@ -286,13 +286,11 @@ fun PlaylistScreen(
                                 textAlign = TextAlign.Center,
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis,
-                                color = colorResource(
-                                    id = R.color.white
-                                )
+                                color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface
                             )
                             Icon(
                                 imageVector = Icons.Rounded.MoreVert,
-                                tint = colorResource(id = R.color.white),
+                                tint = androidx.compose.material3.MaterialTheme.colorScheme.onSurface,
                                 contentDescription = "",
                                 modifier = Modifier.clickable {
                                     selectedPlaylistItemIndex = playlists.indexOf(it)
@@ -367,11 +365,11 @@ fun OnPlaylistClickScreen(playlistID: Long) {
                     Column(Modifier.padding(start = 10.dp)) {
                         Text(
                             text = it.title,
-                            color = Color.White
+                            color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface
                         )
                         Text(
                             text = it.artist,
-                            color = Color.White
+                            color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface
                         )
                     }
                 }

--- a/app/src/main/java/org/listenbrainz/android/presentation/features/brainzplayer/ui/songs/SongScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/presentation/features/brainzplayer/ui/songs/SongScreen.kt
@@ -68,7 +68,7 @@ fun SongScreen() {
                     text = "Add Playlist",
                     fontWeight = FontWeight.Bold,
                     fontSize = 20.sp,
-                    color = Color.Black
+                    color = MaterialTheme.colorScheme.onSurface
                 )
             },
             text = {
@@ -93,7 +93,7 @@ fun SongScreen() {
                         text = "Add",
                         fontWeight = FontWeight.Bold,
                         fontSize = 20.sp,
-                        color = Color.Black
+                        color = MaterialTheme.colorScheme.onSurface
                     )
                 }
             },
@@ -106,7 +106,7 @@ fun SongScreen() {
                         text = "Cancel",
                         fontWeight = FontWeight.Bold,
                         fontSize = 20.sp,
-                        color = Color.Black
+                        color = MaterialTheme.colorScheme.onSurface
                     )
                 }
             }
@@ -140,7 +140,8 @@ fun SongScreen() {
                                 onCheckedChange = {
                                     checkedPlaylistIndices = it
                                     playlistsCollectedFromChecklist.add(playlist)
-                                })
+                                },
+                            colors = CheckboxDefaults.colors(checkedColor = Color.Gray, uncheckedColor = Color.LightGray))
                             Box(modifier = Modifier.fillParentMaxWidth(0.8f)) {
                                 Text(text = playlist.title)
                             }
@@ -164,7 +165,8 @@ fun SongScreen() {
                     songCardMoreOptionsDropMenuExpanded = -1
                     addToExistingPlaylistState = false
                 }) {
-                    Text(text = "Add")
+                    Text(text = "Add",color = MaterialTheme.colorScheme.onSurface)
+
                 }
             },
             dismissButton = {
@@ -172,7 +174,7 @@ fun SongScreen() {
                     songCardMoreOptionsDropMenuExpanded = -1
                     addToExistingPlaylistState = false
                 }) {
-                    Text(text = "Cancel")
+                    Text(text = "Cancel",color = MaterialTheme.colorScheme.onSurface)
                 }
             }
         )
@@ -184,21 +186,21 @@ fun SongScreen() {
         LazyVerticalGrid(columns = GridCells.Fixed(2)) {
             items(songs.value.sortedBy { it.discNumber }) {
                 Box(modifier = Modifier
-                    .padding(2.dp)
-                    .height(240.dp)
-                    .width(200.dp)
-                    .clip(RoundedCornerShape(10.dp))
-                    .clickable {
-                        brainzPlayerViewModel.changePlayable(
-                            songs.value.sortedBy { it.discNumber },
-                            PlayableType.ALL_SONGS,
-                            it.mediaID,
-                            songs.value
-                                .sortedBy { it.discNumber }
-                                .indexOf(it)
-                        )
-                        brainzPlayerViewModel.playOrToggleSong(it, true)
-                    }
+                        .padding(2.dp)
+                        .height(240.dp)
+                        .width(200.dp)
+                        .clip(RoundedCornerShape(10.dp))
+                        .clickable {
+                            brainzPlayerViewModel.changePlayable(
+                                    songs.value.sortedBy { it.discNumber },
+                                    PlayableType.ALL_SONGS,
+                                    it.mediaID,
+                                    songs.value
+                                            .sortedBy { it.discNumber }
+                                            .indexOf(it)
+                            )
+                            brainzPlayerViewModel.playOrToggleSong(it, true)
+                        }
                 ) {
                     DropdownMenu(
                         expanded = songCardMoreOptionsDropMenuExpanded == songs.value.indexOf(it),
@@ -218,15 +220,15 @@ fun SongScreen() {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
                         Box(
                             modifier = Modifier
-                                .padding(10.dp)
-                                .clip(RoundedCornerShape(10.dp))
-                                .size(150.dp)
+                                    .padding(10.dp)
+                                    .clip(RoundedCornerShape(10.dp))
+                                    .size(150.dp)
                         ) {
                             AsyncImage(
                                 modifier = Modifier
-                                    .fillMaxSize()
-                                    .align(Alignment.TopCenter)
-                                    .background(colorResource(id = R.color.bp_bottom_song_viewpager)),
+                                        .fillMaxSize()
+                                        .align(Alignment.TopCenter)
+                                        .background(colorResource(id = R.color.bp_bottom_song_viewpager)),
                                 model = it.albumArt,
                                 contentDescription = "",
                                 error = forwardingPainter(
@@ -241,14 +243,14 @@ fun SongScreen() {
                                 contentScale = ContentScale.Crop
                             )
                             Box(modifier = Modifier
-                                .size(50.dp)
-                                .padding(5.dp)
-                                .clip(CircleShape)
-                                .background(Color.LightGray)
-                                .clickable {
-                                    songCardMoreOptionsDropMenuExpanded = songs.value.indexOf(it)
-                                }
-                                .align(Alignment.BottomEnd),
+                                    .size(50.dp)
+                                    .padding(5.dp)
+                                    .clip(CircleShape)
+                                    .background(Color.LightGray)
+                                    .clickable {
+                                        songCardMoreOptionsDropMenuExpanded = songs.value.indexOf(it)
+                                    }
+                                    .align(Alignment.BottomEnd),
                                 contentAlignment = Alignment.Center
                             ) {
                                 Icon(imageVector = Icons.Rounded.Add, "")
@@ -261,9 +263,7 @@ fun SongScreen() {
                             textAlign = TextAlign.Center,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,
-                            color = colorResource(
-                                id = R.color.white
-                            )
+                            color = MaterialTheme.colorScheme.onSurface
                         )
                         Text(
                             text = it.artist,
@@ -272,9 +272,7 @@ fun SongScreen() {
                             textAlign = TextAlign.Center,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,
-                            color = colorResource(
-                                id = R.color.white
-                            )
+                            color = MaterialTheme.colorScheme.onSurface
                         )
                     }
                 }


### PR DESCRIPTION
**BrainzPlayer Changes**

- Fixed text colors to be readable in both dark and light themes, as the earlier text was the same as the background color in some parts of the app creating a sense of confusion.
- Changed the background of the playlist screen to be the same as others.
- Changed checkbox colors to look more interactive.  

**Changes can be seen below**

![Component 1 (2)](https://user-images.githubusercontent.com/42716731/221373340-5f759f22-bcd2-47dc-95f4-3ed5e38296cf.png)
