### PR TITLE
Fixed Song Duration bug + Player Screen UI changes

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
@@ -149,7 +149,8 @@ fun BrainzPlayerBackDropScreen(
             val songList = brainzPlayerViewModel.mediaItem.collectAsState().value.data ?: listOf()
             SongViewPager(
                 modifier = Modifier.graphicsLayer {
-                    alpha = ( backdropScaffoldState.requireOffset() / (maxDelta - headerHeight.toPx()) )
+                    alpha =
+                        (backdropScaffoldState.requireOffset() / (maxDelta - headerHeight.toPx()))
                 },
                 songList = songList,
                 backdropScaffoldState = backdropScaffoldState,
@@ -188,14 +189,19 @@ fun PlayerScreen(
             }
         }
         item {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Column(modifier = Modifier.fillMaxWidth(0.8f)) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+                modifier = Modifier
+                    .padding(start = 25.dp, end = 25.dp)
+                    .fillMaxWidth()
+            ) {
+                Column(modifier = Modifier.fillMaxWidth(0.9f)) {
                     Spacer(modifier = Modifier.height(25.dp))
                     Text(
                         text = currentlyPlayingSong.title,
                         fontSize = 20.sp,
                         modifier = Modifier
-                            .padding(start = 25.dp)
                             .basicMarquee(),
                         fontWeight = FontWeight.Bold,
                         textAlign = TextAlign.Start,
@@ -205,7 +211,6 @@ fun PlayerScreen(
                         text = currentlyPlayingSong.artist,
                         fontSize = 16.sp,
                         modifier = Modifier
-                            .padding(start = 25.dp)
                             .basicMarquee(),
                         textAlign = TextAlign.Start,
                         color = MaterialTheme.colorScheme.onSurface
@@ -245,26 +250,46 @@ fun PlayerScreen(
                     modifier = Modifier
                         .height(10.dp)
                         .fillMaxWidth(0.98F)
-                        .padding(10.dp),
+                        .padding(horizontal = 20.dp),
                     progress = progress,
                     onValueChange = brainzPlayerViewModel::onSeek,
                     onValueChanged = brainzPlayerViewModel::onSeeked
                 )
             }
-            Row(verticalAlignment = Alignment.CenterVertically,
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween,
                 modifier = Modifier
                     .fillMaxWidth(0.98F)
-                    .padding(start = 10.dp, top = 10.dp, end = 10.dp)) {
+                    .padding(start = 22.dp, top = 10.dp, end = 22.dp)
+            ) {
                 val songCurrentPosition by brainzPlayerViewModel.songCurrentPosition.collectAsState()
                 val duration: String
                 val currentPosition: String
-                if (currentlyPlayingSong.duration / (1000 * 60 * 60) > 0 &&  songCurrentPosition / (1000 * 60 * 60) > 0){
-                    duration = String.format("%02d:%02d:%02d", currentlyPlayingSong.duration/(1000 * 60 * 60),currentlyPlayingSong.duration/(1000 * 60) % 60,currentlyPlayingSong.duration/1000 % 60)
-                    currentPosition = String.format("%02d:%02d:%02d", songCurrentPosition/(1000 * 60 * 60),songCurrentPosition/(1000 * 60) % 60,songCurrentPosition/1000 % 60)
+                if (currentlyPlayingSong.duration / (1000 * 60 * 60) > 0 && songCurrentPosition / (1000 * 60 * 60) > 0) {
+                    duration = String.format(
+                        "%02d:%02d:%02d",
+                        currentlyPlayingSong.duration / (1000 * 60 * 60),
+                        currentlyPlayingSong.duration / (1000 * 60) % 60,
+                        currentlyPlayingSong.duration / 1000 % 60
+                    )
+                    currentPosition = String.format(
+                        "%02d:%02d:%02d",
+                        songCurrentPosition / (1000 * 60 * 60),
+                        songCurrentPosition / (1000 * 60) % 60,
+                        songCurrentPosition / 1000 % 60
+                    )
                 } else {
-                    duration = String.format("%02d:%02d",currentlyPlayingSong.duration/(1000 * 60) % 60,currentlyPlayingSong.duration/1000 % 60)
-                    currentPosition = String.format("%02d:%02d",songCurrentPosition/(1000 * 60) % 60,songCurrentPosition/1000 % 60)
+                    duration = String.format(
+                        "%02d:%02d",
+                        currentlyPlayingSong.duration / (1000 * 60) % 60,
+                        currentlyPlayingSong.duration / 1000 % 60
+                    )
+                    currentPosition = String.format(
+                        "%02d:%02d",
+                        songCurrentPosition / (1000 * 60) % 60,
+                        songCurrentPosition / 1000 % 60
+                    )
                 }
 
 
@@ -290,10 +315,10 @@ fun PlayerScreen(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceEvenly, modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 60.dp)
+                    .padding(top = 20.dp, bottom = 20.dp)
             ) {
                 Icon(
-                    imageVector =    when(repeatMode) {
+                    imageVector = when (repeatMode) {
                         RepeatMode.REPEAT_MODE_OFF -> Icons.Rounded.Loop
                         RepeatMode.REPEAT_MODE_ALL -> Icons.Filled.RepeatOn
                         RepeatMode.REPEAT_MODE_ONE -> Icons.Rounded.RepeatOne
@@ -380,14 +405,16 @@ fun PlayerScreen(
                 Button(
                     onClick = {
                         checkedSongs.forEach { song ->
-                            brainzPlayerViewModel.appPreferences.currentPlayable?.songs?.toMutableList()?.remove(song)
+                            brainzPlayerViewModel.appPreferences.currentPlayable?.songs?.toMutableList()
+                                ?.remove(song)
                         }
                         brainzPlayerViewModel.appPreferences.currentPlayable?.songs?.let {
                             brainzPlayerViewModel.changePlayable(
                                 it,
                                 PlayableType.ALL_SONGS,
                                 brainzPlayerViewModel.appPreferences.currentPlayable?.id ?: 0,
-                                brainzPlayerViewModel.appPreferences.currentPlayable?.songs?.indexOfFirst { it.mediaID == currentlyPlayingSong.mediaID } ?: 0,brainzPlayerViewModel.songCurrentPosition.value
+                                brainzPlayerViewModel.appPreferences.currentPlayable?.songs?.indexOfFirst { it.mediaID == currentlyPlayingSong.mediaID }
+                                    ?: 0, brainzPlayerViewModel.songCurrentPosition.value
                             )
                         }
                         brainzPlayerViewModel.queueChanged(
@@ -414,14 +441,17 @@ fun PlayerScreen(
             }
         }
         // Playlist
-        itemsIndexed(items = brainzPlayerViewModel.appPreferences.currentPlayable?.songs ?: mutableListOf()) { index, song ->
+        itemsIndexed(
+            items = brainzPlayerViewModel.appPreferences.currentPlayable?.songs ?: mutableListOf()
+        ) { index, song ->
             val isChecked = checkedSongs.contains(song)
             BoxWithConstraints {
                 val maxWidth =
-                    (maxWidth - 60.dp).coerceAtMost(600.dp)
+                    (maxWidth - 120.dp)
                 Row(
                     horizontalArrangement = Arrangement.Start,
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.padding(horizontal = 20.dp)
                 )
                 {
                     val modifier = if (currentlyPlayingSong.mediaID == song.mediaID) {
@@ -444,11 +474,16 @@ fun PlayerScreen(
                         brainzPlayerViewModel.skipToPlayable(index)
                         brainzPlayerViewModel.appPreferences.currentPlayable?.songs?.let {
                             brainzPlayerViewModel.changePlayable(
-                                it, PlayableType.ALL_SONGS, brainzPlayerViewModel.appPreferences.currentPlayable?.id ?: 0, index,0L)
+                                it,
+                                PlayableType.ALL_SONGS,
+                                brainzPlayerViewModel.appPreferences.currentPlayable?.id ?: 0,
+                                index,
+                                0L
+                            )
                         }
                         brainzPlayerViewModel.playOrToggleSong(song, true)
                     }
-                    if (currentlyPlayingSong.mediaID!=song.mediaID) {
+                    if (currentlyPlayingSong.mediaID != song.mediaID) {
                         androidx.compose.material3.Surface(
                             shape = RoundedCornerShape(5.dp),
                             shadowElevation = 5.dp
@@ -482,11 +517,11 @@ fun PlayerScreen(
     }
 
     // TODO: fix this
-    val cache= App.context?.let { CacheService<Song>(it, RECENTLY_PLAYED_KEY) }
+    val cache = App.context?.let { CacheService<Song>(it, RECENTLY_PLAYED_KEY) }
     cache?.saveData(currentlyPlayingSong, Song::class.java)
-    val data= cache?.getData(Song::class.java)
+    val data = cache?.getData(Song::class.java)
     if (data != null) {
-        recentlyPlayed.items=data.filter { it.title!="null" }.toList().reversed()
+        recentlyPlayed.items = data.filter { it.title != "null" }.toList().reversed()
     }
 }
 
@@ -494,10 +529,10 @@ fun PlayerScreen(
 @Composable
 fun AlbumArtViewPager(currentlyPlayingSong: Song, pagerState: PagerState) {
     HorizontalPager(
-            state = pagerState,
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(ListenBrainzTheme.colorScheme.background),
+        state = pagerState,
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(ListenBrainzTheme.colorScheme.background),
     ) { page ->
         Column(
             Modifier
@@ -515,7 +550,7 @@ fun AlbumArtViewPager(currentlyPlayingSong: Song, pagerState: PagerState) {
                         // scroll position. We use the absolute value which allows us to mirror
                         // any effects for both directions
                         val pageOffset = pagerState.getOffsetDistanceInPages(page).absoluteValue
-                        
+
                         // We animate the scaleX + scaleY, between 85% and 100%
                         lerp(
                             start = 0.85f,
@@ -525,7 +560,7 @@ fun AlbumArtViewPager(currentlyPlayingSong: Song, pagerState: PagerState) {
                             scaleX = scale
                             scaleY = scale
                         }
-                        
+
                         // We animate the alpha, between 50% and 100%
                         alpha = lerp(
                             start = 0.5f,

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
@@ -397,7 +397,7 @@ fun PlayerScreen(
                 Text(
                     "Listening now",
                     fontSize = 24.sp,
-                    modifier = Modifier.padding(start = 22.dp),
+                    modifier = Modifier.padding(start = ListenBrainzTheme.paddings.defaultPadding),
                     fontWeight = FontWeight.SemiBold,
                     color = MaterialTheme.colorScheme.onSurface
                 )
@@ -429,7 +429,7 @@ fun PlayerScreen(
                     ),
                     enabled = checkedSongs.isNotEmpty(),
                     modifier = Modifier
-                        .padding(end = 20.dp)
+                        .padding(end = ListenBrainzTheme.paddings.vertical)
                         .align(Alignment.CenterVertically)
                         .alpha(if (checkedSongs.isNotEmpty()) 1f else 0f)
                 ) {
@@ -447,20 +447,24 @@ fun PlayerScreen(
             val isChecked = checkedSongs.contains(song)
             BoxWithConstraints {
                 val maxWidth =
-                    (maxWidth - 100.dp)
+                    (maxWidth - 70.dp)
                 Row(
                     horizontalArrangement = Arrangement.Start,
                     verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.padding(horizontal = 10.dp)
+                    modifier = Modifier.padding(horizontal = ListenBrainzTheme.paddings.horizontal)
                 )
                 {
                     val modifier = if (currentlyPlayingSong.mediaID == song.mediaID) {
                         Modifier
-                            .padding(horizontal = 10.dp, vertical = 6.dp)
+                            .padding(vertical = 6.dp)
                             .fillMaxWidth()
                     } else {
                         Modifier
-                            .padding(horizontal = 10.dp, vertical = 6.dp)
+                            .padding(
+                                top = 6.dp,
+                                bottom = 6.dp,
+                                end = ListenBrainzTheme.paddings.smallPadding
+                            )
                             .width(maxWidth)
                     }
                     ListenCardSmall(

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
@@ -397,7 +397,7 @@ fun PlayerScreen(
                 Text(
                     "Listening now",
                     fontSize = 24.sp,
-                    modifier = Modifier.padding(start = 25.dp),
+                    modifier = Modifier.padding(start = 22.dp),
                     fontWeight = FontWeight.SemiBold,
                     color = MaterialTheme.colorScheme.onSurface
                 )
@@ -429,7 +429,7 @@ fun PlayerScreen(
                     ),
                     enabled = checkedSongs.isNotEmpty(),
                     modifier = Modifier
-                        .padding(end = 16.dp)
+                        .padding(end = 20.dp)
                         .align(Alignment.CenterVertically)
                         .alpha(if (checkedSongs.isNotEmpty()) 1f else 0f)
                 ) {
@@ -447,11 +447,11 @@ fun PlayerScreen(
             val isChecked = checkedSongs.contains(song)
             BoxWithConstraints {
                 val maxWidth =
-                    (maxWidth - 120.dp)
+                    (maxWidth - 100.dp)
                 Row(
                     horizontalArrangement = Arrangement.Start,
                     verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.padding(horizontal = 20.dp)
+                    modifier = Modifier.padding(horizontal = 10.dp)
                 )
                 {
                     val modifier = if (currentlyPlayingSong.mediaID == song.mediaID) {
@@ -486,7 +486,7 @@ fun PlayerScreen(
                     if (currentlyPlayingSong.mediaID != song.mediaID) {
                         androidx.compose.material3.Surface(
                             shape = RoundedCornerShape(5.dp),
-                            shadowElevation = 5.dp
+                            shadowElevation = 5.dp,
                         ) {
                             Checkbox(
                                 checked = isChecked,

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
@@ -429,7 +429,7 @@ fun PlayerScreen(
                     ),
                     enabled = checkedSongs.isNotEmpty(),
                     modifier = Modifier
-                        .padding(end = ListenBrainzTheme.paddings.vertical)
+                        .padding(end = ListenBrainzTheme.paddings.horizontal)
                         .align(Alignment.CenterVertically)
                         .alpha(if (checkedSongs.isNotEmpty()) 1f else 0f)
                 ) {

--- a/app/src/main/java/org/listenbrainz/android/util/BrainzPlayerExtensions.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/BrainzPlayerExtensions.kt
@@ -46,7 +46,8 @@ object BrainzPlayerExtensions {
                 title = it.title.toString(),
                 artist = it.subtitle.toString(),
                 uri = it.mediaUri.toString(),
-                albumArt = it.iconUri.toString()
+                albumArt = it.iconUri.toString(),
+                duration = this.duration
             )
         } ?: Song()
 
@@ -76,7 +77,7 @@ object BrainzPlayerExtensions {
     inline val MediaMetadataCompat.artist: String?
         get() = getString(MediaMetadataCompat.METADATA_KEY_ARTIST)
 
-    inline val MediaMetadataCompat.duration
+    inline val MediaMetadataCompat.duration: Long
         get() = getLong(MediaMetadataCompat.METADATA_KEY_DURATION)
 
     inline val MediaMetadataCompat.album: String?


### PR DESCRIPTION
# Overview
The following changes have been made in this PR:

1. Fixed the song duration showing as 0:00 by passing duration in BrainzPlayerExtensions.kt
1. On the player screen, made a bunch of ui changes for consistency
   * The row containing the song title and the heart icon now uses SpaceBetween (for proper spacing)
   * Made the padding of song title row, progress bar and buttons row somewhat consistent
   * The cards below "Listening now" are no longer bound to max 600.dp (this caused issues when the phone was rotated, see image below) and are now properly spaced.

Please let me know if any further changes are required.

# Screenshots

Issue Screenshots:
<img src = "https://github.com/user-attachments/assets/d60cb58b-2584-48af-a861-2eb766373418" width="300px"/>


![WhatsApp Image 2024-12-12 at 12 28 19 PM](https://github.com/user-attachments/assets/33346941-bf5f-439e-8bdf-9225bb0e20a3)

Fixed player screen:
<img src = "https://github.com/user-attachments/assets/63352e02-c8eb-46d7-b3b7-8fc848580d1f" width="300px"/>

<img src = "https://github.com/user-attachments/assets/5b9e69d6-1934-4cfd-8eb6-ffab244b7a12" width="300px"/>

<img src = "https://github.com/user-attachments/assets/4674e811-05cd-4d21-aa53-5a4b48d0a811"/>
(cards fill the screen correctly)

---
Issue on Bug Tracker: [MOBILE-206](https://tickets.metabrainz.org/browse/MOBILE-206)