### PR TITLE
Fix: Back Press in Player Screen Does Not Close the Player

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
@@ -1,6 +1,7 @@
 package org.listenbrainz.android.ui.screens.brainzplayer
 
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -144,7 +145,8 @@ fun BrainzPlayerBackDropScreen(
             PlayerScreen(
                 currentlyPlayingSong = currentlyPlayingSong,
                 isShuffled = isShuffled,
-                repeatMode = repeatMode
+                repeatMode = repeatMode,
+                backdropScaffoldState = backdropScaffoldState
             )
             val songList = brainzPlayerViewModel.mediaItem.collectAsState().value.data ?: listOf()
             SongViewPager(
@@ -165,7 +167,8 @@ fun PlayerScreen(
     brainzPlayerViewModel: BrainzPlayerViewModel = viewModel(),
     currentlyPlayingSong: Song,
     isShuffled: Boolean,
-    repeatMode: RepeatMode
+    repeatMode: RepeatMode,
+    backdropScaffoldState: BackdropScaffoldState,
 ) {
     val coroutineScope = rememberCoroutineScope()
     val playlistViewModel = hiltViewModel<PlaylistViewModel>()
@@ -181,6 +184,14 @@ fun PlayerScreen(
         }
     } else {
         println("Playlist is empty")
+    }
+
+    if(backdropScaffoldState.isConcealed){
+        BackHandler {
+            coroutineScope.launch {
+                backdropScaffoldState.reveal()
+            }
+        }
     }
     LazyColumn {
         item {


### PR DESCRIPTION
This pull request includes changes to the `BrainzPlayerBackDropScreen` in the ListenBrainz Android app to enhance the user interface and improve functionality. The most important changes include the addition of a back button handler and passing the `backdropScaffoldState` to the `PlayerScreen` function.

Enhancements to user interface and functionality:

* [`fun BrainzPlayerBackDropScreen(`](diffhunk://#diff-4feab51026955f2e97a718bc2b191c4e350da713aaadff15183eb966c290086fL147-R149): Modified to pass `backdropScaffoldState` to `PlayerScreen`.
* [`fun PlayerScreen(`](diffhunk://#diff-4feab51026955f2e97a718bc2b191c4e350da713aaadff15183eb966c290086fL168-R171): Added `backdropScaffoldState` parameter to manage the state of the backdrop.
* [`fun PlayerScreen(`](diffhunk://#diff-4feab51026955f2e97a718bc2b191c4e350da713aaadff15183eb966c290086fR188-R195): Implemented `BackHandler` to hide the player when back press happens.

Issue

https://github.com/user-attachments/assets/2a163658-ad5c-44af-a3be-7b60e470d80f


Fixed 

https://github.com/user-attachments/assets/1b18b8b3-7d87-44db-aa70-8cf67cc383c9


Issue on track board : [MOBILE-211
](https://tickets.metabrainz.org/browse/MOBILE-211)