### PR TITLE
MOBILE-182:App Crashes in YIM 23

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/model/yimdata/Yim23AdditionalMetadata.kt
+++ b/app/src/main/java/org/listenbrainz/android/model/yimdata/Yim23AdditionalMetadata.kt
@@ -3,7 +3,7 @@ package org.listenbrainz.android.model.yimdata
 import com.google.gson.annotations.SerializedName
 
 data class Yim23AdditionalMetadata (
-    @SerializedName("caa_id") var caaId    : String   = "",
+    @SerializedName("caa_id") var caaId    : Long   = 0,
     @SerializedName("caa_release_mbid") var caaReleaseMbid   : String   = "",
 
     )

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/yim23/Yim23DiscoveriesListScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/yim23/Yim23DiscoveriesListScreen.kt
@@ -70,9 +70,10 @@ private fun Yim23Discoveries (viewModel: Yim23ViewModel) {
         ) {
         LazyColumn (state = rememberLazyListState()) {
             items(topDiscoveries) {
+
                 YimListenCard(releaseName = it.title, artistName = it.creator,
                     coverArtUrl = Utils.getCoverArtUrl(
-                        caaId = it.extension.extensionData.additionalMetadata.caaId.toLong(),
+                        caaId = it.extension.extensionData.additionalMetadata.caaId,
                         caaReleaseMbid = it.extension.extensionData.additionalMetadata.caaReleaseMbid ,
                         size = 500
                     )

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/yim23/Yim23DiscoveriesScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/yim23/Yim23DiscoveriesScreen.kt
@@ -89,7 +89,7 @@ private fun Yim23DiscoveriesArt(
             Row () {
                 for(i in 3*j-2..3*j){
                     if(tracks[i-1].extension.extensionData.additionalMetadata.caaReleaseMbid != "" &&
-                        tracks[i-1].extension.extensionData.additionalMetadata.caaId != "")
+                        tracks[i-1].extension.extensionData.additionalMetadata.caaId != 0L)
                     GlideImage(
                         model = Utils.getCoverArtUrl(
                             caaReleaseMbid = tracks[i-1].extension.extensionData.additionalMetadata.caaReleaseMbid,

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/yim23/Yim23MissedSongsScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/yim23/Yim23MissedSongsScreen.kt
@@ -86,7 +86,7 @@ private fun Yim23MissedSongsArt (viewModel: Yim23ViewModel) {
             Row () {
                 for(i in 3*j-2..3*j){
                     if(tracks[i-1].extension.extensionData.additionalMetadata.caaReleaseMbid != ""
-                        && tracks[i-1].extension.extensionData.additionalMetadata.caaId != "")
+                        && tracks[i-1].extension.extensionData.additionalMetadata.caaId != 0L)
                         GlideImage(
                             model = Utils.getCoverArtUrl(
                                 caaReleaseMbid = tracks[i-1].extension.extensionData.additionalMetadata.caaReleaseMbid,


### PR DESCRIPTION
# Problem

While scrolling to the end in any of the lists present in YIM23, the app suddenly crashes

# Solution
While creating the models , I mistakenly put caaId as string. So now what happens is when caaId is null for a song, the .toLong() function raises JavaNumberFormatException. To overcome this, I changed the datatype in the model and made some changes where it was used according to the new datatype (Long)
# Action
Please test this locally once just to make sure

# Demo of Change

https://github.com/metabrainz/listenbrainz-android/assets/122373207/93c56eb7-a8ab-41d0-88c7-d8a1f93fdb6c

