### PR TITLE
Feat: Handle mini music player like spotify

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -136,6 +136,7 @@ dependencies {
     implementation(libs.androidx.work.runtime.ktx)
     implementation(libs.androidx.paging.runtime)
     implementation(libs.androidx.paging.compose)
+    implementation(libs.androidx.palette.ktx)
 
     //Room DB
     implementation(libs.androidx.room.runtime)

--- a/app/src/main/java/org/listenbrainz/android/ui/components/SeekBar.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/components/SeekBar.kt
@@ -11,6 +11,8 @@ import androidx.compose.material.Slider
 import androidx.compose.material.SliderDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.semantics.ProgressBarRangeInfo
@@ -44,7 +46,8 @@ fun CustomSeekBar(
     modifier: Modifier = Modifier,
     @FloatRange(from = 0.0, to = 1.0)
     progress: Float,
-    onValueChange: (Float) -> Unit
+    onValueChange: (Float) -> Unit,
+    remainingProgressColor: Color = Color.Transparent
 ) {
     val range = 0f..1f
 
@@ -80,6 +83,10 @@ fun CustomSeekBar(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(4.dp)
+                .graphicsLayer {
+                    alpha = 0.2f
+                }
+                .background(remainingProgressColor)
         )
         Box(
             modifier = Modifier

--- a/app/src/main/java/org/listenbrainz/android/ui/components/SeekBar.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/components/SeekBar.kt
@@ -1,11 +1,22 @@
 package org.listenbrainz.android.ui.components
 
 import androidx.annotation.FloatRange
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.material.Slider
 import androidx.compose.material.SliderDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.progressBarRangeInfo
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
 import org.listenbrainz.android.R
 
 @Composable
@@ -25,6 +36,56 @@ fun SeekBar(
             thumbColor = colorResource(id = R.color.app_bg),
             activeTrackColor = colorResource(id = R.color.bp_color_primary)
         )
-
     )
+}
+
+@Composable
+fun CustomSeekBar(
+    modifier: Modifier = Modifier,
+    @FloatRange(from = 0.0, to = 1.0)
+    progress: Float,
+    onValueChange: (Float) -> Unit
+) {
+    val range = 0f..1f
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .semantics(mergeDescendants = true) {
+                progressBarRangeInfo = ProgressBarRangeInfo(progress, range)
+            }
+            .pointerInput(Unit) {
+                detectDragGestures(
+                    onDragStart = { offset ->
+                        val width = size.width.toFloat()
+                        val newProgress = (offset.x / width).coerceIn(range)
+                        onValueChange(newProgress)
+                    },
+                    onDrag = { change, _ ->
+                        val width = size.width.toFloat()
+                        val newProgress = (change.position.x / width).coerceIn(range)
+                        onValueChange(newProgress)
+                    }
+                )
+            }
+            .pointerInput(Unit) {
+                detectTapGestures { offset ->
+                    val width = size.width.toFloat()
+                    val newProgress = (offset.x / width).coerceIn(range)
+                    onValueChange(newProgress)
+                }
+            }
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(4.dp)
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth(progress)
+                .height(4.dp)
+                .background(colorResource(id = R.color.bp_color_primary))
+        )
+    }
 }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
