### PR TITLE
Rectified a bug, added overflow to text

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/ui/screens/newsbrainz/NewsBrainzScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/newsbrainz/NewsBrainzScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.text.HtmlCompat
 import org.listenbrainz.android.model.BlogPost
@@ -128,11 +129,13 @@ fun BlogCard(
                 Text(
                     text = parsedTitle,
                     textAlign = TextAlign.Left,
-                    color = ListenBrainzTheme.colorScheme.lbSignature
+                    color = ListenBrainzTheme.colorScheme.lbSignature,
+                    modifier = Modifier.padding(end = 5.dp).fillMaxWidth(0.9F)
                 )
                 IconButton(onClick = { onLongClick() }) {
-                   Icon(painter = painterResource(id = R.drawable.news_share), contentDescription = "Share News Button" , tint = ListenBrainzTheme.colorScheme.hint
+                   Icon(painter = painterResource(id = R.drawable.news_share), contentDescription = "Share News Button" , tint = ListenBrainzTheme.colorScheme.hint , modifier = Modifier.padding(start = 5.dp)
                    )
+
                 }
             }
 
@@ -149,7 +152,9 @@ fun BlogCard(
             Text(
                 text = parsedContent,
                 maxLines = 4,
-                color = MaterialTheme.colorScheme.onSurface
+                color = MaterialTheme.colorScheme.onSurface,
+                overflow = TextOverflow.Ellipsis
+
             )
         }
     }


### PR DESCRIPTION
If the title of the blog was very large, it was occupying the full available space and the share button was not visible when I was checking the app today, so changed the code so that title takes only 70% of the row. Also as Aerozol suggested yesterday, added text overflow property to the content of the blog. (https://tickets.metabrainz.org/browse/MOBILE-178?page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel&focusedCommentId=70443#comment-70443)
![updatedNB](https://github.com/metabrainz/listenbrainz-android/assets/122373207/2133e23b-31bf-4724-b421-f44e69968d0b)
