### PR TITLE
ListenService and YIM fixed

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,8 +101,10 @@ android {
 dependencies {
     //AndroidX
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.0'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.1'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.6.1'
+    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.6.1'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     implementation 'androidx.core:core-ktx:1.9.0'
     implementation 'androidx.browser:browser:1.5.0'
@@ -123,8 +125,6 @@ dependencies {
     implementation "com.github.bumptech.glide:compose:1.0.0-alpha.1"
     implementation 'io.coil-kt:coil-compose:2.2.2'
     implementation 'com.caverock:androidsvg-aar:1.4'
-    implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.0'
     kapt 'com.github.bumptech.glide:compiler:4.15.0'
 
     //Permissions
@@ -134,7 +134,6 @@ dependencies {
     implementation "androidx.navigation:navigation-fragment-ktx:$navigationVersion"
     implementation "androidx.navigation:navigation-ui-ktx:$navigationVersion"
     implementation 'androidx.coordinatorlayout:coordinatorlayout:1.2.0'
-    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.6.0'
 
     //Design Setup
     implementation 'com.google.android.material:material:1.9.0-beta01'
@@ -145,27 +144,25 @@ dependencies {
     //Dagger-Hilt
     implementation("com.google.dagger:hilt-android:$hilt_version")
     kapt("com.google.dagger:hilt-android-compiler:$hilt_version")
-    implementation group: 'androidx.lifecycle', name: 'lifecycle-viewmodel-ktx', version: '2.6.0'
     kapt("androidx.hilt:hilt-compiler:1.0.0")
 
     //Jetpack Compose
-    implementation "androidx.compose.ui:ui:1.3.3"
+    implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.ui:ui-tooling:$compose_version"
-    implementation "androidx.compose.ui:ui-util:1.3.3"
-    implementation "androidx.compose.material:material:1.3.1"
-    implementation "androidx.compose.material:material-icons-extended:1.3.1"
+    implementation "androidx.compose.ui:ui-util:$compose_version"
+    implementation "androidx.compose.material:material:$compose_version"
+    implementation "androidx.compose.material:material-icons-extended:$compose_version"
     implementation 'androidx.compose.material3:material3:1.0.1'
     implementation 'androidx.compose.material3:material3-window-size-class:1.0.1'
     implementation "androidx.compose.animation:animation:$compose_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     implementation 'androidx.constraintlayout:constraintlayout-compose:1.0.1'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.6.0'
     implementation 'androidx.hilt:hilt-navigation-compose:1.0.0'
     implementation 'com.airbnb.android:lottie-compose:6.0.0'
-    implementation 'androidx.activity:activity-compose:1.6.1'
+    implementation 'androidx.activity:activity-compose:1.7.0'
 
     // Compose Navigation
-    implementation 'androidx.navigation:navigation-compose:2.6.0-alpha07'     // Stable one
+    implementation 'androidx.navigation:navigation-compose:2.6.0-alpha08'     // Stable one
     implementation "com.google.accompanist:accompanist-navigation-animation:$accompanist_version"     // Experimental but has animations
 
     //Spotify
@@ -176,7 +173,6 @@ dependencies {
     testImplementation 'com.squareup.okhttp3:mockwebserver:5.0.0-alpha.11'
     testImplementation 'androidx.arch.core:core-testing:2.2.0'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4'
-    testImplementation "androidx.room:room-testing:2.5.0"
 
     debugImplementation "androidx.test:monitor:1.6.1"       // Solves "class PlatformTestStorageRegistery not found" error for ui tests.
     debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
@@ -200,14 +196,15 @@ dependencies {
     implementation "com.google.accompanist:accompanist-pager:$accompanist_version"
 
     //Exoplayer
-    api 'com.google.android.exoplayer:exoplayer-core:2.18.4'
-    api 'com.google.android.exoplayer:exoplayer-ui:2.18.4'
-    api 'com.google.android.exoplayer:extension-mediasession:2.18.4'
+    api "com.google.android.exoplayer:exoplayer-core:$exoplayer_version"
+    api "com.google.android.exoplayer:exoplayer-ui:$exoplayer_version"
+    api "com.google.android.exoplayer:extension-mediasession:$exoplayer_version"
 
     //Room db
     implementation "androidx.room:room-runtime:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
     implementation "androidx.room:room-ktx:$room_version"
+    testImplementation "androidx.room:room-testing:$room_version"
 
     //Jetpack Compose accompanists (https://github.com/google/accompanist)
     implementation "com.google.accompanist:accompanist-systemuicontroller:$accompanist_version"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,7 +37,7 @@
             android:name=".service.ListenService"
             android:enabled="true"
             android:exported="true"
-            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE" >
+            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE">
             <intent-filter>
                 <action android:name="android.service.notification.NotificationListenerService" />
             </intent-filter>

--- a/app/src/main/java/org/listenbrainz/android/model/AdditionalInfo.kt
+++ b/app/src/main/java/org/listenbrainz/android/model/AdditionalInfo.kt
@@ -1,20 +1,28 @@
 package org.listenbrainz.android.model
 
 data class AdditionalInfo(
-    val artist_msid: String,
-    val artist_names: List<String>,
-    val discnumber: Int,
-    val duration_ms: Int,
-    val isrc: String,
-    val listening_from: String,
-    val recording_msid: String,
-    val release_artist_name: String,
-    val release_artist_names: List<String>,
-    val release_msid: String,
-    val release_mbid: String? = null,
-    val spotify_album_artist_ids: List<String>,
-    val spotify_album_id: String,
-    val spotify_artist_ids: List<String>,
-    val spotify_id: String?,
-    val tracknumber: Int
+    var artist_msid: String? = null,
+    var artist_names: List<String> = listOf(),
+    var discnumber: Int? = null,
+    var duration_ms: Int? = null,
+    var isrc: String? = null,
+    var listening_from: String? = null,
+    var recording_msid: String? = null,
+    var release_artist_name: String? = null,
+    var release_artist_names: List<String> = listOf(),
+    var release_msid: String? = null,
+    var release_mbid: String? = null,
+    var spotify_album_artist_ids: List<String> = listOf(),
+    var spotify_album_id: String? = null,
+    var spotify_artist_ids: List<String> = listOf(),
+    var spotify_id: String? = null,
+    var tracknumber: Int? = null,
+    
+    // Used for listen submission body
+    var media_player: String? = null,
+    var submission_client: String? = null,
+    var submission_client_version: String? = null
+    /*"media_player": "Rhythmbox",
+    "submission_client": "Rhythmbox ListenBrainz Plugin",
+    "submission_client_version": "1.0",*/
 )

--- a/app/src/main/java/org/listenbrainz/android/model/AdditionalInfo.kt
+++ b/app/src/main/java/org/listenbrainz/android/model/AdditionalInfo.kt
@@ -22,7 +22,4 @@ data class AdditionalInfo(
     var media_player: String? = null,
     var submission_client: String? = null,
     var submission_client_version: String? = null
-    /*"media_player": "Rhythmbox",
-    "submission_client": "Rhythmbox ListenBrainz Plugin",
-    "submission_client_version": "1.0",*/
 )

--- a/app/src/main/java/org/listenbrainz/android/model/ListenSubmitBody.kt
+++ b/app/src/main/java/org/listenbrainz/android/model/ListenSubmitBody.kt
@@ -1,6 +1,7 @@
 package org.listenbrainz.android.model
 
 import com.google.gson.annotations.SerializedName
+import org.listenbrainz.android.BuildConfig
 import java.util.*
 
 class ListenSubmitBody {
@@ -21,9 +22,15 @@ class ListenSubmitBody {
     }
 
     fun addListen(timestamp: Long, metadata: ListenTrackMetadata) {
-        payload.add(Payload(timestamp, metadata))
+        payload.add(Payload(timestamp, metadata).setClientDetails())
     }
 
+    private fun Payload.setClientDetails(): Payload{
+        this.metadata.additionalInfo.submission_client = BuildConfig.APPLICATION_ID
+        this.metadata.additionalInfo.submission_client_version = BuildConfig.VERSION_NAME
+        return this
+    }
+    
     override fun toString(): String {
         return "ListenSubmitBody{" +
                 "listenType='" + listenType + '\'' +

--- a/app/src/main/java/org/listenbrainz/android/model/ListenTrackMetadata.kt
+++ b/app/src/main/java/org/listenbrainz/android/model/ListenTrackMetadata.kt
@@ -11,6 +11,10 @@ class ListenTrackMetadata {
 
     @SerializedName("release_name")
     var release: String? = null
+    
+    @SerializedName("additional_info")
+    var additionalInfo: AdditionalInfo = AdditionalInfo()
+    
     override fun toString(): String {
         return "ListenTrackMetadata{" +
                 "artist='" + artist + '\'' +

--- a/app/src/main/java/org/listenbrainz/android/model/MbidMapping.kt
+++ b/app/src/main/java/org/listenbrainz/android/model/MbidMapping.kt
@@ -2,6 +2,8 @@ package org.listenbrainz.android.model
 
 data class MbidMapping(
     val artist_mbids: List<String>,
+    val caa_id: Long? = null,
+    val caa_release_mbid: String? = null,
     val recording_mbid: String,
     val release_mbid: String? = null
 )

--- a/app/src/main/java/org/listenbrainz/android/ui/components/ListenCards.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/components/ListenCards.kt
@@ -1,7 +1,6 @@
 package org.listenbrainz.android.ui.components
 
 import androidx.annotation.DrawableRes
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -16,13 +15,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import coil.compose.rememberAsyncImagePainter
-import coil.request.ImageRequest
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
 import org.listenbrainz.android.R
@@ -31,6 +27,7 @@ import org.listenbrainz.android.model.Listen
 import org.listenbrainz.android.ui.theme.lb_purple
 import org.listenbrainz.android.ui.theme.onScreenUiModeIsDark
 
+@OptIn(ExperimentalGlideComposeApi::class)
 @Composable
 fun ListenCard(listen: Listen, coverArt: CoverArt?, onItemClicked: (listen: Listen) -> Unit) {
     Card(
@@ -38,7 +35,7 @@ fun ListenCard(listen: Listen, coverArt: CoverArt?, onItemClicked: (listen: List
             .fillMaxWidth()
             .padding(8.dp)
             .clip(RoundedCornerShape(16.dp))
-            .clickable(onClick = { onItemClicked(listen) }),
+            .clickable { onItemClicked(listen) },
         elevation = 0.dp,
         backgroundColor = MaterialTheme.colors.onSurface
     ) {
@@ -47,23 +44,14 @@ fun ListenCard(listen: Listen, coverArt: CoverArt?, onItemClicked: (listen: List
                 .fillMaxWidth()
                 .padding(16.dp)
         ) {
-            val painter = rememberAsyncImagePainter(
-                ImageRequest.Builder(LocalContext.current)
-                    .data(data = coverArt?.images?.get(0)?.thumbnails?.large)
-                    .placeholder(R.drawable.ic_coverartarchive_logo_no_text)
-                    .error(R.drawable.ic_coverartarchive_logo_no_text)
-                    .build()
-            )
-
-            Image(
-                modifier = Modifier
-                    .size(80.dp, 80.dp)
+            GlideImage(
+                model = coverArt?.images?.get(0)?.thumbnails?.large.toString(),
+                modifier = Modifier.size(80.dp, 80.dp)
                     .clip(RoundedCornerShape(16.dp)),
-                painter = painter,
-                alignment = Alignment.CenterStart,
-                contentDescription = "",
-                contentScale = ContentScale.Crop
-            )
+                contentDescription = null
+            ){
+                it.placeholder(R.drawable.ic_metabrainz_logo_no_text).override(250)
+            }
 
             Spacer(modifier = Modifier.width(16.dp))
 

--- a/app/src/main/java/org/listenbrainz/android/ui/components/ListenCards.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/components/ListenCards.kt
@@ -22,14 +22,13 @@ import androidx.compose.ui.unit.sp
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
 import org.listenbrainz.android.R
-import org.listenbrainz.android.model.CoverArt
 import org.listenbrainz.android.model.Listen
 import org.listenbrainz.android.ui.theme.lb_purple
 import org.listenbrainz.android.ui.theme.onScreenUiModeIsDark
 
 @OptIn(ExperimentalGlideComposeApi::class)
 @Composable
-fun ListenCard(listen: Listen, coverArt: CoverArt?, onItemClicked: (listen: Listen) -> Unit) {
+fun ListenCard(listen: Listen, coverArtUrl: String, onItemClicked: (listen: Listen) -> Unit) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -45,7 +44,7 @@ fun ListenCard(listen: Listen, coverArt: CoverArt?, onItemClicked: (listen: List
                 .padding(16.dp)
         ) {
             GlideImage(
-                model = coverArt?.images?.get(0)?.thumbnails?.large.toString(),
+                model = coverArtUrl,
                 modifier = Modifier.size(80.dp, 80.dp)
                     .clip(RoundedCornerShape(16.dp)),
                 contentDescription = null

--- a/app/src/main/java/org/listenbrainz/android/ui/components/YimNavigationStation.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/components/YimNavigationStation.kt
@@ -40,6 +40,9 @@ fun YimNavigationStation(
     val topReleases : List<TopRelease>? = viewModel.getTopReleases()?.toList()
     topReleases?.forEach { item ->
         // https://archive.org/download/mbid-{caa_release_mbid}/mbid-{caa_release_mbid}-{caa_id}_thumb500.jpg
+        if(uriList.size == 10) {
+            return@forEach
+        }
         uriList.add("https://archive.org/download/mbid-${item.caaReleaseMbid}/mbid-${item.caaReleaseMbid}-${item.caaId}_thumb500.jpg")
     }
     val imageUrlString: String = TextUtils.join(",", uriList)

--- a/app/src/main/java/org/listenbrainz/android/ui/components/YimShareButton.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/components/YimShareButton.kt
@@ -1,7 +1,9 @@
 package org.listenbrainz.android.ui.components
 
 import android.content.Context
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.AlertDialog
 import androidx.compose.material.icons.Icons
@@ -10,7 +12,10 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -39,8 +44,9 @@ fun YimShareButton(
     
     IconButton(
         modifier = modifier
-            .size(45.dp)
-            .testTag(stringResource(id = R.string.tt_yim_share) ),
+            .size(50.dp)
+            .testTag(stringResource(id = R.string.tt_yim_share))
+            .clip(CircleShape),
         onClick = { dialogState = true },
         colors = IconButtonDefaults.filledIconButtonColors(
             containerColor = MaterialTheme.colorScheme.onBackground,
@@ -48,11 +54,11 @@ fun YimShareButton(
         ),
         enabled = !disableButton
     ) {
-        Icon(
+        Image (
             imageVector = Icons.Rounded.Share,
             contentDescription = "Share your Year in Music",
-            tint = MaterialTheme.colorScheme.background,
-            modifier = Modifier.size(30.dp)
+            colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.background),
+            contentScale = ContentScale.Fit
         )
     }
 }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/listens/AllUsersListens.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/listens/AllUsersListens.kt
@@ -31,6 +31,7 @@ import org.listenbrainz.android.ui.components.Loader
 import org.listenbrainz.android.ui.navigation.AppNavigationItem
 import org.listenbrainz.android.util.Constants
 import org.listenbrainz.android.util.LBSharedPreferences
+import org.listenbrainz.android.util.Utils.getCoverArtUrl
 import org.listenbrainz.android.viewmodel.ListensViewModel
 
 
@@ -80,17 +81,14 @@ fun AllUserListens(
     
     // Preloader.
     val listState = rememberLazyListState()
-    if (coverArtList.isNotEmpty()){
-        GlideLazyListPreloader(
-            state = listState,
-            data = coverArtList,
-            size = Size(250f,250f),
-            numberOfItemsToPreload = 15
-        ){ item, requestBuilder ->
-            requestBuilder.load(item).placeholder(R.drawable.ic_metabrainz_logo_no_text).override(250)
-        }
+    GlideLazyListPreloader(
+        state = listState,
+        data = coverArtList,
+        size = Size(250f,250f),
+        numberOfItemsToPreload = 15
+    ){ item, requestBuilder ->
+        requestBuilder.placeholder(R.drawable.ic_metabrainz_logo_no_text).override(250).load(item)
     }
-    
     
     LazyColumn(
         modifier = modifier,
@@ -99,7 +97,10 @@ fun AllUserListens(
         items(listens) { listen->
             ListenCard(
                 listen,
-                coverArt = listen.coverArt
+                coverArtUrl = getCoverArtUrl(
+                    caaReleaseMbid = listen.track_metadata.mbid_mapping?.caa_release_mbid,
+                    caaId = listen.track_metadata.mbid_mapping?.caa_id
+                )
             )
             {
                 if (it.track_metadata.additional_info?.spotify_id != null) {

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/listens/AllUsersListens.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/listens/AllUsersListens.kt
@@ -2,7 +2,6 @@ package org.listenbrainz.android.ui.screens.listens
 
 import android.content.Intent
 import android.net.Uri
-import android.provider.MediaStore
 import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
@@ -10,14 +9,19 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.AlertDialog
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavController
+import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
+import com.bumptech.glide.integration.compose.GlideLazyListPreloader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -30,6 +34,7 @@ import org.listenbrainz.android.util.LBSharedPreferences
 import org.listenbrainz.android.viewmodel.ListensViewModel
 
 
+@OptIn(ExperimentalGlideComposeApi::class)
 @Composable
 fun AllUserListens(
     modifier: Modifier = Modifier,
@@ -67,46 +72,74 @@ fun AllUserListens(
     ){
         Loader()
     }
-    LazyColumn(modifier) {
-        items(viewModel.listens) { listen->
+    
+    // Listens list
+    val listens = viewModel.listensFlow.collectAsState().value
+    // Cover art of listens
+    val coverArtList = viewModel.coverArtFlow.collectAsState().value
+    
+    // Preloader.
+    val listState = rememberLazyListState()
+    if (coverArtList.isNotEmpty()){
+        GlideLazyListPreloader(
+            state = listState,
+            data = coverArtList,
+            size = Size(250f,250f),
+            numberOfItemsToPreload = 15
+        ){ item, requestBuilder ->
+            requestBuilder.load(item).placeholder(R.drawable.ic_metabrainz_logo_no_text).override(250)
+        }
+    }
+    
+    
+    LazyColumn(
+        modifier = modifier,
+        state = listState
+    ) {
+        items(listens) { listen->
             ListenCard(
                 listen,
-                coverArt = listen.coverArt,     // TODO: Fix coverArts not working
-                onItemClicked = {
-                    if(it.track_metadata.additional_info?.spotify_id != null) {
-                        Uri.parse(it.track_metadata.additional_info.spotify_id).lastPathSegment?.let { trackId ->
-                            viewModel.playUri("spotify:track:${trackId}")
-                        }
+                coverArt = listen.coverArt
+            )
+            {
+                if (it.track_metadata.additional_info?.spotify_id != null) {
+                    Uri.parse(it.track_metadata.additional_info.spotify_id).lastPathSegment?.let { trackId ->
+                        viewModel.playUri("spotify:track:${trackId}")
                     }
-                    else{
-                        // Execute the API request asynchronously
-                        val scope = CoroutineScope(Dispatchers.Main)
-                        scope.launch {
-                            val videoId = viewModel
-                                .searchYoutubeMusicVideoId(
-                                    trackName = listen.track_metadata.track_name,
-                                    artist = listen.track_metadata.artist_name,
-                                    apiKey = youtubeApiKey
-                                )
-                            when {
-                                videoId != null -> {
-                                    // Play the track in the YouTube Music app
-                                    val trackUri = Uri.parse("https://music.youtube.com/watch?v=$videoId")
-                                    val intent = Intent(Intent.ACTION_VIEW)
-                                    intent.data = trackUri
-                                    intent.setPackage(Constants.YOUTUBE_MUSIC_PACKAGE_NAME)
-                                    when {
-                                        intent.resolveActivity(context.packageManager) != null -> {
-                                            context.startActivity(intent)
-                                        }
-                                        else -> {
-                                            // Display an error message
-                                            Toast.makeText(context, "YouTube Music is not installed to play the track.", Toast.LENGTH_SHORT).show()
-                                        }
+                } else {
+                    // Execute the API request asynchronously
+                    val scope = CoroutineScope(Dispatchers.Main)
+                    scope.launch {
+                        val videoId = viewModel
+                            .searchYoutubeMusicVideoId(
+                                trackName = listen.track_metadata.track_name,
+                                artist = listen.track_metadata.artist_name,
+                                apiKey = youtubeApiKey
+                            )
+                        when {
+                            videoId != null -> {
+                                // Play the track in the YouTube Music app
+                                val trackUri =
+                                    Uri.parse("https://music.youtube.com/watch?v=$videoId")
+                                val intent = Intent(Intent.ACTION_VIEW)
+                                intent.data = trackUri
+                                intent.setPackage(Constants.YOUTUBE_MUSIC_PACKAGE_NAME)
+                                when {
+                                    intent.resolveActivity(context.packageManager) != null -> {
+                                        context.startActivity(intent)
+                                    }
+                                    else -> {
+                                        // Display an error message
+                                        Toast.makeText(
+                                            context,
+                                            "YouTube Music is not installed to play the track.",
+                                            Toast.LENGTH_SHORT
+                                        ).show()
                                     }
                                 }
-                                else -> {
-                                    // Play track via Amazon Music
+                            }
+                            else -> {
+                                // Play track via Amazon Music
 //                                    val intent = Intent()
 //                                    val query = listen.track_metadata.track_name + " " + listen.track_metadata.artist_name
 //                                    intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
@@ -117,12 +150,11 @@ fun AllUserListens(
 //                                    intent.action = MediaStore.INTENT_ACTION_MEDIA_SEARCH
 //                                    intent.putExtra(MediaStore.EXTRA_MEDIA_TITLE, query)
 //                                    context.startActivity(intent)
-                                }
                             }
                         }
                     }
                 }
-            )
+            }
         }
     }
 }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/listens/ListensScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/listens/ListensScreen.kt
@@ -17,25 +17,19 @@ import com.spotify.android.appremote.api.SpotifyAppRemote
 import org.listenbrainz.android.R
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.util.LBSharedPreferences
-import org.listenbrainz.android.util.connectivityobserver.ConnectivityObserver
-import org.listenbrainz.android.util.connectivityobserver.NetworkConnectivityViewModel
-import org.listenbrainz.android.util.connectivityobserver.NetworkConnectivityViewModelImpl
 import org.listenbrainz.android.viewmodel.ListensViewModel
 
 @Composable
 fun ListensScreen(
     navController: NavController,
     viewModel: ListensViewModel = hiltViewModel(),
-    internetConnectivityViewModel: NetworkConnectivityViewModel = NetworkConnectivityViewModelImpl(LocalContext.current),
     spotifyClientId: String = stringResource(id = R.string.spotifyClientId)
 ) {
-
     ListenBrainzTheme {
         
         DisposableEffect(Unit) {
             
-            if (internetConnectivityViewModel.getNetworkStatus() == ConnectivityObserver.NetworkStatus.Available)
-                viewModel.connect(spotifyClientId = spotifyClientId)
+            viewModel.connect(spotifyClientId = spotifyClientId)
 
             onDispose {
                 SpotifyAppRemote.disconnect(viewModel.spotifyAppRemote)

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/listens/ListensScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/listens/ListensScreen.kt
@@ -17,20 +17,25 @@ import com.spotify.android.appremote.api.SpotifyAppRemote
 import org.listenbrainz.android.R
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.util.LBSharedPreferences
-import org.listenbrainz.android.util.Log
+import org.listenbrainz.android.util.connectivityobserver.ConnectivityObserver
+import org.listenbrainz.android.util.connectivityobserver.NetworkConnectivityViewModel
+import org.listenbrainz.android.util.connectivityobserver.NetworkConnectivityViewModelImpl
 import org.listenbrainz.android.viewmodel.ListensViewModel
 
 @Composable
 fun ListensScreen(
-    navController: NavController
+    navController: NavController,
+    viewModel: ListensViewModel = hiltViewModel(),
+    internetConnectivityViewModel: NetworkConnectivityViewModel = NetworkConnectivityViewModelImpl(LocalContext.current),
+    spotifyClientId: String = stringResource(id = R.string.spotifyClientId)
 ) {
-    val viewModel: ListensViewModel = hiltViewModel()
-    val spotifyClientId = stringResource(id = R.string.spotifyClientId)
 
     ListenBrainzTheme {
         
         DisposableEffect(Unit) {
-            viewModel.connect(spotifyClientId = spotifyClientId)
+            
+            if (internetConnectivityViewModel.getNetworkStatus() == ConnectivityObserver.NetworkStatus.Available)
+                viewModel.connect(spotifyClientId = spotifyClientId)
 
             onDispose {
                 SpotifyAppRemote.disconnect(viewModel.spotifyAppRemote)

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/yim/YearInMusicActivity.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/yim/YearInMusicActivity.kt
@@ -22,7 +22,6 @@ class YearInMusicActivity : ComponentActivity() {
         // Login Check
         if (!yimViewModel.isLoggedIn()){
             Toast.makeText(this, "Please Login to access your Year in Music!", Toast.LENGTH_LONG).show()
-            //startActivity(Intent(this, LoginActivity::class.java))
             finish()
         }
         

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/yim/YimDiscoverScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/yim/YimDiscoverScreen.kt
@@ -180,7 +180,7 @@ private fun YimSimilarUsersList(
     paddings: YimPaddings = LocalYimPaddings.current
 ) {
     val similarUsers = remember {
-        yimViewModel.getSimilarUsers()
+        yimViewModel.getSimilarUsers() ?: listOf()
     }
     
     LazyColumn(

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/yim/YimDiscoverScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/yim/YimDiscoverScreen.kt
@@ -34,6 +34,7 @@ import org.listenbrainz.android.ui.components.YimNavigationStation
 import org.listenbrainz.android.ui.theme.LocalYimPaddings
 import org.listenbrainz.android.ui.theme.YearInMusicTheme
 import org.listenbrainz.android.ui.theme.YimPaddings
+import org.listenbrainz.android.util.Utils.getCoverArtUrl
 import org.listenbrainz.android.viewmodel.YimViewModel
 
 @Composable
@@ -217,7 +218,10 @@ private fun YimTopAlbumsFromArtistsList(
     }
     
     newReleasesOfTopArtist!!.forEach { item ->
-        uriList.add("https://archive.org/download/mbid-${item.caaReleaseMbid}/mbid-${item.caaReleaseMbid}-${item.caaId}_thumb250.jpg")
+        uriList.add(getCoverArtUrl(
+            caaReleaseMbid = item.caaReleaseMbid,
+            caaId = item.caaId
+        ))
     }
     
     // Pre-loading images
@@ -246,7 +250,10 @@ private fun YimTopAlbumsFromArtistsList(
             ListenCardSmall(
                 releaseName = newReleasesOfTopArtist[index].title,
                 artistName = newReleasesOfTopArtist[index].artistCreditName,
-                coverArtUrl = "https://archive.org/download/mbid-${newReleasesOfTopArtist[index].caaReleaseMbid}/mbid-${newReleasesOfTopArtist[index].caaReleaseMbid}-${newReleasesOfTopArtist[index].caaId}_thumb250.jpg",
+                coverArtUrl = getCoverArtUrl(
+                    caaReleaseMbid = newReleasesOfTopArtist[index].caaReleaseMbid,
+                    caaId = newReleasesOfTopArtist[index].caaId
+                ),
                 onClick = {},
                 errorAlbumArt = R.drawable.ic_erroralbumart
             )

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/yim/YimEndgameScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/yim/YimEndgameScreen.kt
@@ -10,21 +10,23 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Home
-import androidx.compose.material3.*
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
-import androidx.compose.ui.graphics.TransformOrigin
-import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.*
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
@@ -36,6 +38,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import org.listenbrainz.android.R
 import org.listenbrainz.android.ui.components.YimLabelText
 import org.listenbrainz.android.ui.theme.LocalYimPaddings
@@ -238,16 +241,18 @@ fun YimEndgameScreen(
                 Spacer(modifier = Modifier.height(paddings.largePadding))
                 
                 IconButton(
+                    modifier = Modifier.clip(CircleShape).size(50.dp),
                     onClick = {
                         Toast.makeText(context, "Have a great 2023!", Toast.LENGTH_SHORT).show()
                         activity.finish()
                     },
                     colors = IconButtonDefaults.filledIconButtonColors(containerColor = MaterialTheme.colorScheme.onBackground)
                 ) {
-                    Icon(
+                    Image(
                         imageVector = Icons.Rounded.Home,
-                        tint = yimRed,
-                        contentDescription = "Navigate to home"
+                        colorFilter = ColorFilter.tint(yimRed),
+                        contentDescription = "Navigate to home",
+                        contentScale = ContentScale.Fit
                     )
                 }
                 

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/yim/YimHomeScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/yim/YimHomeScreen.kt
@@ -39,10 +39,10 @@ import org.listenbrainz.android.ui.components.YimShareButton
 import org.listenbrainz.android.ui.theme.LocalYimPaddings
 import org.listenbrainz.android.ui.theme.YearInMusicTheme
 import org.listenbrainz.android.ui.theme.YimPaddings
-import org.listenbrainz.android.viewmodel.YimViewModel
 import org.listenbrainz.android.util.Resource
 import org.listenbrainz.android.util.connectivityobserver.ConnectivityObserver
 import org.listenbrainz.android.util.connectivityobserver.NetworkConnectivityViewModel
+import org.listenbrainz.android.viewmodel.YimViewModel
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
@@ -276,7 +276,6 @@ fun YimHomeScreen(
                     typeOfImage = arrayOf(YimShareable.TRACKS),
                     viewModel = viewModel,
                     disableButton = !isYimAvailable     // Make share function unavailable if user has no yim.
-                    // TODO: Rethink the share button on home screen
                 )
             }
         }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/yim/YimTopAlbumsScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/yim/YimTopAlbumsScreen.kt
@@ -36,6 +36,7 @@ import org.listenbrainz.android.ui.components.YimNavigationStation
 import org.listenbrainz.android.ui.theme.LocalYimPaddings
 import org.listenbrainz.android.ui.theme.YearInMusicTheme
 import org.listenbrainz.android.ui.theme.YimPaddings
+import org.listenbrainz.android.util.Utils
 import org.listenbrainz.android.viewmodel.YimViewModel
 
 @OptIn(ExperimentalGlideComposeApi::class)
@@ -97,7 +98,13 @@ fun YimTopAlbumsScreen(
                         val topReleases : List<TopRelease>? = yimViewModel.getTopReleases()?.toList()
                         topReleases?.forEach { item ->
                             // https://archive.org/download/mbid-{caa_release_mbid}/mbid-{caa_release_mbid}-{caa_id}_thumb500.jpg
-                            uriList.add("https://archive.org/download/mbid-${item.caaReleaseMbid}/mbid-${item.caaReleaseMbid}-${item.caaId}_thumb500.jpg")
+                            uriList.add(
+                                Utils.getCoverArtUrl(
+                                    caaReleaseMbid = item.caaReleaseMbid,
+                                    caaId = item.caaId,
+                                    size = 500
+                                )
+                            )
                         }
                         
                         // Pre-loading images
@@ -184,7 +191,11 @@ private fun YimAlbumViewer(list: List<TopRelease>?, listState: LazyListState) {
                 ) {
                     
                     GlideImage(
-                        model = "https://archive.org/download/mbid-${item.caaReleaseMbid}/mbid-${item.caaReleaseMbid}-${item.caaId}_thumb500.jpg",
+                        model = Utils.getCoverArtUrl(
+                            caaReleaseMbid = item.caaReleaseMbid,
+                            caaId = item.caaId,
+                            size = 500
+                        ),
                         modifier = Modifier
                             .size(300.dp)
                             .clip(RoundedCornerShape(10.dp)),

--- a/app/src/main/java/org/listenbrainz/android/util/ListenHandler.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/ListenHandler.kt
@@ -16,7 +16,7 @@ import retrofit2.Call
 import retrofit2.Response
 
 class ListenHandler : Handler(Looper.getMainLooper()) {
-    private val delay = 30000      // TODO: Revise delay as 30 secs is too long and gives a sense of feeling that listens service is not working.
+    private val delay = 1000
     private val timestamp = "timestamp"
 
     override fun handleMessage(msg: Message) {

--- a/app/src/main/java/org/listenbrainz/android/util/ListenHandler.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/ListenHandler.kt
@@ -16,7 +16,7 @@ import retrofit2.Call
 import retrofit2.Response
 
 class ListenHandler : Handler(Looper.getMainLooper()) {
-    private val delay = 1000
+    private val delay = 30000
     private val timestamp = "timestamp"
 
     override fun handleMessage(msg: Message) {

--- a/app/src/main/java/org/listenbrainz/android/util/Utils.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/Utils.kt
@@ -22,6 +22,12 @@ import java.util.*
  * A set of fairly general Android utility methods.
  */
 object Utils {
+    
+    /** Get *CoverArtArchive* url for cover art of a release.
+     * @param size Allowed sizes are 250, 500, 750 and 1000. Default is 250.*/
+    fun getCoverArtUrl(caaReleaseMbid: String?, caaId: Long?, size: Int = 250): String {
+        return  "https://archive.org/download/mbid-${caaReleaseMbid}/mbid-${caaReleaseMbid}-${caaId}_thumb${size}.jpg"
+    }
 
     fun shareIntent(text: String?): Intent {
         val intent = Intent(Intent.ACTION_SEND).setType("text/plain")

--- a/app/src/main/java/org/listenbrainz/android/util/connectivityobserver/NetworkConnectivityViewModel.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/connectivityobserver/NetworkConnectivityViewModel.kt
@@ -1,5 +1,7 @@
 package org.listenbrainz.android.util.connectivityobserver
 
+import kotlinx.coroutines.flow.Flow
+
 /**
  * Use `NetworkConnectivityViewModelImpl` for instantiating view-model inside activities.
  *
@@ -12,4 +14,6 @@ package org.listenbrainz.android.util.connectivityobserver
 */
 interface NetworkConnectivityViewModel {
     fun getNetworkStatus() : ConnectivityObserver.NetworkStatus
+    
+    fun getNetworkStatusFlow() : Flow<ConnectivityObserver.NetworkStatus>
 }

--- a/app/src/main/java/org/listenbrainz/android/util/connectivityobserver/NetworkConnectivityViewModelImpl.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/connectivityobserver/NetworkConnectivityViewModelImpl.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
@@ -30,5 +31,9 @@ class NetworkConnectivityViewModelImpl (context: Context) : ViewModel(), Network
     }
     override fun getNetworkStatus() : ConnectivityObserver.NetworkStatus{
         return networkStatus.value
+    }
+    
+    override fun getNetworkStatusFlow() : Flow<ConnectivityObserver.NetworkStatus> {
+        return connectivityObserver.observe()
     }
 }

--- a/app/src/main/java/org/listenbrainz/android/viewmodel/ListensViewModel.kt
+++ b/app/src/main/java/org/listenbrainz/android/viewmodel/ListensViewModel.kt
@@ -93,13 +93,8 @@ class ListensViewModel @Inject constructor(
                             }
                         }
                         val responseCoverArt = releaseMBID?.let { repository.fetchCoverArt(it) }
-                        when(responseCoverArt?.status) {
-                            SUCCESS -> {
-                                responseListens[index].coverArt = responseCoverArt.data!!
-                            }
-                            else -> {
-                                // TODO: Use cover art archive
-                            }
+                        if (responseCoverArt?.status == SUCCESS) {
+                            responseListens[index].coverArt = responseCoverArt.data!!
                         }
                     }
                     // Updating coverArts

--- a/app/src/main/java/org/listenbrainz/android/viewmodel/YimViewModel.kt
+++ b/app/src/main/java/org/listenbrainz/android/viewmodel/YimViewModel.kt
@@ -12,9 +12,9 @@ import androidx.lifecycle.viewModelScope
 import com.caverock.androidsvg.SVG
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.*
+import org.listenbrainz.android.model.yimdata.*
 import org.listenbrainz.android.repository.AppPreferences
 import org.listenbrainz.android.repository.YimRepository
-import org.listenbrainz.android.model.yimdata.*
 import org.listenbrainz.android.util.LBSharedPreferences
 import org.listenbrainz.android.util.Resource
 import org.listenbrainz.android.util.Utils.saveBitmap
@@ -95,9 +95,9 @@ class YimViewModel @Inject constructor(
      *
      *  @return `null` for users with less listens.
      */
-    fun getSimilarUsers(): List<Pair<String, Double>> {
-        val list = yimData.value.data?.payload?.data?.similarUsers!!.toList()
-        return list.sortedByDescending {
+    fun getSimilarUsers(): List<Pair<String, Double>>? {
+        val list = yimData.value.data?.payload?.data?.similarUsers?.toList()
+        return list?.sortedByDescending {
             it.second
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,10 @@ buildscript {
         kotlin_version = '1.8.10'
         navigationVersion = '2.5.3'
         hilt_version = '2.45'
-        compose_version = '1.3.3'
-        room_version = '2.5.0'
+        compose_version = '1.4.0'
+        room_version = '2.5.1'
         accompanist_version = '0.28.0'
+        exoplayer_version = '2.18.5'
     }
     repositories {
         google()

--- a/sharedTest/src/main/java/org/listenbrainz/sharedtest/mocks/MockNetworkConnectivityViewModel.kt
+++ b/sharedTest/src/main/java/org/listenbrainz/sharedtest/mocks/MockNetworkConnectivityViewModel.kt
@@ -1,6 +1,8 @@
 package org.listenbrainz.sharedtest.mocks
 
 import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import org.listenbrainz.android.util.connectivityobserver.ConnectivityObserver
 import org.listenbrainz.android.util.connectivityobserver.NetworkConnectivityViewModel
 
@@ -8,5 +10,11 @@ class MockNetworkConnectivityViewModel (private val mockedNetworkStatus: Connect
     
     override fun getNetworkStatus() : ConnectivityObserver.NetworkStatus {
         return mockedNetworkStatus
+    }
+    
+    override fun getNetworkStatusFlow(): Flow<ConnectivityObserver.NetworkStatus> {
+        return flow {
+            emit(mockedNetworkStatus)
+        }
     }
 }


### PR DESCRIPTION
Fixes MOBILE - [124](https://tickets.metabrainz.org/browse/MOBILE-124), [128](https://tickets.metabrainz.org/browse/MOBILE-128), [131](https://tickets.metabrainz.org/browse/MOBILE-131)

1) [124](https://tickets.metabrainz.org/browse/MOBILE-124) : Listen Service can record local listens as well as listens from other media sources that don't share metadata properly. Previously, listens from services like spotify and youtube could only be recorded; but services that don't share metadata properly, trouble the `ListenService` as artist metadata was always null. To fix this, artist metadata can now be extracted from the notification's text as well. New alternatives for title are also added. Fixed in https://github.com/metabrainz/listenbrainz-android/pull/108/commits/e65c7ec9c189a8416ecc7461ddf46c6c6399a2c3

2) YIM crashed due to change in API's response causing NullPointerException, which is now taken care of in https://github.com/metabrainz/listenbrainz-android/pull/108/commits/e65c7ec9c189a8416ecc7461ddf46c6c6399a2c3

3) YIM share button was square and not circle shaped as the intended design. Now Fixed in https://github.com/metabrainz/listenbrainz-android/pull/108/commits/b863e5f620a899b95cc4ed2c8cde0ac2348baa09

4) [131](https://tickets.metabrainz.org/browse/MOBILE-131) : Submission client (`submission_client`) or "who's submitting this listen" field was empty when the app was submitting listens. Now we are including our app's package name and version along with the listen. Fixed in https://github.com/metabrainz/listenbrainz-android/pull/108/commits/6caed0dee36c9998cbd419f6e98fd3e28ddbb12b

5) [128](https://tickets.metabrainz.org/browse/MOBILE-128) : Since there was no preloading, images were loaded after they were on the screen which is determined by the lazy list. Used glide and its preloader. Fixed in https://github.com/metabrainz/listenbrainz-android/pull/108/commits/6caed0dee36c9998cbd419f6e98fd3e28ddbb12b
Caching was ineffective before, now fixed in https://github.com/metabrainz/listenbrainz-android/pull/108/commits/2ba50ad7832d1d4395a61794574088840f519d04. See commit description for details

6) Bumped dependencies and removed duplicate dependency declarations. Fixed in https://github.com/metabrainz/listenbrainz-android/pull/108/commits/6caed0dee36c9998cbd419f6e98fd3e28ddbb12b