### PR TITLE
Fix uninitialized property

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/ui/theme/Theme.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/theme/Theme.kt
@@ -92,7 +92,7 @@ private val colorSchemeLight = ColorScheme(
     hint = Color(0xFF707070)
 )
 
-private lateinit var LocalColorScheme: ProvidableCompositionLocal<ColorScheme>
+private var LocalColorScheme: ProvidableCompositionLocal<ColorScheme> = staticCompositionLocalOf { colorSchemeLight }
 
 private val DarkColorScheme = darkColorScheme(
     background = app_bg_dark,


### PR DESCRIPTION
Fixes: "UninitializedPropertyAccessException: lateinit property LocalColorScheme has not been initialized" reported on sentry