### PR TITLE
Blacklist UI added and minor tweaks

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/repository/ListensRepository.kt
+++ b/app/src/main/java/org/listenbrainz/android/repository/ListensRepository.kt
@@ -1,10 +1,17 @@
 package org.listenbrainz.android.repository
 
+import android.graphics.drawable.Drawable
 import org.listenbrainz.android.model.CoverArt
 import org.listenbrainz.android.model.Listen
 import org.listenbrainz.android.util.Resource
 
 interface ListensRepository {
+    
     suspend fun fetchUserListens(userName: String): Resource<List<Listen>>
+    
     suspend fun fetchCoverArt(MBID: String): Resource<CoverArt>
+    
+    fun getPackageIcon(packageName: String): Drawable?
+    
+    fun getPackageLabel(packageName: String): String
 }

--- a/app/src/main/java/org/listenbrainz/android/repository/ListensRepositoryImpl.kt
+++ b/app/src/main/java/org/listenbrainz/android/repository/ListensRepositoryImpl.kt
@@ -1,9 +1,11 @@
 package org.listenbrainz.android.repository
 
+import android.graphics.drawable.Drawable
 import androidx.annotation.WorkerThread
-import org.listenbrainz.android.service.ListensService
+import org.listenbrainz.android.application.App
 import org.listenbrainz.android.model.CoverArt
 import org.listenbrainz.android.model.Listen
+import org.listenbrainz.android.service.ListensService
 import org.listenbrainz.android.util.Resource
 import org.listenbrainz.android.util.Resource.Status.FAILED
 import org.listenbrainz.android.util.Resource.Status.SUCCESS
@@ -33,5 +35,30 @@ class ListensRepositoryImpl @Inject constructor(val service: ListensService) : L
             e.printStackTrace()
             Resource.failure()
         }
+    }
+    
+    /** Retrieve any installed application's icon. If the requested application is not installed, null is returned.
+     *
+     * Usage:
+     * ```
+     * Image(
+     *    painter = rememberDrawablePainter( drawable = getPackageIcon(packageName) ),
+     *    contentDescription = "Example Description"
+     * )
+     * ```
+     * */
+    override fun getPackageIcon(packageName: String): Drawable? {
+        return try {
+            App.context!!.packageManager.getApplicationIcon(packageName)
+        }
+        catch (e: Exception) {
+            null
+        }
+    }
+    
+    @Suppress("DEPRECATION")
+    override fun getPackageLabel(packageName: String): String {
+        val info = App.context!!.packageManager.getApplicationInfo(packageName, 0)   // Replacement requires SDK 33
+        return App.context!!.packageManager.getApplicationLabel(info).toString()
     }
 }

--- a/app/src/main/java/org/listenbrainz/android/ui/navigation/BottomNavigationBar.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/navigation/BottomNavigationBar.kt
@@ -1,6 +1,5 @@
 package org.listenbrainz.android.ui.navigation
 
-import android.app.Activity
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.*
@@ -18,14 +17,12 @@ import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import kotlinx.coroutines.launch
 import org.listenbrainz.android.R