@@ -63,7 +63,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
@@ -121,10 +120,10 @@ fun BrainzPlayerBackDropScreen(
 
     BackdropScaffold(
         modifier = Modifier.padding(top = paddingValues.calculateTopPadding()),
-        frontLayerShape = RectangleShape,
+        frontLayerShape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp),
         backLayerBackgroundColor = MaterialTheme.colorScheme.background,
         frontLayerScrimColor = Color.Unspecified,
-        headerHeight = if (isPlaying) headerHeight else 56.dp, // 136.dp is optimal header height.
+        headerHeight = headerHeight, // 136.dp is optimal header height.
         peekHeight = 0.dp,
         scaffoldState = backdropScaffoldState,
         backLayerContent = {
@@ -612,4 +611,5 @@ fun BrainzPlayerBackDropScreenPreview() {
         paddingValues = PaddingValues(0.dp)
     ) {}
 }
+
 

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
@@ -67,6 +67,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -87,6 +88,7 @@ import org.listenbrainz.android.model.Playlist.Companion.recentlyPlayed
 import org.listenbrainz.android.model.RepeatMode
 import org.listenbrainz.android.model.Song
 import org.listenbrainz.android.model.feed.FeedListenArtist
+import org.listenbrainz.android.ui.components.CustomSeekBar
 import org.listenbrainz.android.ui.components.ListenCardSmall
 import org.listenbrainz.android.ui.components.PlayPauseIcon
 import org.listenbrainz.android.ui.components.SeekBar
@@ -258,14 +260,17 @@ fun PlayerScreen(
         item {
             Box {
                 val progress by brainzPlayerViewModel.progress.collectAsState()
-                SeekBar(
+                CustomSeekBar(
                     modifier = Modifier
                         .height(10.dp)
                         .fillMaxWidth(0.98F)
                         .padding(horizontal = 20.dp),
                     progress = progress,
-                    onValueChange = brainzPlayerViewModel::onSeek,
-                    onValueChanged = brainzPlayerViewModel::onSeeked
+                    onValueChange = { newProgress ->
+                        brainzPlayerViewModel.onSeek(newProgress)
+                        brainzPlayerViewModel.onSeeked()
+                    },
+                    remainingProgressColor = colorResource(id = R.color.bp_color_primary)
                 )
             }
             Row(

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
@@ -457,8 +457,7 @@ fun PlayerScreen(
         ) { index, song ->
             val isChecked = checkedSongs.contains(song)
             BoxWithConstraints {
-                val maxWidth =
-                    (maxWidth - 70.dp)
+                val maxWidth = (this@BoxWithConstraints.maxWidth - 70.dp)
                 Row(
                     horizontalArrangement = Arrangement.Start,
                     verticalAlignment = Alignment.CenterVertically,
@@ -529,14 +528,6 @@ fun PlayerScreen(
             // Fixes bottom nav bar overlapping over last song
             Spacer(modifier = Modifier.height(56.dp))
         }
-    }
-
-    // TODO: fix this
-    val cache = App.context?.let { CacheService<Song>(it, RECENTLY_PLAYED_KEY) }
-    cache?.saveData(currentlyPlayingSong, Song::class.java)
-    val data = cache?.getData(Song::class.java)
-    if (data != null) {
-        recentlyPlayed.items = data.filter { it.title != "null" }.toList().reversed()
     }
 }
 

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
@@ -63,6 +63,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
@@ -114,16 +115,16 @@ fun BrainzPlayerBackDropScreen(
     }
     val repeatMode by brainzPlayerViewModel.repeatMode.collectAsState()
 
-    /** 56.dp is default bottom navigation height. 80.dp is our mini player's height. */
-    val headerHeight by animateDpAsState(targetValue = if (currentlyPlayingSong.title == "null" && currentlyPlayingSong.artist == "null") 56.dp else 136.dp)
+    /** 56.dp is default bottom navigation height. 70.dp is our mini player's height. */
+    val headerHeight by animateDpAsState(targetValue = if (currentlyPlayingSong.title == "null" && currentlyPlayingSong.artist == "null") 56.dp else 126.dp)
     val isPlaying = brainzPlayerViewModel.isPlaying.collectAsState().value
 
     BackdropScaffold(
         modifier = Modifier.padding(top = paddingValues.calculateTopPadding()),
-        frontLayerShape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp),
+        frontLayerShape = RectangleShape,
         backLayerBackgroundColor = MaterialTheme.colorScheme.background,
         frontLayerScrimColor = Color.Unspecified,
-        headerHeight = headerHeight, // 136.dp is optimal header height.
+        headerHeight = headerHeight, // 126.dp is optimal header height.
         peekHeight = 0.dp,
         scaffoldState = backdropScaffoldState,
         backLayerContent = {

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
@@ -76,6 +76,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.util.lerp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
 import kotlinx.coroutines.launch
@@ -108,13 +109,13 @@ fun BrainzPlayerBackDropScreen(
     paddingValues: PaddingValues,
     backLayerContent: @Composable () -> Unit
 ) {
-    val isShuffled by brainzPlayerViewModel.isShuffled.collectAsState()
+    val isShuffled by brainzPlayerViewModel.isShuffled.collectAsStateWithLifecycle()
     val currentlyPlayingSong =
-        brainzPlayerViewModel.currentlyPlayingSong.collectAsState().value.toSong
+        brainzPlayerViewModel.currentlyPlayingSong.collectAsStateWithLifecycle().value.toSong
     var maxDelta by rememberSaveable {
         mutableFloatStateOf(0F)
     }
-    val repeatMode by brainzPlayerViewModel.repeatMode.collectAsState()
+    val repeatMode by brainzPlayerViewModel.repeatMode.collectAsStateWithLifecycle()
 
     /** 56.dp is default bottom navigation height. 70.dp is our mini player's height. */
     val headerHeight by animateDpAsState(targetValue = if (currentlyPlayingSong.title == "null" && currentlyPlayingSong.artist == "null") 56.dp else 126.dp)

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerScreen.kt
@@ -80,8 +80,7 @@ fun BrainzPlayerScreen() {
     topAlbums.add(Album())
     
     Column(
-        modifier = Modifier
-            .fillMaxSize()
+        modifier = Modifier.fillMaxSize()
     ) {
         Navigation(albums = albums, previewAlbums = topAlbums, artists = artists, previewArtists = topArtists, playlists, songsPlayedToday, songsPlayedThisWeek ,topRecents ,songs, albumSongsMap)
     }
@@ -108,7 +107,8 @@ fun BrainzPlayerHomeScreen(
         brainzPlayerViewModel.currentlyPlayingSong.collectAsState().value.toSong
     val isPlaying = brainzPlayerViewModel.isPlaying
     Column {
-        Row(modifier = Modifier
+        Row(
+            modifier = Modifier
             .fillMaxWidth()
             .horizontalScroll(rememberScrollState())
             .background(
@@ -118,7 +118,8 @@ fun BrainzPlayerHomeScreen(
                         Color.Transparent
                     )
                 )
-            )) {
+            )
+        ) {
             Spacer(modifier = Modifier.width(ListenBrainzTheme.paddings.chipsHorizontal / 2))
             repeat(5) { position ->
                 ElevatedSuggestionChip(

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/OverviewScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/OverviewScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -33,34 +34,52 @@ import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.viewmodel.BrainzPlayerViewModel
 
 @Composable
-fun OverviewScreen (
+fun OverviewScreen(
     songsPlayedToday: List<Song>,
     goToRecentScreen: () -> Unit,
     goToArtistScreen: () -> Unit,
     goToAlbumScreen: () -> Unit,
     recentlyPlayedSongs: List<Song>,
     brainzPlayerViewModel: BrainzPlayerViewModel = hiltViewModel(),
-    artists : List<Artist>,
+    artists: List<Artist>,
     albums: List<Album>
 ) {
-    Column (modifier = Modifier.verticalScroll(rememberScrollState())) {
-       RecentlyPlayedOverview(recentlyPlayedSongs = recentlyPlayedSongs, goToRecentScreen = goToRecentScreen ,brainzPlayerViewModel = brainzPlayerViewModel)
-        ArtistsOverview(artists = artists, goToArtistScreen = goToArtistScreen)
-        AlbumsOverview(albums = albums, goToAlbumScreen = goToAlbumScreen)
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+    ) {
+        RecentlyPlayedOverview(
+            modifier = Modifier.fillMaxWidth(),
+            recentlyPlayedSongs = recentlyPlayedSongs,
+            goToRecentScreen = goToRecentScreen,
+            brainzPlayerViewModel = brainzPlayerViewModel
+        )
+        ArtistsOverview(
+            modifier = Modifier.fillMaxWidth(),
+            artists = artists,
+            goToArtistScreen = goToArtistScreen
+        )
+        AlbumsOverview(
+            modifier = Modifier.fillMaxWidth(),
+            albums = albums,
+            goToAlbumScreen = goToAlbumScreen
+        )
     }
-
-
 }
 
 @Composable
 private fun RecentlyPlayedOverview(
+    modifier: Modifier = Modifier,
     recentlyPlayedSongs: List<Song>,
-    brainzPlayerViewModel : BrainzPlayerViewModel,
-    goToRecentScreen : () -> Unit
+    brainzPlayerViewModel: BrainzPlayerViewModel,
+    goToRecentScreen: () -> Unit
 ) {
-    Column(modifier = Modifier.background(
-        brush = ListenBrainzTheme.colorScheme.gradientBrush
-    ).padding(top = 15.dp, bottom = 15.dp)) {
+    Column(
+        modifier = modifier
+            .background(brush = ListenBrainzTheme.colorScheme.gradientBrush)
+            .padding(top = 15.dp, bottom = 15.dp)
+    ) {
         Text(
             "Recently Played", style = TextStyle(
                 fontSize = 24.sp,
@@ -101,7 +120,9 @@ private fun RecentlyPlayedOverview(
                             }
                     ) {
                         Column(
-                            modifier = Modifier.fillMaxSize().background(ListenBrainzTheme.colorScheme.placeHolderColor)
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(ListenBrainzTheme.colorScheme.placeHolderColor)
                                 .padding(start = 5.dp, bottom = 20.dp),
                             verticalArrangement = Arrangement.Bottom
                         ) {
@@ -120,12 +141,17 @@ private fun RecentlyPlayedOverview(
 
 @Composable
 private fun ArtistsOverview(
-    artists : List<Artist>,
-    goToArtistScreen : () -> Unit
+    modifier: Modifier = Modifier,
+    artists: List<Artist>,
+    goToArtistScreen: () -> Unit
 ) {
-    Column(modifier = Modifier.background(
-        brush = ListenBrainzTheme.colorScheme.gradientBrush
-    ).padding(top = 15.dp, bottom = 15.dp)) {
+    Column(
+        modifier = modifier
+            .background(
+                brush = ListenBrainzTheme.colorScheme.gradientBrush
+            )
+            .padding(top = 15.dp, bottom = 15.dp)
+    ) {
         Text(
             "Artists", style = TextStyle(
                 fontSize = 24.sp,
@@ -156,7 +182,9 @@ private fun ArtistsOverview(
                             }
                     ) {
                         Column(
-                            modifier = Modifier.fillMaxSize().background(ListenBrainzTheme.colorScheme.placeHolderColor)
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(ListenBrainzTheme.colorScheme.placeHolderColor)
                                 .padding(start = 5.dp, bottom = 20.dp),
                             verticalArrangement = Arrangement.Bottom
                         ) {
@@ -168,7 +196,6 @@ private fun ArtistsOverview(
                         }
                     }
                 }
-
             }
         }
     }
@@ -176,30 +203,35 @@ private fun ArtistsOverview(
 
 @Composable
 private fun AlbumsOverview(
+    modifier: Modifier = Modifier,
     albums: List<Album>,
     goToAlbumScreen: () -> Unit
-){
-   Column(modifier = Modifier.background(
-        brush = ListenBrainzTheme.colorScheme.gradientBrush
-    ).padding(top = 15.dp, bottom = 15.dp)){
-        Text("Albums" , style = TextStyle(
-            fontSize = 24.sp,
-            fontWeight = FontWeight.Bold,
-            color = ListenBrainzTheme.colorScheme.lbSignature
-        ) , modifier = Modifier.padding(start = 17.dp))
+) {
+    Column(
+        modifier = modifier
+            .background(brush = ListenBrainzTheme.colorScheme.gradientBrush)
+            .padding(top = 15.dp, bottom = 15.dp)
+    ) {
+        Text(
+            "Albums", style = TextStyle(
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold,
+                color = ListenBrainzTheme.colorScheme.lbSignature
+            ), modifier = Modifier.padding(start = 17.dp)
+        )
         LazyRow(
             modifier = Modifier
-                .height(250.dp)){
-            items(items = albums) {
-                    album ->
-                if(album.title != ""){
-                    BrainzPlayerActivityCards(icon = album.albumArt,
+                .height(250.dp)
+        ) {
+            items(items = albums) { album ->
+                if (album.title != "") {
+                    BrainzPlayerActivityCards(
+                        icon = album.albumArt,
                         errorIcon = R.drawable.ic_album,
                         title = album.artist,
                         subtitle = album.title,
                     )
-                }
-                else{
+                } else {
                     Box(
                         modifier = Modifier
                             .padding(10.dp)
@@ -208,13 +240,22 @@ private fun AlbumsOverview(
                             .clickable {
                                 goToAlbumScreen()
                             }
-                    ){
-                        Column (modifier = Modifier.fillMaxSize().background(ListenBrainzTheme.colorScheme.placeHolderColor).padding(start = 5.dp , bottom = 20.dp) , verticalArrangement = Arrangement.Bottom) {
-                            Text(" All \n Albums" , style = TextStyle(fontSize = 20.sp) , color = ListenBrainzTheme.colorScheme.lbSignature)
+                    ) {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(ListenBrainzTheme.colorScheme.placeHolderColor)
+                                .padding(start = 5.dp, bottom = 20.dp),
+                            verticalArrangement = Arrangement.Bottom
+                        ) {
+                            Text(
+                                " All \n Albums",
+                                style = TextStyle(fontSize = 20.sp),
+                                color = ListenBrainzTheme.colorScheme.lbSignature
+                            )
                         }
                     }
                 }
-
             }
         }
     }

--- a/app/src/main/java/org/listenbrainz/android/util/SongViewPager.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/SongViewPager.kt
@@ -63,10 +63,10 @@ import coil.request.SuccessResult
 import kotlinx.coroutines.launch
 import org.listenbrainz.android.R
 import org.listenbrainz.android.model.Song
-import org.listenbrainz.android.service.NOTHING_PLAYING
 import org.listenbrainz.android.ui.components.CustomSeekBar
 import org.listenbrainz.android.ui.components.PlayPauseIcon
 import org.listenbrainz.android.ui.screens.brainzplayer.ui.components.basicMarquee
+import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.viewmodel.BrainzPlayerViewModel
 
 @OptIn(ExperimentalMaterialApi::class, ExperimentalFoundationApi::class)
@@ -99,7 +99,7 @@ fun SongViewPager(
         state = pagerState,
         modifier = modifier
             .fillMaxWidth()
-            .dynamicBackgroundFromAlbumArt(currentlyPlayingSong.albumArt)
+            .dynamicBackgroundFromAlbumArt(songList[pagerState.currentPage].albumArt)
     ) { index ->
         val song = songList[index]
 
@@ -221,7 +221,7 @@ fun SongViewPager(
 @Composable
 fun Modifier.dynamicBackgroundFromAlbumArt(
     albumArtUrl: String?,
-    defaultColor: Color = MaterialTheme.colorScheme.tertiaryContainer,
+    defaultColor: Color = ListenBrainzTheme.colorScheme.level1,
     dullnessFactor: Float = 0.6f
 ) = composed {
     val context = LocalContext.current

--- a/app/src/main/java/org/listenbrainz/android/util/SongViewPager.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/SongViewPager.kt
@@ -99,10 +99,8 @@ fun SongViewPager(
         state = pagerState,
         modifier = modifier
             .fillMaxWidth()
-            .dynamicBackgroundFromAlbumArt(songList[pagerState.currentPage].albumArt)
-    ) { index ->
-        val song = songList[index]
-
+            .dynamicBackgroundFromAlbumArt(currentlyPlayingSong.albumArt)
+    ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -146,7 +144,7 @@ fun SongViewPager(
                                 .matchParentSize()
                                 .clip(shape = RoundedCornerShape(8.dp))
                                 .graphicsLayer { clip = true },
-                            model = song.albumArt,
+                            model = currentlyPlayingSong.albumArt,
                             contentDescription = "",
                             error = painterResource(
                                 id = R.drawable.ic_erroralbumart
@@ -199,10 +197,10 @@ fun SongViewPager(
                         }
                         Text(
                             text = when {
-                                song.artist == "null" && song.title == "null"-> ""
-                                song.artist == "null" -> song.title
-                                song.title == "null" -> song.artist
-                                else -> song.artist + "  -  " + song.title
+                                currentlyPlayingSong.artist == "null" && currentlyPlayingSong.title == "null"-> ""
+                                currentlyPlayingSong.artist == "null" -> currentlyPlayingSong.title
+                                currentlyPlayingSong.title == "null" -> currentlyPlayingSong.artist
+                                else -> currentlyPlayingSong.artist + "  -  " + currentlyPlayingSong.title
                             },
                             fontSize = 13.sp,
                             fontWeight = FontWeight.Bold,

--- a/app/src/main/java/org/listenbrainz/android/util/SongViewPager.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/SongViewPager.kt
@@ -214,7 +214,6 @@ fun SongViewPager(
                 }
             }
         }
-        //  TODO("Fix View Pager changing pages")
     }
 }
 

--- a/app/src/main/java/org/listenbrainz/android/util/SongViewPager.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/SongViewPager.kt
@@ -48,8 +48,8 @@ import coil.compose.AsyncImage
 import kotlinx.coroutines.launch
 import org.listenbrainz.android.R
 import org.listenbrainz.android.model.Song
+import org.listenbrainz.android.ui.components.CustomSeekBar
 import org.listenbrainz.android.ui.components.PlayPauseIcon
-import org.listenbrainz.android.ui.components.SeekBar
 import org.listenbrainz.android.ui.screens.brainzplayer.ui.components.basicMarquee
 import org.listenbrainz.android.viewmodel.BrainzPlayerViewModel
 
@@ -64,7 +64,7 @@ fun SongViewPager(
 ) {
     val coroutineScope = rememberCoroutineScope()
     val pagerState: PagerState = rememberPagerState { songList.size }
-    
+
     HorizontalPager(state = pagerState, modifier = modifier
         .fillMaxWidth()
         .background(MaterialTheme.colorScheme.tertiaryContainer)
@@ -83,14 +83,16 @@ fun SongViewPager(
         ) {
             Box {
                 val progress by viewModel.progress.collectAsState()
-                SeekBar(
+                CustomSeekBar(
                     modifier = Modifier
                         .height(10.dp)
                         .fillMaxWidth()
-                        .padding(top = 12.dp, start = 5.dp, end = 5.dp),
+                        .padding(start = 14.dp, end = 14.dp),
                     progress = progress,
-                    onValueChange = viewModel::onSeek,
-                    onValueChanged = viewModel::onSeeked
+                    onValueChange = { newProgress ->
+                        viewModel.onSeek(newProgress)
+                        viewModel.onSeeked()
+                    }
                 )
             }
             Spacer(modifier = Modifier.height(14.dp))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,6 +48,7 @@ loggerAndroid = "1.0.0"
 compileSdk = "35"
 targetSdk = "35"
 minSdk = "22"
+paletteKtx = "1.0.0"
 
 [libraries]
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
@@ -141,6 +142,7 @@ androidx-test-espresso-intents = { module = "androidx.test.espresso:espresso-int
 vico-compose = { module = "com.patrykandpatrick.vico:compose", version.ref = "vicoCompose" }
 compose-ratingbar = { module = "com.github.a914-gowtham:compose-ratingbar", version.ref = "composeRatingbar" }
 logger-android = { module = "com.github.akshaaatt:Logger-Android", version.ref = "loggerAndroid" }
+androidx-palette-ktx = { group = "androidx.palette", name = "palette-ktx", version.ref = "paletteKtx" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }


### PR DESCRIPTION
This pull request introduces the following changes to enhance the mini music player:

- **Persistent Mini Player:** The mini music player remains visible even when the song is paused.
- **Dynamic Background:** Background color now adapts to the poster using the Palette library.
- **Custom Seekbar:** Implemented a custom seekbar for better user experience.
- **Dependency Update:** Added the Palette library for dynamic color extraction.

**Screenshots-**
<p align="center">
  <img src="https://github.com/user-attachments/assets/a3d8d9da-859a-412e-afa0-30bd6dc40857" alt="Screenshot 1" width="45%">
  <img src="https://github.com/user-attachments/assets/f5961a22-e196-49c7-afe5-c07ff775d48f" alt="Screenshot 2" width="45%">
</p>

**Issue Link:** [MOBILE-209](https://tickets.metabrainz.org/browse/MOBILE-209)

Let me know if any changes are required :)