### PR TITLE
Small fix in Favouritescreen UI (Song Title and Artist name are not displaying in light theme)

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/PlaylistScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/PlaylistScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.inset
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -365,11 +366,13 @@ fun OnPlaylistClickScreen(playlistID: Long) {
                     Column(Modifier.padding(start = 10.dp)) {
                         Text(
                             text = it.title,
-                            color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface
+                           // color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface
+                            color= Color.White
                         )
                         Text(
                             text = it.artist,
-                            color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface
+                            //color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface
+                            color= Color.White
                         )
                     }
                 }


### PR DESCRIPTION

### Description: 

In the FavouriteSong screen, The song name and artist name are not displaying.
![gsoc_prob_1](https://user-images.githubusercontent.com/87614560/227691443-d808c4f2-5430-4e71-abfe-5074573fbf16.jpeg)

### Solution:

**Light Theme:**

![gsoc_final_sol](https://user-images.githubusercontent.com/87614560/227691722-fa0a6fba-4050-4e11-86fa-200e3db25f35.jpeg)

**Dark Theme:**



![gsoc_sol1](https://user-images.githubusercontent.com/87614560/227691898-c51b66da-e443-42cc-b6da-ed3f92c1744c.jpeg)
