### PR TITLE
Fix links not clickable in About screen

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/ui/screens/about/AboutScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/about/AboutScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
@@ -22,8 +23,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.listenbrainz.android.R
@@ -33,6 +39,7 @@ import org.listenbrainz.android.util.Utils.sendFeedback
 @Composable
 fun AboutScreen(version: String, onBack: () -> Unit) {
     val context = LocalContext.current
+    val uriHandler = LocalUriHandler.current
 
     Scaffold(
         topBar = {
@@ -106,11 +113,42 @@ fun AboutScreen(version: String, onBack: () -> Unit) {
                         .padding(0.dp, 8.dp, 8.dp, 8.dp)
                 )
 
-                Text(
-                    "The source code for this app is available on GitHub at https://github.com/metabrainz/listenbrainz-android\n\n" +
+                val annotatedStringGithub: AnnotatedString = buildAnnotatedString {
+                    val originalString = "The source code for this app is available on GitHub at https://github.com/metabrainz/listenbrainz-android\n\n" +
                             "Got something interesting you'd like to ask or share? Start a discussion at #metabrainz IRC channel on libera.chat.\n\n" +
-                            "Reports, comments and suggestions are welcomed, just tap 'Feedback' in the menu to send us an email!",
-                    color = MaterialTheme.colorScheme.onSurface
+                            "Reports, comments and suggestions are welcomed, just tap 'Feedback' in the menu to send us an email!"
+                    val startIndexGithub = originalString.indexOf("https://github.com")
+                    val endIndexGithub = startIndexGithub + 50
+                    append(originalString)
+                    addStyle(
+                        style = SpanStyle(
+                            color = MaterialTheme.colorScheme.onSurface
+                        ), start = 0, end = originalString.length - 1
+                    )
+                    addStyle(
+                        style = SpanStyle(
+                            color = Color(0xff64B5F6),
+                            textDecoration = TextDecoration.Underline
+                        ), start = startIndexGithub, end = endIndexGithub
+                    )
+                    addStringAnnotation(
+                        tag = "URL",
+                        annotation = "https://github.com/metabrainz/listenbrainz-android",
+                        start = startIndexGithub,
+                        end = endIndexGithub
+                    )
+                }
+
+                ClickableText(
+                    text = annotatedStringGithub,
+                    style = MaterialTheme.typography.bodyLarge,
+                    onClick = {offset ->
+                        annotatedStringGithub
+                            .getStringAnnotations("URL", offset, offset)
+                            .firstOrNull()?.let { stringAnnotation ->
+                                uriHandler.openUri(stringAnnotation.item)
+                            }
+                    }
                 )
 
                 Text("Bugs",
@@ -131,13 +169,72 @@ fun AboutScreen(version: String, onBack: () -> Unit) {
                         .padding(0.dp, 8.dp, 8.dp, 8.dp)
                 )
 
-                Text(
-                    "This app uses\n\n" +
+                val annotatedStringAttributions: AnnotatedString = buildAnnotatedString {
+                    val originalString = "This app uses\n\n" +
                             "Icons designed by Freepik, Pixel Perfect, Good Ware, photo3idea_studio and Pixelmeetup from www.flaticon.com and www.freepik.com\n\n" +
                             "Animations by Korhan Ulusoy, Jake Cowan, KidA Studio, puput Santoso and Paul Roux on LottieFiles from lottiefiles.com\n\n" +
                             "The complete resources with links can be found at\n" +
-                            "https://github.com/metabrainz/listenbrainz-android/blob/master/app/src/main/play/asset_attributions.md",
-                    color = MaterialTheme.colorScheme.onSurface
+                            "https://github.com/metabrainz/listenbrainz-android/blob/main/asset_attributions.md"
+                    val startIndexFlaticon = originalString.indexOf("www.flaticon.com")
+                    val startIndexFreepik = originalString.indexOf("www.freepik.com")
+                    val startIndexGithub = originalString.indexOf("https://github.com")
+                    val endIndexFlaticon = startIndexFlaticon + 16
+                    val endIndexFreepik = startIndexFreepik + 15
+                    val endIndexGithub = startIndexGithub + 82
+                    append(originalString)
+                    addStyle(
+                        style = SpanStyle(
+                            color = MaterialTheme.colorScheme.onSurface
+                        ), start = 0, end = originalString.length - 1
+                    )
+                    addStyle(
+                        style = SpanStyle(
+                            color = Color(0xff64B5F6),
+                            textDecoration = TextDecoration.Underline
+                        ), start = startIndexFlaticon, end = endIndexFlaticon
+                    )
+                    addStringAnnotation(
+                        tag = "URL",
+                        annotation = "https://flaticon.com",
+                        start = startIndexFlaticon,
+                        end = endIndexFlaticon
+                    )
+                    addStyle(
+                        style = SpanStyle(
+                            color = Color(0xff64B5F6),
+                            textDecoration = TextDecoration.Underline
+                        ), start = startIndexFreepik, end = endIndexFreepik
+                    )
+                    addStringAnnotation(
+                        tag = "URL",
+                        annotation = "https://freepik.com",
+                        start = startIndexFreepik,
+                        end = endIndexFreepik
+                    )
+                    addStyle(
+                        style = SpanStyle(
+                            color = Color(0xff64B5F6),
+                            textDecoration = TextDecoration.Underline
+                        ), start = startIndexGithub, end = endIndexGithub
+                    )
+                    addStringAnnotation(
+                        tag = "URL",
+                        annotation = "https://github.com/metabrainz/listenbrainz-android/blob/main/asset_attributions.md",
+                        start = startIndexGithub,
+                        end = endIndexGithub
+                    )
+                }
+
+                ClickableText(
+                    text = annotatedStringAttributions,
+                    style = MaterialTheme.typography.bodyLarge,
+                    onClick = {offset ->
+                        annotatedStringAttributions
+                            .getStringAnnotations("URL", offset, offset)
+                            .firstOrNull()?.let { stringAnnotation ->
+                                uriHandler.openUri(stringAnnotation.item)
+                            }
+                    }
                 )
             }
         }


### PR DESCRIPTION
The About screen links were not clickable, making it less interactive. I fixed this by following [this answer](https://stackoverflow.com/questions/65567412/jetpack-compose-text-hyperlink-some-section-of-the-text).

<img src="https://github.com/metabrainz/listenbrainz-android/assets/85404940/ee8ac123-ff80-4865-b455-099ee235724e" width="400"/>

I have also fixed the Attributions link from
"https://github.com/metabrainz/listenbrainz-android/blob/master/app/src/main/play/asset_attributions.md"
to
"https://github.com/metabrainz/listenbrainz-android/blob/main/asset_attributions.md"