### PR TITLE
MOBILE-192: Sort Collections by Name/Title by Default

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,8 +31,8 @@ android {
         applicationId 'org.listenbrainz.android'
         minSdk 21
         targetSdk 34
-        versionCode 48
-        versionName "2.5.4"
+        versionCode 49
+        versionName "2.5.5"
         multiDexEnabled true
         testInstrumentationRunner "org.listenbrainz.android.di.CustomTestRunner" // "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,8 +31,8 @@ android {
         applicationId 'org.listenbrainz.android'
         minSdk 21
         targetSdk 34
-        versionCode 49
-        versionName "2.5.5"
+        versionCode 50
+        versionName "2.6.0"
         multiDexEnabled true
         testInstrumentationRunner "org.listenbrainz.android.di.CustomTestRunner" // "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/org/listenbrainz/android/model/dao/AlbumDao.kt
+++ b/app/src/main/java/org/listenbrainz/android/model/dao/AlbumDao.kt
@@ -10,10 +10,10 @@ interface AlbumDao {
     @Query(value = "SELECT * FROM ALBUMS WHERE albumId = :albumId")
     fun getAlbumEntity(albumId: Long): Flow<AlbumEntity>
     
-    @Query(value = "SELECT * FROM ALBUMS")
+    @Query(value = "SELECT * FROM ALBUMS ORDER BY `title`")
     fun getAlbumEntities(): Flow<List<AlbumEntity>>
     
-    @Query(value = "SELECT * FROM ALBUMS")
+    @Query(value = "SELECT * FROM ALBUMS ORDER BY `title`")
     fun getAlbumEntitiesAsList(): List<AlbumEntity>
     
     @Insert(onConflict = OnConflictStrategy.IGNORE)

--- a/app/src/main/java/org/listenbrainz/android/model/dao/ArtistDao.kt
+++ b/app/src/main/java/org/listenbrainz/android/model/dao/ArtistDao.kt
@@ -12,10 +12,10 @@ interface ArtistDao {
     @Query(value = "SELECT * FROM ARTISTS WHERE artistID = :artistID")
     fun getArtistEntity(artistID: String) : Flow<ArtistEntity>
     
-    @Query(value = "SELECT * FROM ARTISTS")
+    @Query(value = "SELECT * FROM ARTISTS ORDER BY `name`")
     fun getArtistEntities() : Flow<List<ArtistEntity>>
     
-    @Query(value = "SELECT * FROM ARTISTS")
+    @Query(value = "SELECT * FROM ARTISTS ORDER BY `name`")
     fun getArtistEntitiesAsList() : List<ArtistEntity>
     
     @Insert(onConflict = OnConflictStrategy.NONE)

--- a/app/src/main/java/org/listenbrainz/android/model/dao/SongDao.kt
+++ b/app/src/main/java/org/listenbrainz/android/model/dao/SongDao.kt
@@ -14,10 +14,10 @@ interface SongDao {
         value = "SELECT * FROM SONGS WHERE mediaID = :mediaId ")
     fun getSongEntity(mediaId: String) : Flow<SongEntity>
 
-    @Query(value = "SELECT * FROM SONGS")
+    @Query(value = "SELECT * FROM SONGS ORDER BY `title`")
     fun getSongEntities() : Flow<List<SongEntity>>
 
-    @Query(value = "SELECT * FROM SONGS")
+    @Query(value = "SELECT * FROM SONGS ORDER BY `title`")
     fun getSongEntitiesAsList() : List<SongEntity>
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/SongScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/SongScreen.kt
@@ -202,7 +202,7 @@ fun SongScreen() {
             BPLibraryEmptyMessage(modifier = Modifier.align(Alignment.Center))
         } else {
             LazyVerticalGrid(columns = GridCells.Fixed(2)) {
-                items(songs.value.sortedBy { it.discNumber }) {
+                items(songs.value) {
                     Box(modifier = Modifier
                         .padding(2.dp)
                         .height(240.dp)

--- a/fastlane/metadata/android/en-US/changelogs/49.txt
+++ b/fastlane/metadata/android/en-US/changelogs/49.txt
@@ -1,0 +1,1 @@
+YIM 23 fixes!

--- a/fastlane/metadata/android/en-US/changelogs/50.txt
+++ b/fastlane/metadata/android/en-US/changelogs/50.txt
@@ -1,0 +1,1 @@
+Login fix


### PR DESCRIPTION
As per [MOBILE-192](https://tickets.metabrainz.org/browse/MOBILE-192) the collections in the player were not sorted in any way. I have made the following changes to make this experience more usable and consistent:

- Added `ORDER BY` clauses to the DOAs for the problematic collections. This provides a sane default sorting by name/title.
- Removed the additional sorting from the `SongScreen` so that the list on the `BrainzPlayerScreen` and `SongScreen` are consistent, as with the other collection screens.