### PR TITLE
Concurrency and typo fixes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,8 +31,8 @@ android {
         applicationId 'org.listenbrainz.android'
         minSdk 21
         targetSdk 34
-        versionCode 46
-        versionName "2.5.2"
+        versionCode 47
+        versionName "2.5.3"
         multiDexEnabled true
         testInstrumentationRunner "org.listenbrainz.android.di.CustomTestRunner" // "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,8 +31,8 @@ android {
         applicationId 'org.listenbrainz.android'
         minSdk 21
         targetSdk 34
-        versionCode 47
-        versionName "2.5.3"
+        versionCode 48
+        versionName "2.5.4"
         multiDexEnabled true
         testInstrumentationRunner "org.listenbrainz.android.di.CustomTestRunner" // "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/fastlane/metadata/android/en-US/changelogs/47.txt
+++ b/fastlane/metadata/android/en-US/changelogs/47.txt
@@ -1,0 +1,1 @@
+Listens Submission fixes

--- a/fastlane/metadata/android/en-US/changelogs/48.txt
+++ b/fastlane/metadata/android/en-US/changelogs/48.txt
@@ -1,0 +1,1 @@
+YIM 23 fixes!


### PR DESCRIPTION
## Changelog
1) Concurreny fix in `SpotifyAppRemote` connection functions that caused a crash sometimes. 
    Why? Since Spotify sometimes runs callbacks twice, it makes our coroutine resume twice which causes an exception.
2) Typo fix.

Note: Checkout [this](https://github.com/metabrainz/listenbrainz-android/commit/f20f9f8bf93c76d0cfc44e6bdc0ea16735b06952) commit's description where concurrency fix is reverted.