### PR TITLE
Fix: Minor ui bugs in Profile Screen

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/listens/ListensScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/listens/ListensScreen.kt
@@ -334,28 +334,39 @@ fun ListensScreen(
                 }
 
                 item {
-                    Box(modifier = Modifier
-                        .padding(top = 30.dp)
-                        .clip(shape = RoundedCornerShape(20.dp))
-                        .fillMaxWidth()
-                        .background(
-                            ListenBrainzTheme.colorScheme.songsListenedToBG
-                        )){
-                        Column {
-                            SimilarUsersCard(similarUsers = when(similarUsersCollapsibleState.value){
-                                true -> uiState.listensTabUiState.similarUsers?.take(5) ?: emptyList()
-                                false -> uiState.listensTabUiState.similarUsers ?: emptyList()
-                            }, goToUserPage = goToUserPage)
+                    if(!uiState.listensTabUiState.similarUsers.isNullOrEmpty()) {
+                        Box(
+                            modifier = Modifier
+                                .padding(top = 30.dp)
+                                .clip(shape = RoundedCornerShape(20.dp))
+                                .fillMaxWidth()
+                                .background(
+                                    ListenBrainzTheme.colorScheme.songsListenedToBG
+                                )
+                        ) {
+                            Column {
+                                SimilarUsersCard(
+                                    similarUsers = when (similarUsersCollapsibleState.value) {
+                                        true -> uiState.listensTabUiState.similarUsers.take(5)
 
-                            if((uiState.listensTabUiState.similarUsers?.size ?: 0) > 5){
-                                Spacer(modifier = Modifier.height(20.dp))
-                                Row (modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
-                                    LoadMoreButton(
-                                        state = similarUsersCollapsibleState.value,
-                                        onClick = {
-                                            similarUsersCollapsibleState.value = !similarUsersCollapsibleState.value
-                                        }
-                                    )
+                                        false -> uiState.listensTabUiState.similarUsers
+                                    }, goToUserPage = goToUserPage
+                                )
+
+                                if ((uiState.listensTabUiState.similarUsers.size) > 5) {
+                                    Spacer(modifier = Modifier.height(20.dp))
+                                    Row(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        horizontalArrangement = Arrangement.Center
+                                    ) {
+                                        LoadMoreButton(
+                                            state = similarUsersCollapsibleState.value,
+                                            onClick = {
+                                                similarUsersCollapsibleState.value =
+                                                    !similarUsersCollapsibleState.value
+                                            }
+                                        )
+                                    }
                                 }
                             }
                         }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/listens/ListensScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/listens/ListensScreen.kt
@@ -295,6 +295,7 @@ fun ListensScreen(
                 item {
                     Box(modifier = Modifier
                         .padding(top = 30.dp)
+                        .fillMaxWidth()
                         .background(ListenBrainzTheme.colorScheme.songsListenedToBG)
                     ) {
                         Column {
@@ -336,6 +337,7 @@ fun ListensScreen(
                     Box(modifier = Modifier
                         .padding(top = 30.dp)
                         .clip(shape = RoundedCornerShape(20.dp))
+                        .fillMaxWidth()
                         .background(
                             ListenBrainzTheme.colorScheme.songsListenedToBG
                         )){
@@ -603,7 +605,7 @@ fun CompatibilityCard(compatibility: Float, similarArtists: List<Artist>, goToAr
 private fun FollowersCard(followersCount: Int?, followingCount: Int?, followers: List<Pair<String,Boolean>>,
                           following: List<Pair<String,Boolean>>, followersState: Boolean, onStateChange: (Boolean) -> Unit,
                           onFollowButtonClick: (String?, Boolean) -> Unit, goToUserPage: (String?) -> Unit) {
-    Column(modifier = Modifier.padding(start = 16.dp , top = 30.dp)) {
+    Column(modifier = Modifier.padding(start = 16.dp , top = 30.dp, end = 16.dp)) {
         Text(
             "Followers",
             color = ListenBrainzTheme.colorScheme.text,


### PR DESCRIPTION
This PR addresses the following UI issues in the profile screen [(Images):](https://imgur.com/a/images-0OkH5wA)  

1. **Background Width Issue (In light mode)**  
   - Ensures the background of the followers section and similar users section spans the full width of the screen.  

2. **Padding Issue in Followers Section**  
   - Adds proper padding to the right side of the follower cards to prevent them from touching the screen’s edge.  

3. **Empty Similar Users Section**  
   - Hides the similar users section if no data is available.  

Let me know if any further changes are required!  