### PR TITLE
Optimized feed's pagers

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/ui/screens/feed/FollowListensPagingSource.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/feed/FollowListensPagingSource.kt
@@ -17,8 +17,8 @@ class FollowListensPagingSource(
     private val ioDispatcher: CoroutineDispatcher
 ): PagingSource<Int, FeedUiEventItem>() {
     
-    override fun getRefreshKey(state: PagingState<Int, FeedUiEventItem>): Int {
-        return (System.currentTimeMillis()/1000).toInt()
+    override fun getRefreshKey(state: PagingState<Int, FeedUiEventItem>): Int? {
+        return null
     }
     
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, FeedUiEventItem> {

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/feed/MyFeedPagingSource.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/feed/MyFeedPagingSource.kt
@@ -18,8 +18,8 @@ class MyFeedPagingSource (
     private val ioDispatcher: CoroutineDispatcher
 ): PagingSource<Int, FeedUiEventItem>() {
 
-    override fun getRefreshKey(state: PagingState<Int, FeedUiEventItem>): Int {
-        return (System.currentTimeMillis()/1000).toInt()
+    override fun getRefreshKey(state: PagingState<Int, FeedUiEventItem>): Int? {
+        return null
     }
     
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, FeedUiEventItem> {

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/feed/SimilarListensPagingSource.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/feed/SimilarListensPagingSource.kt
@@ -18,7 +18,7 @@ class SimilarListensPagingSource(
 ): PagingSource<Int, FeedUiEventItem>() {
     
     override fun getRefreshKey(state: PagingState<Int, FeedUiEventItem>): Int? {
-        return (System.currentTimeMillis()/1000).toInt()
+        return null
     }
     
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, FeedUiEventItem> {


### PR DESCRIPTION
Since null in max_ts means server assumes max_ts as current time, it makes sense to just leave it as null.