### PR TITLE
Mobile-204: Profile icon in the Bottom Navigation Bar does not update its selected state

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/ui/navigation/BottomNavigationBar.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/navigation/BottomNavigationBar.kt
@@ -50,7 +50,7 @@ fun BottomNavigationBar(
         items.forEach { item ->
             val navBackStackEntry by navController.currentBackStackEntryAsState()
             val currentDestination = navBackStackEntry?.destination
-            val selected = currentDestination?.hierarchy?.any { it.route == item.route } == true
+            val selected = currentDestination?.route?.startsWith("${item.route}/") == true || currentDestination?.route == item.route
             BottomNavigationItem(
                 icon = {
                     Icon(


### PR DESCRIPTION
This PR resolves an issue where the Profile tab in the Bottom Navigation Bar failed to update its selected state. The problem occurred due to route comparison logic that did not account for variations in routes such as `profile/{username}`.

Changes Made
- Updated the route comparison logic to handle both static and parameterized routes.
- Verified consistent behavior across all navigation items in the Bottom Navigation Bar.

Issue Link
Linked to issue [MOBILE-204](https://tickets.metabrainz.org/projects/MOBILE/issues/MOBILE-204).
