### PR TITLE
Receive Dependabot updates on Wednesdays

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "wednesday"
+      time: "00:00"
 
   # Updates for Gradle dependencies used in the app
   - package-ecosystem: gradle
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "wednesday"
+      time: "00:00"
     open-pull-requests-limit: 10


### PR DESCRIPTION
- It was noticed that dependabot informed us about the updates always on a Monday during the weekly meeting. In order to avoid that from happening, we are shifting to a Wednesday.