### PR TITLE
Fixed empty cover art showing blank space on brainzplayer & overview screens

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/ui/components/BrainzPlayerListenCard.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/components/BrainzPlayerListenCard.kt
@@ -10,12 +10,15 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.GenericShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -133,8 +136,13 @@ private fun AlbumArt(
             .data(coverArtUrl)
             .build(),
         fallback = painterResource(id = errorAlbumArt),
-        modifier = Modifier.size(ListenBrainzTheme.sizes.listenCardHeight),
-        contentScale = ContentScale.Fit,
+        error = painterResource(id = errorAlbumArt),
+        modifier = Modifier
+            .size(ListenBrainzTheme.sizes.listenCardHeight)
+            .clip(GenericShape { size, _ ->
+                addRect(Rect(0f, 0f, size.width*0.95f, size.height))
+            }),
+        contentScale = ContentScale.Crop,
         placeholder = painterResource(id = errorAlbumArt),
         filterQuality = FilterQuality.Low,
         contentDescription = "Album Cover Art"

--- a/app/src/main/java/org/listenbrainz/android/ui/components/ListenCardSmall.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/components/ListenCardSmall.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.GenericShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -28,6 +29,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.layout.ContentScale
@@ -257,8 +259,13 @@ private fun AlbumArt(
             .data(coverArtUrl)
             .build(),
         fallback = painterResource(id = errorAlbumArt),
-        modifier = Modifier.size(ListenBrainzTheme.sizes.listenCardHeight),
-        contentScale = ContentScale.Fit,
+        error = painterResource(id = errorAlbumArt),
+        modifier = Modifier
+            .size(ListenBrainzTheme.sizes.listenCardHeight)
+            .clip(GenericShape { size, _ ->
+                addRect(Rect(0f, 0f, size.width*0.95f, size.height))
+            }),
+        contentScale = ContentScale.Crop,
         placeholder = painterResource(id = errorAlbumArt),
         filterQuality = FilterQuality.Low,
         contentDescription = "Album Cover Art"

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/AlbumsOverviewScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/AlbumsOverviewScreen.kt
@@ -54,7 +54,7 @@ fun AlbumsOverViewScreen(
                     )
                     for (j in 1..albumsStarting[startingLetter]!!.size) {
                         val coverArt = albumsStarting[startingLetter]!![j - 1].albumArt
-                        BrainzPlayerListenCard(title = albumsStarting[startingLetter]!![j - 1].title, subTitle = albumsStarting[startingLetter]!![j - 1].artist, coverArtUrl = coverArt,modifier = Modifier.padding(
+                        BrainzPlayerListenCard(title = albumsStarting[startingLetter]!![j - 1].title, subTitle = albumsStarting[startingLetter]!![j - 1].artist, coverArtUrl = coverArt, errorAlbumArt = R.drawable.ic_erroralbumart, modifier = Modifier.padding(
                             start = 10.dp,
                             end = 10.dp,
                             top = 3.dp,

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/ArtistsOverviewScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/ArtistsOverviewScreen.kt
@@ -74,7 +74,7 @@ fun ArtistsOverviewScreen(
                         BrainzPlayerListenCard(title = artistsStarting[startingLetter]!![j - 1].name, subTitle = when (artistsStarting[startingLetter]!![j - 1].songs.size) {
                             1 -> "1 track"
                             else -> "${artistsStarting[startingLetter]!![j - 1].songs.size} tracks"
-                        }, coverArtUrl = coverArt, onPlayIconClick = {
+                        }, coverArtUrl = coverArt, errorAlbumArt = R.drawable.ic_artist, onPlayIconClick = {
                             onPlayClick(artistsStarting[startingLetter]!![j-1])
                         }, modifier = Modifier.padding(start = 10.dp, end = 10.dp), dropDown = { BrainzPlayerDropDownMenu(onAddToNewPlaylist = {onAddToNewPlaylist(artist)}, onAddToExistingPlaylist = {onAddToExistingPlaylist(artist)},onAddToQueue = {onAddToQueue(artist)}, onPlayNext = {onPlayNext(artist)},expanded = dropdownState == Pair(i,j-1), onDismiss = {dropdownState = Pair(-1,-1)})}, onDropdownIconClick = {dropdownState = Pair(i,j-1)}, dropDownState = dropdownState == Pair(i,j-1))
                         Spacer(modifier = Modifier.height(10.dp))

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/OverviewScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/OverviewScreen.kt
@@ -75,7 +75,7 @@ private fun RecentlyPlayedOverview(
             items(items = recentlyPlayedSongs) { song ->
                 if (song.title != "") {
                     BrainzPlayerActivityCards(icon = song.albumArt,
-                        errorIcon = R.drawable.ic_artist,
+                        errorIcon = R.drawable.ic_song,
                         title = song.artist,
                         subtitle = song.title,
                         modifier = Modifier
@@ -194,7 +194,7 @@ private fun AlbumsOverview(
                     album ->
                 if(album.title != ""){
                     BrainzPlayerActivityCards(icon = album.albumArt,
-                        errorIcon = R.drawable.ic_artist,
+                        errorIcon = R.drawable.ic_album,
                         title = album.artist,
                         subtitle = album.title,
                     )

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/RecentPlaysOverviewScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/RecentPlaysOverviewScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import org.listenbrainz.android.R
 import org.listenbrainz.android.model.Song
 import org.listenbrainz.android.ui.components.BrainzPlayerDropDownMenu
 import org.listenbrainz.android.ui.components.BrainzPlayerListenCard
@@ -86,7 +87,7 @@ private fun PlayedToday(
     )) {
         itemsIndexed(songsPlayedToday){
             index, it ->
-            BrainzPlayerListenCard(title = it.title, subTitle = it.artist, coverArtUrl = it.albumArt, onPlayIconClick = {onPlayIconClick(it)}, onDropdownIconClick = {dropDownState.value = Pair(1,index)}, dropDownState = dropDownState.value == Pair(1,index),dropDown = {BrainzPlayerDropDownMenu(
+            BrainzPlayerListenCard(title = it.title, subTitle = it.artist, coverArtUrl = it.albumArt, errorAlbumArt = R.drawable.ic_erroralbumart, onPlayIconClick = {onPlayIconClick(it)}, onDropdownIconClick = {dropDownState.value = Pair(1,index)}, dropDownState = dropDownState.value == Pair(1,index),dropDown = {BrainzPlayerDropDownMenu(
                 expanded = dropDownState.value == Pair(1,index),
                 onDismiss = {dropDownState.value = Pair(-1,-1)},
                 onAddToQueue = {onAddToQueue(it)},
@@ -117,7 +118,7 @@ private fun PlayedThisWeek(
     )) {
         itemsIndexed(songsPlayedThisWeek){
             index, it ->
-            BrainzPlayerListenCard(title = it.title, subTitle = it.artist, coverArtUrl = it.albumArt, onPlayIconClick = {onPlayIconClick(it)}, onDropdownIconClick = {dropDownState.value = Pair(2,index)}, dropDownState = dropDownState.value == Pair(2,index),dropDown = {BrainzPlayerDropDownMenu(
+            BrainzPlayerListenCard(title = it.title, subTitle = it.artist, coverArtUrl = it.albumArt, errorAlbumArt = R.drawable.ic_erroralbumart, onPlayIconClick = {onPlayIconClick(it)}, onDropdownIconClick = {dropDownState.value = Pair(2,index)}, dropDownState = dropDownState.value == Pair(2,index),dropDown = {BrainzPlayerDropDownMenu(
                 expanded = dropDownState.value == Pair(2,index),
                 onDismiss = {dropDownState.value = Pair(-1,-1)},
                 onAddToQueue = {onAddToQueue(it)},

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/SongsOverviewScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/SongsOverviewScreen.kt
@@ -56,7 +56,7 @@ fun SongsOverviewScreen(
                         val song: Song = songsStarting[startingLetter]!![j-1]
                         var coverArt: String? = null
                         coverArt = songsStarting[startingLetter]!![j - 1].albumArt
-                        BrainzPlayerListenCard(modifier = Modifier.padding(start= 10.dp, end = 10.dp),title = songsStarting[startingLetter]!![j - 1].title, subTitle = songsStarting[startingLetter]!![j - 1].artist, coverArtUrl = coverArt){
+                        BrainzPlayerListenCard(modifier = Modifier.padding(start= 10.dp, end = 10.dp),title = songsStarting[startingLetter]!![j - 1].title, subTitle = songsStarting[startingLetter]!![j - 1].artist, coverArtUrl = coverArt, errorAlbumArt = R.drawable.ic_erroralbumart){
                             onPlayIconClick(song,songsStarting[startingLetter]!!)
                         }
                         Spacer(modifier = Modifier.height(10.dp))


### PR DESCRIPTION
# Overview
The following changes have been made in this PR:
1. Added the missing `error` argument in `AsyncImage` of both `ListenCardSmall` and `BrainzPlayerListenCard`, so that `errorAlbumArt` properly shows on the cards, instead of blank space.
2. Added a rectangular clip to both `ListenCardSmall` & `BrainzPlayerListenCard`, so that `R.drawable.ic_erroralbumart` appears on the cards with no rounded corners on the left side, in line with normal album/cover arts.
3. Added proper `errorAlbumArt` arguments to multiple brainzplayer overview screens (with suitable drawables as shown in images below)
4. Changed `errorIcon` argument for cards in `OverviewScreen.kt` to better match the intended category (`ic_song` for songs & `ic_album` for albums

Please let me know if any changes are required, especially to those argument values I have passed for `errorAlbumArt` and `errorIcon`.

# Screenshots
### Issue Screenshots
<img src = "https://github.com/user-attachments/assets/7640be00-a0da-44a0-b473-b4236ef7b4ff" width = "250px"/>
<img src = "https://github.com/user-attachments/assets/3a23292b-a065-4205-bc14-ff02cca3728e" width = "250px"/>
<img src = "https://github.com/user-attachments/assets/41a6a311-ab2f-4677-9d75-acdc420d2aa7" width = "250px"/>

### Fixed Screenshots
<img src = "https://github.com/user-attachments/assets/ccf60478-639c-44d0-ab14-27343ffe8ddf" width = "250px"/>
<img src = "https://github.com/user-attachments/assets/930da81a-13b1-4056-8c95-eca95203d263" width = "250px"/>
<img src = "https://github.com/user-attachments/assets/228b91a6-6cf7-4aaa-92b0-ec6d1b7b78a4" width = "250px"/>

### `errorIcon` Changes (were previously `ic_artist`)
<img src = "https://github.com/user-attachments/assets/69725172-ce8b-4087-b5c7-ad83676f45fc" width = "250px"/> <img src = "https://github.com/user-attachments/assets/b28f246a-2c97-4f17-b688-a8992af18ac2" width = "250px"/>

---
Issue on tracker board: [MOBILE-207](https://tickets.metabrainz.org/projects/MOBILE/issues/MOBILE-207?filter=allissues)


