### PR TITLE
Fix: Declare NewsBrainzActivity in androidManifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,12 +40,7 @@
 
         <activity
             android:name=".ui.screens.newsbrainz.NewsBrainzActivity"
-            android:exported="false"
-            android:label="@string/title_activity_news_brainz"
-            android:theme="@style/AppTheme">
-            <meta-data
-                android:name="android.app.lib_name"
-                android:value="" />
+            android:label="@string/title_activity_news_brainz">
         </activity>
 
         <service

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,6 +38,16 @@
                 android:value="" />
         </activity>
 
+        <activity
+            android:name=".ui.screens.newsbrainz.NewsBrainzActivity"
+            android:exported="false"
+            android:label="@string/title_activity_news_brainz"
+            android:theme="@style/AppTheme">
+            <meta-data
+                android:name="android.app.lib_name"
+                android:value="" />
+        </activity>
+
         <service
             android:name=".service.ListenScrobbleService"
             android:enabled="true"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -207,6 +207,9 @@
     <!-- Year in Music -->
     <string name="title_activity_year_in_music">YearInMusicActivity</string>
 
+    <!-- News Brainz Acitivity -->
+    <string name="title_activity_news_brainz">NewsBrainzActivity</string>
+
     <!-- BrainzPlayer -->
     <string name="bp_loading_text">Loading your music library</string>
 


### PR DESCRIPTION
Clicking the News button in the main screen does not open the News activity as it's not defined in the AndroidManifest