### PR TITLE
Dark and Light Mode Fixed

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/ui/screens/settings/SettingsActivity.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/settings/SettingsActivity.kt
@@ -16,6 +16,7 @@ import androidx.preference.SwitchPreference
 import org.listenbrainz.android.application.App
 import org.listenbrainz.android.R
 import org.listenbrainz.android.databinding.ActivityPreferencesBinding
+import org.listenbrainz.android.ui.screens.dashboard.DashboardActivity
 import org.listenbrainz.android.util.UserPreferences.PREFERENCE_LISTENING_ENABLED
 import org.listenbrainz.android.util.UserPreferences.PREFERENCE_SYSTEM_THEME
 import org.listenbrainz.android.util.UserPreferences.preferenceListeningEnabled
@@ -70,14 +71,20 @@ class SettingsActivity : AppCompatActivity() {
                     "Dark" -> {
                         setDefaultNightMode(MODE_NIGHT_YES)
                         isUiModeIsDark.value = true
+                        startActivity(Intent(this@SettingsActivity,DashboardActivity::class.java))
+                        finish()
                     }
                     "Light" -> {
                         setDefaultNightMode(MODE_NIGHT_NO)
                         isUiModeIsDark.value = false
+                        startActivity(Intent(this@SettingsActivity,DashboardActivity::class.java))
+                        finish()
                     }
                     else -> {
                         setDefaultNightMode(MODE_NIGHT_FOLLOW_SYSTEM)
                         isUiModeIsDark.value = null
+                        startActivity(Intent(this@SettingsActivity,DashboardActivity::class.java))
+                        finish()
                     }
                 }
                 return@OnPreferenceChangeListener true


### PR DESCRIPTION
### Issue Link: https://tickets.metabrainz.org/browse/MOBILE-132

### What Happening?
There was a little problem applying the theme in the app.
Let me take one situation, what I have also tried to detect through this video.

Suppose, your application is in light mode, And you change the theme to dark, everything is fine, and the dark mode has perfectly applied to your app.
Again, you come back to the settings and change it into light mode, but the theme is not applying as expected. But when we removed the application from **back-stack**, and again **relaunch** everything is fine.

Please go through this Video:

https://user-images.githubusercontent.com/87614560/228027513-8d0eda08-0f25-4c0c-9bed-bd6bd61daf78.mp4

### My Approach:

Actually, there is no problem with the previous code, from my knowledge. It is happening because somehow the application is not receiving any update about the UI Mode as soon as it updating. Like, somehow we have to broadcast all the components that yes something is happening.

Then I have also gone through some of the Play Store applications, where they apply something like this. So, after also seeing their approach in this type of case, I am just restarting the application when the UI mode change is happening.

It works.

### Result:

https://user-images.githubusercontent.com/87614560/228029631-25f6e9ba-1e4a-48db-8f5b-c4ec591d6527.mp4

(This branch is updated with the current main branch)

Fixes #107 



