### PR TITLE
Make intent nullable for service

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/service/ListenScrobbleService.kt
+++ b/app/src/main/java/org/listenbrainz/android/service/ListenScrobbleService.kt
@@ -33,7 +33,7 @@ class ListenScrobbleService : NotificationListenerService() {
         initialize()
     }
 
-    override fun onStartCommand(intent: Intent, flags: Int, startId: Int) = Service.START_STICKY
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int) = Service.START_STICKY
 
     private fun initialize() {
         d("Initializing Listener Service")


### PR DESCRIPTION
- The system kills the service after onStartCommand() returns, and it will not re-deliver the last Intent. Instead, the system calls onStartCommand() with a null Intent. We now handle this situation in order to avoid crashes.