### PR TITLE
Fix: Light theme on profile screen and ui enhancement.

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/BaseProfileScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/BaseProfileScreen.kt
@@ -183,7 +183,7 @@ fun BaseProfileScreen(
 
                 Row (modifier = Modifier
                     .align(Alignment.End)
-                    .padding(end = 20.dp)) {
+                    .padding(end = 20.dp, bottom = 4.dp)) {
                     if(currentTab.value == ProfileScreenTab.LISTENS){
                         when(isLoggedInUser) {
                             true -> AddListensButton()
@@ -258,6 +258,7 @@ private fun FollowButton(onFollowClick: (String) -> Unit, username: String?) {
         }
 
     }, modifier = Modifier
+        .clip(RoundedCornerShape(4.dp))
         .background(lb_purple)
         .width(100.dp)
         .height(30.dp)) {
@@ -279,6 +280,7 @@ private fun UnFollowButton(onUnFollowClick: (String) -> Unit, username: String?)
         }
 
     }, modifier = Modifier
+        .clip(RoundedCornerShape(4.dp))
         .background(lb_purple)
         .width(100.dp)
         .height(30.dp)) {
@@ -295,6 +297,7 @@ private fun UnFollowButton(onUnFollowClick: (String) -> Unit, username: String?)
 @Composable
 private fun AddListensButton() {
     IconButton(onClick = { /*TODO*/ }, modifier = Modifier
+        .clip(RoundedCornerShape(4.dp))
         .background(Color(0xFF353070))
         .width(110.dp)
         .height(30.dp)) {
@@ -311,6 +314,7 @@ private fun AddListensButton() {
 @Composable
 private fun MusicBrainzButton(onClick: () -> Unit) {
     IconButton(onClick = onClick, modifier = Modifier
+        .clip(RoundedCornerShape(4.dp))
         .background(Color(0xFF353070))
         .width(140.dp)
         .height(30.dp)) {

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/listens/ListensScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/listens/ListensScreen.kt
@@ -279,6 +279,7 @@ fun ListensScreen(
                     item {
                         Box(
                             modifier = Modifier
+                                .fillMaxWidth()
                                 .padding(top = 30.dp)
                                 .background(ListenBrainzTheme.colorScheme.songsListenedToBG)
                         ) {
@@ -421,8 +422,8 @@ private fun BuildSimilarArtists(similarArtists: List<Artist>, onArtistClick: (St
         similarArtists.isEmpty() -> {
             Text(
                 "You have no common artists",
-                color = white,
-                modifier = Modifier.padding(horizontal = 16.dp),
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.padding(start = 16.dp, bottom = 8.dp),
                 style = MaterialTheme.typography.bodyMedium
             )
         }


### PR DESCRIPTION
These are the changes made in this PR.
1. Fixed the compatibility box to occupy the full width of screen.
2. Changed the text color of "You have no common artists" to onSurface for proper visibility in both dark and light themes.
3. Made the corners of addListenButton, musicBrainButton, Follow and unfollow button rounded with 4.dp.
4. Also added a padding of 4.dp below this row, to enhance the ui.

Do let me know if any changes have to be made.

### Screenshots:
Issue screenshot:
![compat_light_unfixed](https://github.com/user-attachments/assets/31048565-14f7-4810-a539-55f13546d514)

Fixed light screen:
![compat_light_fixed](https://github.com/user-attachments/assets/0a42272c-dc62-4f88-b7e3-1549f527b202)

Fixed dark mode screen:
![compat_dark_fixed](https://github.com/user-attachments/assets/c83a2de1-93a4-4e5e-823e-63f147b9cde3)


Linked to issue: [Mobile-205](https://tickets.metabrainz.org/projects/MOBILE/issues/MOBILE-205?filter=allopenissues)