### PR TITLE
Feat: All Queue Features are added

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/model/Playable.kt
+++ b/app/src/main/java/org/listenbrainz/android/model/Playable.kt
@@ -4,7 +4,8 @@ data class Playable(
     val type: PlayableType,
     val id: Long,
     val songs: List<Song>,
-    var currentSongIndex : Int
+    var currentSongIndex : Int,
+    var seekTo: Long = 0L
 )
 
 enum class PlayableType{

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/ArtistScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/ArtistScreen.kt
@@ -3,6 +3,7 @@ package org.listenbrainz.android.ui.screens.brainzplayer
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
@@ -12,24 +13,28 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Card
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.MaterialTheme
+import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.Person
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.State
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.drawscope.inset
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
@@ -44,8 +49,13 @@ import coil.compose.AsyncImage
 import org.listenbrainz.android.R
 import org.listenbrainz.android.model.Artist
 import org.listenbrainz.android.model.PlayableType
+import org.listenbrainz.android.service.BrainzPlayerService
 import org.listenbrainz.android.ui.components.BPLibraryEmptyMessage
+import org.listenbrainz.android.ui.components.ListenCardSmall
 import org.listenbrainz.android.ui.components.forwardingPainter
+import org.listenbrainz.android.util.BrainzPlayerExtensions.toSong
+import org.listenbrainz.android.util.LBSharedPreferences
+import org.listenbrainz.android.viewmodel.AlbumViewModel
 import org.listenbrainz.android.viewmodel.ArtistViewModel
 import org.listenbrainz.android.viewmodel.BrainzPlayerViewModel
 
@@ -55,6 +65,7 @@ import org.listenbrainz.android.viewmodel.BrainzPlayerViewModel
 fun ArtistScreen(navHostController: NavHostController) {
     val artistViewModel = hiltViewModel<ArtistViewModel>()
     val artists = artistViewModel.artists.collectAsState(initial = listOf())
+
     val refreshing by artistViewModel.isRefreshing.collectAsState()
     val pullRefreshState = rememberPullRefreshState(
         refreshing = refreshing,
@@ -88,22 +99,65 @@ private fun ArtistsScreen(
     artists: State<List<Artist>>,
     navHostController: NavHostController
 ) {
+    val brainzPlayerViewModel = hiltViewModel<BrainzPlayerViewModel>()
+    val currentlyPlayingSong =
+        brainzPlayerViewModel.currentlyPlayingSong.collectAsState().value.toSong
+    var artistCardMoreOptionsDropMenuExpanded by rememberSaveable { mutableStateOf(-1) }
+    val currentSongIndex = BrainzPlayerService.playableSongs!!.indexOfFirst { song -> song.mediaID==currentlyPlayingSong.mediaID   }+1
     LazyVerticalGrid(columns = GridCells.Fixed(2)) {
-        items(artists.value) {
+        items(artists.value) {artist ->
             Box(modifier = Modifier
                 .padding(2.dp)
                 .height(220.dp)
                 .width(200.dp)
                 .clip(RoundedCornerShape(10.dp))
                 .clickable {
-                    navHostController.navigate("onArtistClick/${it.id}")
+                    navHostController.navigate("onArtistClick/${artist.id}")
                 }
             ) {
+                DropdownMenu(
+                    expanded = artistCardMoreOptionsDropMenuExpanded == artists.value.indexOf(artist),
+                    onDismissRequest = {
+                        artistCardMoreOptionsDropMenuExpanded = -1
+                    }) {
+                    DropdownMenuItem(
+                        text = { Text(text = "Play Next") },
+                        onClick = {
+                            BrainzPlayerService.playableSongs.addAll(currentSongIndex, artist.songs)
+                            brainzPlayerViewModel.changePlayable(
+                                BrainzPlayerService.playableSongs,
+                                PlayableType.ALL_SONGS,
+                                LBSharedPreferences.currentPlayable?.id ?: 0,
+                                BrainzPlayerService.playableSongs.indexOfFirst { song -> song.mediaID==currentlyPlayingSong.mediaID   } ?: 0,brainzPlayerViewModel.songCurrentPosition.value
+                            )
+                            brainzPlayerViewModel.queueChanged(
+                                currentlyPlayingSong,
+                                brainzPlayerViewModel.isPlaying.value
+                            )
+                            artistCardMoreOptionsDropMenuExpanded = -1
+                        })
+                    DropdownMenuItem(
+                        text = { Text(text = "Add to queue") },
+                        onClick = {
+                            BrainzPlayerService.playableSongs.addAll(BrainzPlayerService.playableSongs.size,artist.songs)
+                            brainzPlayerViewModel.changePlayable(
+                                BrainzPlayerService.playableSongs,
+                                PlayableType.ALL_SONGS,
+                                LBSharedPreferences.currentPlayable?.id ?: 0,
+                                BrainzPlayerService.playableSongs.indexOfFirst { song -> song.mediaID==currentlyPlayingSong.mediaID   } ?: 0,brainzPlayerViewModel.songCurrentPosition.value
+                            )
+                            brainzPlayerViewModel.queueChanged(
+                                currentlyPlayingSong,
+                                brainzPlayerViewModel.isPlaying.value
+                            )
+                            artistCardMoreOptionsDropMenuExpanded = -1
+                        })
+                }
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     Box(
                         modifier = Modifier
                             .padding(10.dp)
-                            .clip(CircleShape)
+                            .clip(RoundedCornerShape(10.dp))
                             .size(150.dp)
                     ) {
                         Image(
@@ -111,14 +165,27 @@ private fun ArtistsScreen(
                                 .fillMaxSize()
                                 .align(Alignment.TopCenter)
                                 .background(colorResource(id = R.color.bp_bottom_song_viewpager)),
-                            imageVector = Icons.Rounded.Person,
+                            imageVector = Icons.Default.Person,
                             colorFilter = ColorFilter.tint(colorResource(id = R.color.gray)),
                             contentDescription = "",
                             contentScale = ContentScale.Crop
                         )
+                        Box(modifier = Modifier
+                            .size(50.dp)
+                            .padding(5.dp)
+                            .clip(CircleShape)
+                            .background(Color.LightGray)
+                            .clickable {
+                                artistCardMoreOptionsDropMenuExpanded = artists.value.indexOf(artist)
+                            }
+                            .align(Alignment.BottomEnd),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(imageVector = Icons.Rounded.Add, "")
+                        }
                     }
                     Text(
-                        text = it.name,
+                        text = artist.name,
                         fontSize = 17.sp,
                         fontWeight = FontWeight.Bold,
                         textAlign = TextAlign.Center,
@@ -136,10 +203,18 @@ private fun ArtistsScreen(
 fun OnArtistClickScreen(artistID: String, navHostController: NavHostController) {
     val brainzPlayerViewModel = hiltViewModel<BrainzPlayerViewModel>()
     val artistViewModel = hiltViewModel<ArtistViewModel>()
+    val albumViewModel = hiltViewModel<AlbumViewModel>()
     val artist = artistViewModel.getArtistByID(artistID).collectAsState(initial = Artist()).value
     val artistAlbums =
         artistViewModel.getAllAlbumsOfArtist(artist).collectAsState(initial = listOf()).value.distinctBy { it.albumId }
-    val artistSongs = artistViewModel.getAllSongsOfArtist(artist).collectAsState(initial = listOf()).value.distinctBy { it.mediaID }
+    val artistSongs =
+        artistViewModel.getAllSongsOfArtist(artist).collectAsState(initial = listOf()).value.distinctBy { it.mediaID }
+    val currentlyPlayingSong =
+        brainzPlayerViewModel.currentlyPlayingSong.collectAsState().value.toSong
+    var artistCardMoreOptionsDropMenuExpanded by rememberSaveable { mutableStateOf(-1) }
+    var albumCardMoreOptionsDropMenuExpanded by rememberSaveable { mutableStateOf(-1) }
+    val currentSongIndex =
+        BrainzPlayerService.playableSongs!!.indexOfFirst { song -> song.mediaID == currentlyPlayingSong.mediaID } + 1
 
     LazyColumn {
         item {
@@ -153,6 +228,7 @@ fun OnArtistClickScreen(artistID: String, navHostController: NavHostController) 
         item {
             LazyRow {
                 items(items = artistAlbums) {
+                    val albumSongs = albumViewModel.getAllSongsOfAlbum(it.albumId).collectAsState(listOf()).value
                     Box(
                         modifier = Modifier
                             .height(240.dp)
@@ -164,11 +240,54 @@ fun OnArtistClickScreen(artistID: String, navHostController: NavHostController) 
                             },
                         contentAlignment = Alignment.TopCenter
                     ) {
+                        DropdownMenu(
+                            expanded = albumCardMoreOptionsDropMenuExpanded == artistAlbums.indexOf(it),
+                            onDismissRequest = {
+                                albumCardMoreOptionsDropMenuExpanded = -1
+                            }) {
+                            DropdownMenuItem(
+                                text = { Text(text = "Play Next") },
+                                onClick = {
+                                    BrainzPlayerService.playableSongs.addAll(currentSongIndex, albumSongs)
+                                    brainzPlayerViewModel.changePlayable(
+                                        BrainzPlayerService.playableSongs,
+                                        PlayableType.ALL_SONGS,
+                                        LBSharedPreferences.currentPlayable?.id ?: 0,
+                                        BrainzPlayerService.playableSongs.indexOfFirst { song -> song.mediaID == currentlyPlayingSong.mediaID }
+                                            ?: 0, brainzPlayerViewModel.songCurrentPosition.value
+                                    )
+                                    brainzPlayerViewModel.queueChanged(
+                                        currentlyPlayingSong,
+                                        brainzPlayerViewModel.isPlaying.value
+                                    )
+                                    albumCardMoreOptionsDropMenuExpanded = -1
+                                })
+                            DropdownMenuItem(
+                                text = { Text(text = "Add to queue") },
+                                onClick = {
+                                    BrainzPlayerService.playableSongs.addAll(
+                                        BrainzPlayerService.playableSongs.size,
+                                        albumSongs
+                                    )
+                                    brainzPlayerViewModel.changePlayable(
+                                        BrainzPlayerService.playableSongs,
+                                        PlayableType.ALL_SONGS,
+                                        LBSharedPreferences.currentPlayable?.id ?: 0,
+                                        BrainzPlayerService.playableSongs.indexOfFirst { song -> song.mediaID == currentlyPlayingSong.mediaID }
+                                            ?: 0, brainzPlayerViewModel.songCurrentPosition.value
+                                    )
+                                    brainzPlayerViewModel.queueChanged(
+                                        currentlyPlayingSong,
+                                        brainzPlayerViewModel.isPlaying.value
+                                    )
+                                    albumCardMoreOptionsDropMenuExpanded = -1
+                                })
+                        }
                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
                             Box(
                                 modifier = Modifier
                                     .padding(10.dp)
-                                    .clip(CircleShape)
+                                    .clip(RoundedCornerShape(10.dp))
                                     .background(color = colorResource(id = R.color.bp_bottom_song_viewpager))
                                     .size(150.dp)
                             ) {
@@ -176,7 +295,7 @@ fun OnArtistClickScreen(artistID: String, navHostController: NavHostController) 
                                     modifier = Modifier
                                         .fillMaxSize()
                                         .align(Alignment.TopCenter)
-                                        .clip(CircleShape),
+                                        .clip(RoundedCornerShape(10.dp)),
                                     model = it.albumArt,
                                     contentDescription = "",
                                     error = forwardingPainter(
@@ -190,6 +309,19 @@ fun OnArtistClickScreen(artistID: String, navHostController: NavHostController) 
                                     },
                                     contentScale = ContentScale.Crop
                                 )
+                                Box(modifier = Modifier
+                                    .size(50.dp)
+                                    .padding(5.dp)
+                                    .clip(CircleShape)
+                                    .background(Color.LightGray)
+                                    .clickable {
+                                        albumCardMoreOptionsDropMenuExpanded = artistAlbums.indexOf(it)
+                                    }
+                                    .align(Alignment.BottomEnd),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Icon(imageVector = Icons.Rounded.Add, "")
+                                }
                             }
                             Text(
                                 text = it.title,
@@ -214,44 +346,94 @@ fun OnArtistClickScreen(artistID: String, navHostController: NavHostController) 
                 color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface
             )
         }
-        items(artistSongs){
-            Card(
-                modifier = Modifier
-                    .padding(10.dp)
-                    .fillMaxWidth(0.98f)
-                    .clickable {
+        items(artistSongs) {
+            BoxWithConstraints {
+                val maxWidth =
+                    (maxWidth - 60.dp).coerceAtMost(600.dp)
+                Row(
+                    horizontalArrangement = Arrangement.Start,
+                    verticalAlignment = Alignment.CenterVertically
+                )
+                {
+                    val modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp).width(maxWidth)
+                    ListenCardSmall(
+                        modifier = modifier,
+                        releaseName = it.title,
+                        artistName = it.artist,
+                        coverArtUrl = it.albumArt,
+                        imageLoadSize = 200,
+                        useSystemTheme = true,
+                        errorAlbumArt = R.drawable.ic_erroralbumart
+                    ) {
                         brainzPlayerViewModel.changePlayable(
                             artistSongs,
                             PlayableType.ARTIST,
                             it.artistId,
-                            artistSongs.indexOf(it)
+                            artistSongs.indexOf(it),
+                            0L
                         )
                         brainzPlayerViewModel.playOrToggleSong(it, true)
-                    },
-                backgroundColor = MaterialTheme.colors.onSurface
-            ) {
-                Spacer(modifier = Modifier.height(50.dp))
-                Row(horizontalArrangement = Arrangement.Start) {
-                    AsyncImage(
-                        model = it.albumArt,
-                        contentDescription = "",
-                        error = painterResource(
-                            id = R.drawable.ic_erroralbumart
-                        ),
-                        contentScale = ContentScale.FillBounds,
-                        modifier = Modifier.size(70.dp)
-                    )
-                    Column(Modifier.padding(start = 10.dp)) {
-                        androidx.compose.material.Text(
-                            text = it.title,
-                            color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface
+                    }
+                    androidx.compose.material3.Surface(
+                        shape = RoundedCornerShape(5.dp),
+                        shadowElevation = 5.dp
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Menu,
+                            contentDescription = "",
+                            modifier = Modifier
+                                .padding(10.dp)
+                                .clickable {
+                                    artistCardMoreOptionsDropMenuExpanded = artistSongs.indexOf(it)
+                                }
                         )
-                        androidx.compose.material.Text(
-                            text = it.artist,
-                            color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface
-                        )
+                        DropdownMenu(
+                            expanded = artistCardMoreOptionsDropMenuExpanded == artistSongs.indexOf(it),
+                            onDismissRequest = {
+                                artistCardMoreOptionsDropMenuExpanded = -1
+                            }) {
+                            DropdownMenuItem(
+                                text = { Text(text = "Play Next") },
+                                onClick = {
+                                    BrainzPlayerService.playableSongs.add(currentSongIndex, it)
+                                    brainzPlayerViewModel.changePlayable(
+                                        BrainzPlayerService.playableSongs,
+                                        PlayableType.ALL_SONGS,
+                                        LBSharedPreferences.currentPlayable?.id ?: 0,
+                                        BrainzPlayerService.playableSongs.indexOfFirst { song -> song.mediaID == currentlyPlayingSong.mediaID }
+                                            ?: 0, brainzPlayerViewModel.songCurrentPosition.value
+                                    )
+                                    brainzPlayerViewModel.queueChanged(
+                                        currentlyPlayingSong,
+                                        brainzPlayerViewModel.isPlaying.value
+                                    )
+                                    artistCardMoreOptionsDropMenuExpanded = -1
+                                })
+                            DropdownMenuItem(
+                                text = { Text(text = "Add to queue") },
+                                onClick = {
+                                    BrainzPlayerService.playableSongs.add(
+                                        BrainzPlayerService.playableSongs.size,
+                                        it
+                                    )
+                                    brainzPlayerViewModel.changePlayable(
+                                        BrainzPlayerService.playableSongs,
+                                        PlayableType.ALL_SONGS,
+                                        LBSharedPreferences.currentPlayable?.id ?: 0,
+                                        BrainzPlayerService.playableSongs.indexOfFirst { song -> song.mediaID == currentlyPlayingSong.mediaID }
+                                            ?: 0, brainzPlayerViewModel.songCurrentPosition.value
+                                    )
+                                    brainzPlayerViewModel.queueChanged(
+                                        currentlyPlayingSong,
+                                        brainzPlayerViewModel.isPlaying.value
+                                    )
+                                    artistCardMoreOptionsDropMenuExpanded = -1
+                                }
+                            )
+                        }
                     }
                 }
+
             }
 
         }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
@@ -44,6 +44,7 @@ import org.listenbrainz.android.model.PlayableType
 import org.listenbrainz.android.model.Playlist.Companion.recentlyPlayed
 import org.listenbrainz.android.model.RepeatMode
 import org.listenbrainz.android.model.Song
+import org.listenbrainz.android.service.BrainzPlayerService
 import org.listenbrainz.android.ui.components.ListenCardSmall
 import org.listenbrainz.android.ui.components.PlayPauseIcon
 import org.listenbrainz.android.ui.components.SeekBar
@@ -76,7 +77,7 @@ fun BrainzPlayerBackDropScreen(
     }
     val repeatMode by brainzPlayerViewModel.repeatMode.collectAsState()
     val headerHeight by animateDpAsState(targetValue = if (currentlyPlayingSong.title == "null" && currentlyPlayingSong.artist == "null") 0.dp else 136.dp)
-    
+
     BackdropScaffold(
         frontLayerShape = RectangleShape,
         backLayerBackgroundColor = MaterialTheme.colorScheme.background,
@@ -142,7 +143,7 @@ fun AlbumArtViewPager(viewModel: BrainzPlayerViewModel) {
                             // scroll position. We use the absolute value which allows us to mirror
                             // any effects for both directions
                             val pageOffset = calculateCurrentOffsetForPage(page).absoluteValue
-        
+
                             // We animate the scaleX + scaleY, between 85% and 100%
                             lerp(
                                 start = 0.85f,
@@ -152,7 +153,7 @@ fun AlbumArtViewPager(viewModel: BrainzPlayerViewModel) {
                                 scaleX = scale
                                 scaleY = scale
                             }
-        
+
                             // We animate the alpha, between 50% and 100%
                             alpha = lerp(
                                 start = 0.5f,
@@ -371,7 +372,7 @@ fun PlayerScreen(
             }
         }
         val checkedSongs = mutableStateListOf<Song>()
-        var songs = LBSharedPreferences.currentPlayable?.songs?.toMutableList() ?: mutableListOf()
+        val songs = BrainzPlayerService.playableSongs ?: mutableListOf()
         item {
             Row(
                 modifier = Modifier.fillMaxWidth().padding(start = 5.dp),
@@ -388,16 +389,17 @@ fun PlayerScreen(
                 Button(
                     onClick = {
                         checkedSongs.forEach { song ->
-                            songs.remove(song)
+                            BrainzPlayerService.playableSongs.remove(song)
                         }
                         brainzPlayerViewModel.changePlayable(
-                            songs,
+                            BrainzPlayerService.playableSongs,
                             PlayableType.ALL_SONGS,
                             LBSharedPreferences.currentPlayable?.id ?: 0,
-                            songs.indexOfFirst { it.mediaID == currentlyPlayingSong.mediaID } ?: 0
+                            BrainzPlayerService.playableSongs.indexOfFirst { it.mediaID == currentlyPlayingSong.mediaID } ?: 0,brainzPlayerViewModel.songCurrentPosition.value
                         )
                         brainzPlayerViewModel.queueChanged(
-                            !brainzPlayerViewModel.isPlaying.value
+                            currentlyPlayingSong,
+                            brainzPlayerViewModel.isPlaying.value
                         )
                         checkedSongs.clear()
                     },
@@ -418,9 +420,8 @@ fun PlayerScreen(
                 }
             }
         }
-        
         // Playlist
-        itemsIndexed(items = songs) {index, song ->
+        itemsIndexed(items = BrainzPlayerService.playableSongs) {index, song ->
             val isChecked = checkedSongs.contains(song)
             BoxWithConstraints {
                 val maxWidth =
@@ -445,6 +446,7 @@ fun PlayerScreen(
                         errorAlbumArt = R.drawable.ic_erroralbumart
                     ) {
                         brainzPlayerViewModel.skipToPlayable(index)
+                        brainzPlayerViewModel.changePlayable(BrainzPlayerService.playableSongs, PlayableType.ALL_SONGS, LBSharedPreferences.currentPlayable?.id ?: 0, index,0L)
                         brainzPlayerViewModel.playOrToggleSong(song, true)
                     }
                     if (currentlyPlayingSong.mediaID!=song.mediaID) {
@@ -479,7 +481,7 @@ fun PlayerScreen(
             Spacer(modifier = Modifier.height(56.dp))
         }
     }
-    
+
     // TODO: fix this
     val cache= App.context?.let { CacheService<Song>(it, RECENTLY_PLAYED_KEY) }
     cache?.saveData(currentlyPlayingSong, Song::class.java)

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
@@ -466,9 +466,9 @@ fun PlayerScreen(
                                 modifier = Modifier
                                     .size(45.dp),
                                 colors = CheckboxDefaults.colors(
-                                    checkmarkColor = androidx.compose.material.MaterialTheme.colors.onSurface,
-                                    disabledColor = androidx.compose.material.MaterialTheme.colors.onSurface,
-                                    uncheckedColor = androidx.compose.material.MaterialTheme.colors.onSurface,
+                                    checkmarkColor = MaterialTheme.colorScheme.onSurface,
+                                    disabledColor = MaterialTheme.colorScheme.onSurface,
+                                    uncheckedColor = MaterialTheme.colorScheme.onSurface,
                                 )
                             )
                         }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerScreen.kt
@@ -130,7 +130,7 @@ fun BrainzPlayerHomeScreen(
                     title = it.title,
                     modifier = Modifier
                         .clickable {
-                            brainzPlayerViewModel.changePlayable(recentlyPlayedSongs.items, PlayableType.ALL_SONGS, it.mediaID,recentlyPlayedSongs.items.sortedBy { it.discNumber }.indexOf(it))
+                            brainzPlayerViewModel.changePlayable(recentlyPlayedSongs.items, PlayableType.ALL_SONGS, it.mediaID,recentlyPlayedSongs.items.sortedBy { it.discNumber }.indexOf(it),0L)
                             brainzPlayerViewModel.playOrToggleSong(it, true)
                         }
                 )

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/PlaylistScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/PlaylistScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material3.*
@@ -37,8 +38,13 @@ import androidx.navigation.NavHostController
 import coil.compose.AsyncImage
 import kotlinx.coroutines.launch
 import org.listenbrainz.android.R
+import org.listenbrainz.android.model.PlayableType
 import org.listenbrainz.android.model.Playlist
+import org.listenbrainz.android.service.BrainzPlayerService
+import org.listenbrainz.android.ui.components.ListenCardSmall
 import org.listenbrainz.android.ui.components.forwardingPainter
+import org.listenbrainz.android.util.BrainzPlayerExtensions.toSong
+import org.listenbrainz.android.util.LBSharedPreferences
 import org.listenbrainz.android.viewmodel.BrainzPlayerViewModel
 import org.listenbrainz.android.viewmodel.PlaylistViewModel
 
@@ -50,6 +56,11 @@ fun PlaylistScreen(
     navHostController: NavHostController,
     context: Context = LocalContext.current
 ) {
+    val brainzPlayerViewModel = hiltViewModel<BrainzPlayerViewModel>()
+    val currentlyPlayingSong =
+        brainzPlayerViewModel.currentlyPlayingSong.collectAsState().value.toSong
+    val currentSongIndex =
+        BrainzPlayerService.playableSongs!!.indexOfFirst { song -> song.mediaID == currentlyPlayingSong.mediaID } + 1
     var isFABDialogVisible by rememberSaveable {
         mutableStateOf(false)
     }
@@ -59,7 +70,6 @@ fun PlaylistScreen(
     var deletePlaylistState by remember {
         mutableStateOf(false)
     }
-    val brainzPlayerViewModel = hiltViewModel<BrainzPlayerViewModel>()
     val coroutineScope = rememberCoroutineScope()
     val playlistViewModel = hiltViewModel<PlaylistViewModel>()
     val playlists by playlistViewModel.playlists.collectAsState(initial = listOf())
@@ -316,6 +326,43 @@ fun PlaylistScreen(
                                     renamePlaylistDialog = true
                                     selectedPlaylistItemIndex = playlists.indexOf(it)
                                 })
+                                DropdownMenuItem(
+                                    text = { Text(text = "Play Next") },
+                                    onClick = {
+                                        BrainzPlayerService.playableSongs.addAll(currentSongIndex, it.items)
+                                        brainzPlayerViewModel.changePlayable(
+                                            BrainzPlayerService.playableSongs,
+                                            PlayableType.ALL_SONGS,
+                                            LBSharedPreferences.currentPlayable?.id ?: 0,
+                                            BrainzPlayerService.playableSongs.indexOfFirst { song -> song.mediaID == currentlyPlayingSong.mediaID }
+                                                ?: 0, brainzPlayerViewModel.songCurrentPosition.value
+                                        )
+                                        brainzPlayerViewModel.queueChanged(
+                                            currentlyPlayingSong,
+                                            brainzPlayerViewModel.isPlaying.value
+                                        )
+                                        selectedPlaylistItemIndex = -1
+                                    })
+                                DropdownMenuItem(
+                                    text = { Text(text = "Add to queue") },
+                                    onClick = {
+                                        BrainzPlayerService.playableSongs.addAll(
+                                            BrainzPlayerService.playableSongs.size,
+                                            it.items
+                                        )
+                                        brainzPlayerViewModel.changePlayable(
+                                            BrainzPlayerService.playableSongs,
+                                            PlayableType.ALL_SONGS,
+                                            LBSharedPreferences.currentPlayable?.id ?: 0,
+                                            BrainzPlayerService.playableSongs.indexOfFirst { song -> song.mediaID == currentlyPlayingSong.mediaID }
+                                                ?: 0, brainzPlayerViewModel.songCurrentPosition.value
+                                        )
+                                        brainzPlayerViewModel.queueChanged(
+                                            currentlyPlayingSong,
+                                            brainzPlayerViewModel.isPlaying.value
+                                        )
+                                        selectedPlaylistItemIndex = -1
+                                    })
                                 if (it.id != (-1).toLong() && it.id != (0).toLong() && it.id != (1).toLong())
                                     DropdownMenuItem(
                                         text = { Text(text = "Delete Playlist") },
@@ -340,37 +387,101 @@ fun OnPlaylistClickScreen(playlistID: Long) {
     val playlistViewModel = hiltViewModel<PlaylistViewModel>()
     val selectedPlaylist =
         playlistViewModel.getPlaylistByID(playlistID).collectAsState(Playlist()).value
+    var selectedPlaylistItemIndex by remember {
+        mutableStateOf(-1)
+    }
+    val currentlyPlayingSong =
+        brainzPlayerViewModel.currentlyPlayingSong.collectAsState().value.toSong
+    val currentSongIndex =
+        BrainzPlayerService.playableSongs!!.indexOfFirst { song -> song.mediaID == currentlyPlayingSong.mediaID } + 1
     LazyColumn {
         items(selectedPlaylist.items) {
-            androidx.compose.material.Card(
-                modifier = Modifier
-                    .padding(10.dp)
-                    .clickable {
+            BoxWithConstraints {
+                val maxWidth =
+                    (maxWidth - 60.dp).coerceAtMost(600.dp)
+                Row(
+                    horizontalArrangement = Arrangement.Start,
+                    verticalAlignment = Alignment.CenterVertically
+                )
+                {
+                    val modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp).width(maxWidth)
+                    ListenCardSmall(
+                        modifier = modifier,
+                        releaseName = it.title,
+                        artistName = it.artist,
+                        coverArtUrl = it.albumArt,
+                        imageLoadSize = 200,
+                        useSystemTheme = true,
+                        errorAlbumArt = R.drawable.ic_erroralbumart
+                    ) {
+                        brainzPlayerViewModel.changePlayable(
+                            selectedPlaylist.items.sortedBy { it.trackNumber },
+                            PlayableType.ALBUM,
+                            it.albumID,
+                            selectedPlaylist.items
+                                .sortedBy { it.trackNumber }
+                                .indexOf(it),
+                            0L
+                        )
                         brainzPlayerViewModel.playOrToggleSong(it, true)
                     }
-                    .fillMaxWidth(0.98f),
-                backgroundColor = MaterialTheme.colors.onSurface
-            ) {
-                Spacer(modifier = Modifier.height(50.dp))
-                Row(horizontalArrangement = Arrangement.Start) {
-                    AsyncImage(
-                        model = it.albumArt,
-                        contentDescription = "",
-                        error = painterResource(
-                            id = R.drawable.ic_erroralbumart
-                        ),
-                        contentScale = ContentScale.FillBounds,
-                        modifier = Modifier.size(70.dp)
-                    )
-                    Column(Modifier.padding(start = 10.dp)) {
-                        Text(
-                            text = it.title,
-                            color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface
+                    androidx.compose.material3.Surface(
+                        shape = RoundedCornerShape(5.dp),
+                        shadowElevation = 5.dp
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Menu,
+                            contentDescription = "",
+                            modifier = Modifier
+                                .padding(10.dp)
+                                .clickable {
+                                    selectedPlaylistItemIndex = selectedPlaylist.items.indexOf(it)
+                                }
                         )
-                        Text(
-                            text = it.artist,
-                            color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface
-                        )
+                        DropdownMenu(
+                            expanded = selectedPlaylistItemIndex == selectedPlaylist.items.indexOf(it),
+                            onDismissRequest = {
+                                selectedPlaylistItemIndex = -1
+                            }) {
+                            DropdownMenuItem(
+                                text = { Text(text = "Play Next") },
+                                onClick = {
+                                    BrainzPlayerService.playableSongs.add(currentSongIndex, it)
+                                    brainzPlayerViewModel.changePlayable(
+                                        BrainzPlayerService.playableSongs,
+                                        PlayableType.ALL_SONGS,
+                                        LBSharedPreferences.currentPlayable?.id ?: 0,
+                                        BrainzPlayerService.playableSongs.indexOfFirst { song -> song.mediaID == currentlyPlayingSong.mediaID }
+                                            ?: 0, brainzPlayerViewModel.songCurrentPosition.value
+                                    )
+                                    brainzPlayerViewModel.queueChanged(
+                                        currentlyPlayingSong,
+                                        brainzPlayerViewModel.isPlaying.value
+                                    )
+                                    selectedPlaylistItemIndex = -1
+                                })
+                            DropdownMenuItem(
+                                text = { Text(text = "Add to queue") },
+                                onClick = {
+                                    BrainzPlayerService.playableSongs.add(
+                                        BrainzPlayerService.playableSongs.size,
+                                        it
+                                    )
+                                    brainzPlayerViewModel.changePlayable(
+                                        BrainzPlayerService.playableSongs,
+                                        PlayableType.ALL_SONGS,
+                                        LBSharedPreferences.currentPlayable?.id ?: 0,
+                                        BrainzPlayerService.playableSongs.indexOfFirst { song -> song.mediaID == currentlyPlayingSong.mediaID }
+                                            ?: 0, brainzPlayerViewModel.songCurrentPosition.value
+                                    )
+                                    brainzPlayerViewModel.queueChanged(
+                                        currentlyPlayingSong,
+                                        brainzPlayerViewModel.isPlaying.value
+                                    )
+                                    selectedPlaylistItemIndex = -1
+                                }
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/org/listenbrainz/android/viewmodel/BrainzPlayerViewModel.kt
+++ b/app/src/main/java/org/listenbrainz/android/viewmodel/BrainzPlayerViewModel.kt
@@ -158,14 +158,20 @@ class BrainzPlayerViewModel @Inject constructor(
         }
     }
 
-    fun queueChanged(toggle: Boolean ) {
-         if (toggle) brainzPlayerServiceConnection.transportControls.pause()
-        else brainzPlayerServiceConnection.transportControls.play()
+    fun queueChanged(mediaItem: Song,toggle: Boolean ) {
+        brainzPlayerServiceConnection.transportControls.playFromMediaId(mediaItem.mediaID.toString(), null)
+        playbackState.value.let { playbackState ->
+            when {
+                playbackState.isPlaying -> if (!toggle) brainzPlayerServiceConnection.transportControls.pause()
+                playbackState.isPlayEnabled -> brainzPlayerServiceConnection.transportControls.play()
+                else -> Unit
+            }
+        }
     }
 
-    fun changePlayable(newPlayableList: List<Song>, playableType: PlayableType, playableId: Long, currentIndex: Int ) {
+    fun changePlayable(newPlayableList: List<Song>, playableType: PlayableType, playableId: Long, currentIndex: Int, seekTo: Long = 0L ) {
         appPreferences.currentPlayable =
-            Playable(playableType, playableId, newPlayableList, currentIndex)
+            Playable(playableType, playableId, newPlayableList, currentIndex, seekTo)
     }
     
     /**Skip to the given song at given [index] in the current playlist.*/


### PR DESCRIPTION
This PR contains the feature to add a song, Playlist, or album to the queue, and also has a feature for playing next. 
Some changes in UI such as making the card as same as the queue card because there are two different types of cards to show the list of songs and a drop-down button so the user can choose to play next or to add to the queue.


@akshaaatt bhaiya can you please review it and suggest any changes if required? 