-import org.listenbrainz.android.ui.screens.dashboard.DashboardActivity
 
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun BottomNavigationBar(
     navController: NavController = rememberNavController(),
-    activity: Activity,
     backdropScaffoldState: BackdropScaffoldState = rememberBackdropScaffoldState(initialValue = BackdropValue.Revealed)
 ) {
     val items = listOf(
@@ -64,7 +61,7 @@ fun BottomNavigationBar(
                             launchSingleTop = true
                             // Restore previous state
                             restoreState = true
-                        // TODO: Implement refresh for listens Screen.
+                        
                         }
                     }
                     
@@ -80,5 +77,5 @@ fun BottomNavigationBar(
 @Preview
 @Composable
 fun BottomNavigationBarPreview() {
-    BottomNavigationBar(navController = rememberNavController(), activity = DashboardActivity())
+    BottomNavigationBar(navController = rememberNavController())
 }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
@@ -75,7 +75,8 @@ fun BrainzPlayerBackDropScreen(
         mutableStateOf(0F)
     }
     val repeatMode by brainzPlayerViewModel.repeatMode.collectAsState()
-    val headerHeight by animateDpAsState(targetValue = if (currentlyPlayingSong.title == "null" && currentlyPlayingSong.artist == "null") 0.dp else 136.dp)
+    /** 56.dp is default bottom navigation height. 80.dp is our mini player's height. */
+    val headerHeight by animateDpAsState(targetValue = if (currentlyPlayingSong.title == "null" && currentlyPlayingSong.artist == "null") 56.dp else 136.dp)
     
     BackdropScaffold(
         frontLayerShape = RectangleShape,

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/dashboard/DashboardActivity.kt
@@ -17,10 +17,10 @@ import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.navigation.compose.rememberNavController
 import com.google.accompanist.pager.ExperimentalPagerApi
 import dagger.hilt.android.AndroidEntryPoint
-import org.listenbrainz.android.ui.navigation.BottomNavigationBar
 import org.listenbrainz.android.ui.components.DialogLB
 import org.listenbrainz.android.ui.components.TopAppBar
 import org.listenbrainz.android.ui.navigation.AppNavigation
+import org.listenbrainz.android.ui.navigation.BottomNavigationBar
 import org.listenbrainz.android.ui.screens.brainzplayer.BrainzPlayerBackDropScreen
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.util.UserPreferences.PermissionStatus
@@ -111,7 +111,7 @@ class DashboardActivity : ComponentActivity() {
                     rememberBackdropScaffoldState(initialValue = BackdropValue.Revealed)
                 Scaffold(
                     topBar = { TopAppBar(activity = this) },
-                    bottomBar = { BottomNavigationBar(navController = navController, activity = this, backdropScaffoldState = backdropScaffoldState) },
+                    bottomBar = { BottomNavigationBar(navController = navController, backdropScaffoldState = backdropScaffoldState) },
                     backgroundColor = MaterialTheme.colorScheme.background
                 ) {
                     if (isGrantedPerms == PermissionStatus.GRANTED.name) {

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/listens/AllUsersListens.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/listens/AllUsersListens.kt
@@ -2,7 +2,6 @@ package org.listenbrainz.android.ui.screens.listens
 
 import android.content.Context
 import android.content.Intent
-import android.content.res.Configuration
 import android.net.Uri
 import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
@@ -47,7 +46,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
@@ -97,7 +95,7 @@ fun AllUserListens(
         
         // BlackList Dialog
         if (showBlacklist){
-            ListeningAppsList() { showBlacklist = false }
+            ListeningAppsList(viewModel = viewModel) { showBlacklist = false }
         }
         
         // FAB
@@ -241,12 +239,10 @@ private fun ListensList(
     }
 }
 
-@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
-@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Composable
 fun ListeningAppsList(
     viewModel: ListensViewModel = hiltViewModel(),
-    onDismiss: () -> Unit = {}
+    onDismiss: () -> Unit
 ){
     var blacklist by remember { mutableStateOf(viewModel.appPreferences.listeningBlacklist) }
     

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/listens/AllUsersListens.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/listens/AllUsersListens.kt
@@ -1,27 +1,59 @@
 package org.listenbrainz.android.ui.screens.listens
 
+import android.content.Context
 import android.content.Intent
+import android.content.res.Configuration
 import android.net.Uri
 import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.AlertDialog
+import androidx.compose.material.FloatingActionButton
+import androidx.compose.material.Switch
+import androidx.compose.material.SwitchDefaults
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Block
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideLazyListPreloader
+import com.google.accompanist.drawablepainter.rememberDrawablePainter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -35,45 +67,90 @@ import org.listenbrainz.android.util.Utils.getCoverArtUrl
 import org.listenbrainz.android.viewmodel.ListensViewModel
 
 
-@OptIn(ExperimentalGlideComposeApi::class)
 @Composable
 fun AllUserListens(
     modifier: Modifier = Modifier,
     viewModel: ListensViewModel,
     navController: NavController
 ) {
-    val context = LocalContext.current
-    val youtubeApiKey = stringResource(id = R.string.youtubeApiKey)
-
-    if(LBSharedPreferences.username == "") {
-        AlertDialog(
-            onDismissRequest = { },
-            confirmButton = {
-                TextButton(onClick = {
-                    navController.navigate(AppNavigationItem.Profile.route)
-                })
-                { Text(text = "OK") }
-            },
-            dismissButton = {
-                TextButton(onClick = {
-                    navController.popBackStack()
-                })
-                { Text(text = "Cancel") }
-            },
-            title = { Text(text = "Please login to your profile") },
-            text = { Text(text = "We will fetch your listens once you have logged in") }
-        )
-        return
-    }
-
-    AnimatedVisibility(
-        visible = viewModel.isLoading,
-        enter = fadeIn(initialAlpha = 0.4f),
-        exit = fadeOut(animationSpec = tween(durationMillis = 250))
-    ){
-        Loader()
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        
+        var showBlacklist by remember { mutableStateOf(false) }
+        
+        // Error Dialog
+        if(LBSharedPreferences.username == "") {
+            NotLoggedInErrorDialog(navController)
+            return
+        }
+      
+        
+        // Loading Animation
+        AnimatedVisibility(
+            visible = viewModel.isLoading,
+            enter = fadeIn(initialAlpha = 0.4f),
+            exit = fadeOut(animationSpec = tween(durationMillis = 250))
+        ){
+            Loader()
+        }
+        
+        ListensList(viewModel, modifier)
+        
+        // BlackList Dialog
+        if (showBlacklist){
+            ListeningAppsList() { showBlacklist = false }
+        }
+        
+        // FAB
+        AnimatedVisibility(modifier = Modifier
+            .align(Alignment.BottomEnd)
+            .padding(16.dp), visible = !showBlacklist) {
+            FloatingActionButton(
+                modifier = Modifier.border(1.dp, Color.Gray, shape = CircleShape),
+                shape = CircleShape,
+                onClick = { showBlacklist = true },
+                backgroundColor = MaterialTheme.colorScheme.tertiaryContainer
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Block,
+                    tint = MaterialTheme.colorScheme.onSurface,
+                    contentDescription = "Blacklist"
+                )
+            }
+        }
     }
     
+}
+
+@Composable
+private fun NotLoggedInErrorDialog(navController: NavController) {
+    AlertDialog(
+        onDismissRequest = { /*DON'T DO ANYTHING*/ },
+        confirmButton = {
+            TextButton(onClick = {
+                navController.navigate(AppNavigationItem.Profile.route)
+            })
+            { Text(text = "OK") }
+        },
+        dismissButton = {
+            TextButton(onClick = {
+                navController.popBackStack()
+            })
+            { Text(text = "Cancel") }
+        },
+        title = { Text(text = "Please login to your profile") },
+        text = { Text(text = "We will fetch your listens once you have logged in") }
+    )
+}
+
+
+@Composable
+@OptIn(ExperimentalGlideComposeApi::class)
+private fun ListensList(
+    viewModel: ListensViewModel,
+    modifier: Modifier = Modifier,
+    context: Context = LocalContext.current
+) {
+    val youtubeApiKey = stringResource(id = R.string.youtubeApiKey)
     // Listens list
     val listens = viewModel.listensFlow.collectAsState().value
     // Cover art of listens
@@ -84,9 +161,9 @@ fun AllUserListens(
     GlideLazyListPreloader(
         state = listState,
         data = coverArtList,
-        size = Size(250f,250f),
+        size = Size(250f, 250f),
         numberOfItemsToPreload = 15
-    ){ item, requestBuilder ->
+    ) { item, requestBuilder ->
         requestBuilder.placeholder(R.drawable.ic_metabrainz_logo_no_text).override(250).load(item)
     }
     
@@ -94,7 +171,7 @@ fun AllUserListens(
         modifier = modifier,
         state = listState
     ) {
-        items(listens) { listen->
+        items(listens) { listen ->
             ListenCard(
                 listen,
                 coverArtUrl = getCoverArtUrl(
@@ -129,6 +206,7 @@ fun AllUserListens(
                                     intent.resolveActivity(context.packageManager) != null -> {
                                         context.startActivity(intent)
                                     }
+    
                                     else -> {
                                         // Display an error message
                                         Toast.makeText(
@@ -139,18 +217,21 @@ fun AllUserListens(
                                     }
                                 }
                             }
+    
                             else -> {
+                                /*
                                 // Play track via Amazon Music
-//                                    val intent = Intent()
-//                                    val query = listen.track_metadata.track_name + " " + listen.track_metadata.artist_name
-//                                    intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-//                                    intent.setClassName(
-//                                        "com.amazon.mp3",
-//                                        "com.amazon.mp3.activity.IntentProxyActivity"
-//                                    )
-//                                    intent.action = MediaStore.INTENT_ACTION_MEDIA_SEARCH
-//                                    intent.putExtra(MediaStore.EXTRA_MEDIA_TITLE, query)
-//                                    context.startActivity(intent)
+                                val intent = Intent()
+                                val query = listen.track_metadata.track_name + " " + listen.track_metadata.artist_name
+                                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                                intent.setClassName(
+                                    "com.amazon.mp3",
+                                    "com.amazon.mp3.activity.IntentProxyActivity"
+                                )
+                                intent.action = MediaStore.INTENT_ACTION_MEDIA_SEARCH
+                                intent.putExtra(MediaStore.EXTRA_MEDIA_TITLE, query)
+                                context.startActivity(intent)
+                                */
                             }
                         }
                     }
@@ -158,4 +239,98 @@ fun AllUserListens(
             }
         }
     }
+}
+
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Composable
+fun ListeningAppsList(
+    viewModel: ListensViewModel = hiltViewModel(),
+    onDismiss: () -> Unit = {}
+){
+    var blacklist by remember { mutableStateOf(viewModel.appPreferences.listeningBlacklist) }
+    
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        backgroundColor = MaterialTheme.colorScheme.background,
+        buttons = {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(8.dp),
+            ) {
+                Button(
+                    onClick = onDismiss,
+                    modifier = Modifier.align(Alignment.CenterEnd),
+                    colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent),
+                    contentPadding = PaddingValues(horizontal = 8.dp)
+                ){
+                    Text(
+                        text = "OK",
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                }
+            }
+        },
+        title = {
+            Text(
+                text = "Listening Apps List",
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        },
+        text = {
+            LazyColumn {
+                items(items = viewModel.appPreferences.listeningApps){packageName ->
+                    
+                    Box(modifier = Modifier.fillMaxWidth()) {
+                        
+                        Row(
+                            modifier = Modifier
+                                .align(Alignment.CenterStart)
+                                .fillMaxWidth(0.85f),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            
+                            Image(
+                                modifier = Modifier
+                                    .fillMaxWidth(0.15f)
+                                    .padding(end = 5.dp),
+                                painter = rememberDrawablePainter(drawable = viewModel.repository.getPackageIcon(packageName)),
+                                contentDescription = null
+                            )
+                            
+                            Text(
+                                modifier = Modifier.fillMaxWidth(0.85f),
+                                text = viewModel.repository.getPackageLabel(packageName),
+                                color = MaterialTheme.colorScheme.onSurface,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                        Switch(
+                            modifier = Modifier
+                                .fillMaxWidth(0.15f)
+                                .align(Alignment.CenterEnd),
+                            checked = packageName !in blacklist,
+                            onCheckedChange = { isChecked ->
+                                if (!isChecked){
+                                    viewModel.appPreferences.listeningBlacklist = blacklist + packageName
+                                    blacklist = blacklist + packageName
+                                } else{
+                                    viewModel.appPreferences.listeningBlacklist = blacklist - packageName
+                                    blacklist = blacklist - packageName
+                                }
+                                
+                            },
+                            colors = SwitchDefaults.colors(
+                                checkedTrackColor = MaterialTheme.colorScheme.inverseOnSurface,
+                                checkedThumbColor = MaterialTheme.colorScheme.inverseOnSurface
+                            )
+                        )
+                    }
+                }
+            }
+        }
+    )
 }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/listens/ListensScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/listens/ListensScreen.kt
@@ -1,13 +1,13 @@
 package org.listenbrainz.android.ui.screens.listens
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -42,18 +42,17 @@ fun ListensScreen(
             }
         }
 
+        val showNowPlaying by remember(viewModel.playerState?.track?.name) {
+            mutableStateOf(viewModel.playerState?.track?.name != null)
+        }
+        
         Column {
-            if (viewModel.playerState?.track?.name != null) {
-                AnimatedVisibility(
-                    visible = true,
-                    enter = fadeIn(initialAlpha = 0.4f),
-                    exit = fadeOut(animationSpec = tween(durationMillis = 250))
-                ) {
-                    NowPlaying(
-                        playerState = viewModel.playerState,
-                        bitmap = viewModel.bitmap
-                    )
-                }
+            
+            AnimatedVisibility(visible = showNowPlaying) {
+                NowPlaying(
+                    playerState = viewModel.playerState,
+                    bitmap = viewModel.bitmap
+                )
             }
 
             AllUserListens(

--- a/app/src/main/java/org/listenbrainz/android/util/ListenHandler.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/ListenHandler.kt
@@ -16,7 +16,7 @@ import retrofit2.Call
 import retrofit2.Response
 
 class ListenHandler : Handler(Looper.getMainLooper()) {
-    private val delay = 1000//30000
+    private val delay = 30000
     private val timestamp = "timestamp"
 
     override fun handleMessage(msg: Message) {

--- a/app/src/main/java/org/listenbrainz/android/util/ListenHandler.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/ListenHandler.kt
@@ -16,7 +16,7 @@ import retrofit2.Call
 import retrofit2.Response
 
 class ListenHandler : Handler(Looper.getMainLooper()) {
-    private val delay = 30000
+    private val delay = 1000//30000
     private val timestamp = "timestamp"
 
     override fun handleMessage(msg: Message) {

--- a/app/src/main/java/org/listenbrainz/android/util/ListenSessionListener.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/ListenSessionListener.kt
@@ -25,12 +25,6 @@ class ListenSessionListener(
             if (controller.packageName in appPreferences.listeningBlacklist)
                 continue
             
-            /*// TODO: Remove this
-            if (!appPreferences.preferenceListeningSpotifyEnabled && controller.packageName == Constants.SPOTIFY_PACKAGE_NAME) {
-                d("Spotify listens blocked from Listens Service.")
-                continue
-            }*/
-            
             val callback = ListenCallback()
             activeSessions[controller] = callback
             controller.registerCallback(callback)

--- a/app/src/main/java/org/listenbrainz/android/util/ListenSessionListener.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/ListenSessionListener.kt
@@ -8,7 +8,10 @@ import org.listenbrainz.android.repository.AppPreferences
 import org.listenbrainz.android.util.Log.d
 import org.listenbrainz.android.util.Log.w
 
-class ListenSessionListener(private val handler: ListenHandler, private val appPreferences: AppPreferences) : OnActiveSessionsChangedListener {
+class ListenSessionListener(
+    private val handler: ListenHandler,
+    private val appPreferences: AppPreferences
+) : OnActiveSessionsChangedListener {
     
     private val activeSessions: MutableMap<MediaController, ListenCallback?> = HashMap()
 
@@ -22,11 +25,11 @@ class ListenSessionListener(private val handler: ListenHandler, private val appP
             if (controller.packageName in appPreferences.listeningBlacklist)
                 continue
             
-            // TODO: Remove this
+            /*// TODO: Remove this
             if (!appPreferences.preferenceListeningSpotifyEnabled && controller.packageName == Constants.SPOTIFY_PACKAGE_NAME) {
                 d("Spotify listens blocked from Listens Service.")
                 continue
-            }
+            }*/
             
             val callback = ListenCallback()
             activeSessions[controller] = callback

--- a/app/src/main/java/org/listenbrainz/android/viewmodel/ListensViewModel.kt
+++ b/app/src/main/java/org/listenbrainz/android/viewmodel/ListensViewModel.kt
@@ -266,6 +266,5 @@ class ListensViewModel @Inject constructor(
     private fun logMessage(msg: String) {
         d(msg)
     }
-    
-    // Get
+
 }

--- a/app/src/main/java/org/listenbrainz/android/viewmodel/ListensViewModel.kt
+++ b/app/src/main/java/org/listenbrainz/android/viewmodel/ListensViewModel.kt
@@ -25,13 +25,16 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.listenbrainz.android.BuildConfig
 import org.listenbrainz.android.model.Listen
+import org.listenbrainz.android.repository.AppPreferences
 import org.listenbrainz.android.repository.ListensRepository
 import org.listenbrainz.android.service.YouTubeApiService
 import org.listenbrainz.android.util.Constants
 import org.listenbrainz.android.util.Log.d
 import org.listenbrainz.android.util.Log.e
 import org.listenbrainz.android.util.Log.v
-import org.listenbrainz.android.util.Resource.Status.*
+import org.listenbrainz.android.util.Resource.Status.FAILED
+import org.listenbrainz.android.util.Resource.Status.LOADING
+import org.listenbrainz.android.util.Resource.Status.SUCCESS
 import org.listenbrainz.android.util.Utils.getCoverArtUrl
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
@@ -44,6 +47,7 @@ import kotlin.coroutines.suspendCoroutine
 @HiltViewModel
 class ListensViewModel @Inject constructor(
     val repository: ListensRepository,
+    val appPreferences: AppPreferences,
     private val application: Application
 ) : AndroidViewModel(application) {
     // TODO: remove dependency of this view-model on application
@@ -262,4 +266,6 @@ class ListensViewModel @Inject constructor(
     private fun logMessage(msg: String) {
         d(msg)
     }
+    
+    // Get
 }


### PR DESCRIPTION
Listening Service Blacklist UI added. Users can now access the list of apps from which listens have been recorded in the past and enable/disable submitting listens from them. This option can be found on ListensScreen through the floating action button.

In minor tweaks: 
1) Front layer header height was 0.dp, changed it to 56.dp to match height of bottom navigation bar. 
2) Changed minor compose if conditions to animated visibility.