### PR TITLE
Optimised ListenService and adapted appPreferences

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -162,7 +162,7 @@ dependencies {
     implementation 'androidx.activity:activity-compose:1.7.0'
 
     // Compose Navigation
-    implementation 'androidx.navigation:navigation-compose:2.6.0-alpha08'     // Stable one
+    implementation 'androidx.navigation:navigation-compose:2.6.0-alpha09'     // Stable one
     implementation "com.google.accompanist:accompanist-navigation-animation:$accompanist_version"     // Experimental but has animations
 
     //Spotify
@@ -186,7 +186,7 @@ dependencies {
     androidTestImplementation 'androidx.arch.core:core-testing:2.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.5.1'
-    androidTestImplementation 'app.cash.turbine:turbine:0.12.1'
+    androidTestImplementation 'app.cash.turbine:turbine:0.12.3'
     androidTestImplementation 'tools.fastlane:screengrab:2.1.1'     // Fastlane ScreenGrab
 
     testImplementation project(path: ':sharedTest')

--- a/app/src/androidTest/java/org/listenbrainz/android/TestAppModule.kt
+++ b/app/src/androidTest/java/org/listenbrainz/android/TestAppModule.kt
@@ -1,0 +1,35 @@
+package org.listenbrainz.android
+
+import android.content.Context
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
+import org.listenbrainz.android.di.AppModule
+import org.listenbrainz.android.repository.AppPreferences
+import org.listenbrainz.android.service.BrainzPlayerServiceConnection
+import org.listenbrainz.sharedtest.mocks.MockAppPreferences
+import javax.inject.Singleton
+
+@Module
+@TestInstallIn(
+    components = [SingletonComponent::class],
+    replaces = [AppModule::class]
+)
+class TestAppModule {
+    
+    @Singleton
+    @Provides
+    fun providesServiceConnection( @ApplicationContext context: Context
+    ) = BrainzPlayerServiceConnection(context)
+    
+    @Singleton
+    @Provides
+    fun providesContext(@ApplicationContext context: Context): Context = context
+    
+    @Singleton
+    @Provides
+    fun providesAppPreferences() : AppPreferences = MockAppPreferences()
+    
+}

--- a/app/src/androidTest/java/org/listenbrainz/android/YearInMusicActivityTest.kt
+++ b/app/src/androidTest/java/org/listenbrainz/android/YearInMusicActivityTest.kt
@@ -7,6 +7,8 @@ import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -21,11 +23,15 @@ import org.listenbrainz.sharedtest.mocks.MockNetworkConnectivityViewModel
 import org.listenbrainz.sharedtest.mocks.MockYimRepository
 import org.listenbrainz.sharedtest.utils.EntityTestUtils.testYimUsername
 
-@LargeTest
 @RunWith(AndroidJUnit4::class)
+@LargeTest
+@HiltAndroidTest
 class YearInMusicActivityTest {
-
+    
     @get:Rule(order = 0)
+    var hiltRule = HiltAndroidRule(this)
+    
+    @get:Rule(order = 1)
     val rule = createAndroidComposeRule<ComponentActivity>()
 
     private lateinit var activity : ComponentActivity

--- a/app/src/androidTest/java/org/listenbrainz/android/di/HiltTestApplication.kt
+++ b/app/src/androidTest/java/org/listenbrainz/android/di/HiltTestApplication.kt
@@ -3,7 +3,9 @@ package org.listenbrainz.android
 import android.app.Application
 import android.content.Context
 import android.os.Bundle
-import android.provider.Settings.Global.*
+import android.provider.Settings.Global.ANIMATOR_DURATION_SCALE
+import android.provider.Settings.Global.TRANSITION_ANIMATION_SCALE
+import android.provider.Settings.Global.WINDOW_ANIMATION_SCALE
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.runner.AndroidJUnitRunner
 import dagger.hilt.android.testing.HiltTestApplication

--- a/app/src/androidTest/java/org/listenbrainz/android/di/TestAppModule.kt
+++ b/app/src/androidTest/java/org/listenbrainz/android/di/TestAppModule.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android
+package org.listenbrainz.android.di
 
 import android.content.Context
 import dagger.Module

--- a/app/src/main/java/org/listenbrainz/android/repository/AppPreferences.kt
+++ b/app/src/main/java/org/listenbrainz/android/repository/AppPreferences.kt
@@ -24,6 +24,12 @@ interface AppPreferences {
     
     var preferenceListeningEnabled: Boolean
     
+    /** Blacklist for ListenService.*/
+    var listeningBlacklist: List<String>
+    
+    /** Music Apps in users device registered by listenService.*/
+    var listeningApps: List<String>
+    
     val preferenceListenBrainzToken : String?
     
     val onboardingPreference: Boolean

--- a/app/src/main/java/org/listenbrainz/android/repository/AppPreferencesImpl.kt
+++ b/app/src/main/java/org/listenbrainz/android/repository/AppPreferencesImpl.kt
@@ -2,16 +2,18 @@ package org.listenbrainz.android.repository
 
 import android.content.Context
 import androidx.preference.PreferenceManager
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import org.listenbrainz.android.application.App
 import org.listenbrainz.android.model.AccessToken
 import org.listenbrainz.android.model.Playable
 import org.listenbrainz.android.model.UserInfo
-
 import org.listenbrainz.android.util.LBSharedPreferences
-
 import org.listenbrainz.android.util.TypeConverter
 import org.listenbrainz.android.util.UserPreferences.PREFERENCE_ALBUMS_ON_DEVICE
 import org.listenbrainz.android.util.UserPreferences.PREFERENCE_LISTENBRAINZ_TOKEN
+import org.listenbrainz.android.util.UserPreferences.PREFERENCE_LISTENING_APPS
+import org.listenbrainz.android.util.UserPreferences.PREFERENCE_LISTENING_BLACKLIST
 import org.listenbrainz.android.util.UserPreferences.PREFERENCE_LISTENING_ENABLED
 import org.listenbrainz.android.util.UserPreferences.PREFERENCE_LISTENING_SPOTIFY
 import org.listenbrainz.android.util.UserPreferences.PREFERENCE_ONBOARDING
@@ -24,7 +26,7 @@ import org.listenbrainz.android.util.UserPreferences.PermissionStatus
 class AppPreferencesImpl(context : Context = App.context!!): AppPreferences {
     
     private val preferences = PreferenceManager.getDefaultSharedPreferences(context)
-    
+    private val gson = Gson()
     // Helper Functions
     
     private fun setString(key: String?, value: String?) {
@@ -63,6 +65,28 @@ class AppPreferencesImpl(context : Context = App.context!!): AppPreferences {
     override var preferenceListeningEnabled: Boolean
         get() = preferences.getBoolean(PREFERENCE_LISTENING_ENABLED, false)
         set(value) = setBoolean(PREFERENCE_LISTENING_ENABLED, value)
+    
+    override var listeningBlacklist: List<String>
+        get() {
+            val jsonString = preferences.getString(PREFERENCE_LISTENING_BLACKLIST, "")
+            val type = object : TypeToken<List<String>>() {}.type
+            return gson.fromJson(jsonString, type) ?: listOf()
+        }
+        set(value) {
+            val jsonString = gson.toJson(value)
+            setString(PREFERENCE_LISTENING_BLACKLIST, jsonString)
+        }
+    
+    override var listeningApps: List<String>    // No need to use Set here
+        get() {
+            val jsonString = preferences.getString(PREFERENCE_LISTENING_APPS, "")
+            val type = object : TypeToken<List<String>>() {}.type
+            return gson.fromJson(jsonString, type) ?: listOf()
+        }
+        set(value) {
+            val jsonString = gson.toJson(value)
+            setString(PREFERENCE_LISTENING_APPS, jsonString)
+        }
     
     override var preferenceListenBrainzToken: String?
         get() = preferences.getString(PREFERENCE_LISTENBRAINZ_TOKEN, null)

--- a/app/src/main/java/org/listenbrainz/android/service/ListenService.kt
+++ b/app/src/main/java/org/listenbrainz/android/service/ListenService.kt
@@ -47,6 +47,8 @@ class ListenService : NotificationListenerService() {
         if (token.isNullOrEmpty())
             d("ListenBrainz User token has not been set!")
         
+        appPreferences.listeningBlacklist = listOf()
+        
         handler = ListenHandler()
         sessionManager = applicationContext.getSystemService(MEDIA_SESSION_SERVICE) as MediaSessionManager
         sessionListener = ListenSessionListener(handler!!, appPreferences)

--- a/app/src/main/java/org/listenbrainz/android/service/ListenService.kt
+++ b/app/src/main/java/org/listenbrainz/android/service/ListenService.kt
@@ -47,8 +47,6 @@ class ListenService : NotificationListenerService() {
         if (token.isNullOrEmpty())
             d("ListenBrainz User token has not been set!")
         
-        appPreferences.listeningBlacklist = listOf()
-        
         handler = ListenHandler()
         sessionManager = applicationContext.getSystemService(MEDIA_SESSION_SERVICE) as MediaSessionManager
         sessionListener = ListenSessionListener(handler!!, appPreferences)

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/login/LoginActivity.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/login/LoginActivity.kt
@@ -3,8 +3,13 @@ package org.listenbrainz.android.ui.screens.login
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.*
-
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -25,7 +30,6 @@ import kotlinx.coroutines.launch
 import org.listenbrainz.android.R
 import org.listenbrainz.android.model.AccessToken
 import org.listenbrainz.android.model.UserInfo
-import org.listenbrainz.android.repository.AppPreferencesImpl
 import org.listenbrainz.android.ui.components.ListenBrainzActivity
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.viewmodel.LoginViewModel
@@ -37,7 +41,6 @@ class LoginActivity : ListenBrainzActivity() {
         super.onCreate(savedInstanceState)
         
         val viewModel = ViewModelProvider(this)[LoginViewModel::class.java]
-        viewModel.appPreferences = AppPreferencesImpl(this)
         
         // Variable used to show progress of login process.
         var loginState by mutableStateOf(R.string.login_uninitialized)

--- a/app/src/main/java/org/listenbrainz/android/util/ListenHandler.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/ListenHandler.kt
@@ -22,7 +22,7 @@ class ListenHandler : Handler(Looper.getMainLooper()) {
     override fun handleMessage(msg: Message) {
         super.handleMessage(msg)
         val token = preferenceListenBrainzToken
-        if (token == null || token.isEmpty()) {
+        if (token.isNullOrEmpty()) {
             d("ListenBrainz User token has not been set!")
             return
         }

--- a/app/src/main/java/org/listenbrainz/android/util/ListenHandler.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/ListenHandler.kt
@@ -16,7 +16,7 @@ import retrofit2.Call
 import retrofit2.Response
 
 class ListenHandler : Handler(Looper.getMainLooper()) {
-    private val delay = 1000//30000
+    private val delay = 30000
     private val timestamp = "timestamp"
 
     override fun handleMessage(msg: Message) {

--- a/app/src/main/java/org/listenbrainz/android/util/ListenHandler.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/ListenHandler.kt
@@ -16,7 +16,7 @@ import retrofit2.Call
 import retrofit2.Response
 
 class ListenHandler : Handler(Looper.getMainLooper()) {
-    private val delay = 30000
+    private val delay = 1000//30000
     private val timestamp = "timestamp"
 
     override fun handleMessage(msg: Message) {

--- a/app/src/main/java/org/listenbrainz/android/util/ListenSessionListener.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/ListenSessionListener.kt
@@ -17,11 +17,12 @@ class ListenSessionListener(private val handler: ListenHandler, private val appP
         if (controllers == null) return
         clearSessions()
         for (controller in controllers) {
-    
+            
+            // BlackList
             if (controller.packageName in appPreferences.listeningBlacklist)
                 continue
             
-            // Enable listens from spotify option.
+            // TODO: Remove this
             if (!appPreferences.preferenceListeningSpotifyEnabled && controller.packageName == Constants.SPOTIFY_PACKAGE_NAME) {
                 d("Spotify listens blocked from Listens Service.")
                 continue

--- a/app/src/main/java/org/listenbrainz/android/util/UserPreferences.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/UserPreferences.kt
@@ -5,6 +5,8 @@ import org.listenbrainz.android.application.App
 
 object UserPreferences {
     const val PREFERENCE_LISTENBRAINZ_TOKEN = "listenbrainz_user_token"
+    const val PREFERENCE_LISTENING_BLACKLIST = "listening_blacklist"
+    const val PREFERENCE_LISTENING_APPS = "listening_apps"
     const val PREFERENCE_LISTENING_ENABLED = "listening_enabled"
     const val PREFERENCE_LISTENING_SPOTIFY = "listening_spotify_enabled"
     const val PREFERENCE_SYSTEM_LANGUAGE = "use_english"

--- a/app/src/main/java/org/listenbrainz/android/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/org/listenbrainz/android/viewmodel/LoginViewModel.kt
@@ -17,10 +17,9 @@ import javax.inject.Inject
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
-    private val repository: LoginRepository
+    private val repository: LoginRepository,
+    val appPreferences: AppPreferences
 ) : ViewModel() {
-    
-    lateinit var appPreferences: AppPreferences
     
     /** Initial value: **null** */
     val accessTokenFlow: Flow<AccessToken?> = repository.accessTokenFlow

--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,9 @@ buildscript {
         kotlin_version = '1.8.10'
         navigationVersion = '2.5.3'
         hilt_version = '2.45'
-        compose_version = '1.4.0'
+        compose_version = '1.4.1'
         room_version = '2.5.1'
-        accompanist_version = '0.28.0'
+        accompanist_version = '0.30.0'
         exoplayer_version = '2.18.5'
     }
     repositories {

--- a/sharedTest/build.gradle
+++ b/sharedTest/build.gradle
@@ -23,7 +23,7 @@ android {
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.core:core-ktx:1.10.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.8.0'
 
@@ -40,8 +40,8 @@ dependencies {
     implementation 'com.squareup.okhttp3:mockwebserver:5.0.0-alpha.11'
     implementation 'androidx.arch.core:core-testing:2.2.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4'
-    implementation "androidx.room:room-testing:2.5.0"
-    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation "androidx.room:room-testing:2.5.1"
+    implementation 'androidx.core:core-ktx:1.10.0'
     debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
 
     implementation 'androidx.test:runner:1.5.2'
@@ -50,7 +50,7 @@ dependencies {
     implementation 'androidx.test.espresso:espresso-core:3.5.1'
     implementation 'androidx.test.espresso:espresso-intents:3.5.1'
     implementation "androidx.compose.ui:ui-test-junit4:$compose_version"
-    implementation 'app.cash.turbine:turbine:0.12.1'
+    implementation 'app.cash.turbine:turbine:0.12.3'
 
     implementation project(path: ':app')
 }

--- a/sharedTest/src/main/java/org/listenbrainz/sharedtest/mocks/MockAppPreferences.kt
+++ b/sharedTest/src/main/java/org/listenbrainz/sharedtest/mocks/MockAppPreferences.kt
@@ -26,7 +26,9 @@ class MockAppPreferences(
     override val username: String? = "",
     override val refreshToken: String? = "",
     override var albumsOnDevice: Boolean = true,
-    override var songsOnDevice: Boolean = true
+    override var songsOnDevice: Boolean = true,
+    override var listeningBlacklist: List<String> = listOf(),
+    override var listeningApps: List<String> = listOf()
 ) : AppPreferences {
     
     override fun saveOAuthToken(token: AccessToken) {


### PR DESCRIPTION
Listens Service was registering multiple callbacks which led to multiple submissions of the same song and multiple callbacks for same app's music notification. That is fixed now.

ClearSessions method was useless as it had no connection whatsoever with the service components itself, meaning it didn't unregister callbacks as expected.

TestAppModule established to deal with appPreferences easily and thus enabling us to use appPreferences app wide easily now.

Blocking infra added, UI pending.