### PR TITLE
Fix: Delete song from BrainzPlayer playlist

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
@@ -421,17 +421,17 @@ fun PlayerScreen(
                 Spacer(modifier = Modifier.weight(1f))
                 Button(
                     onClick = {
-                        checkedSongs.forEach { song ->
-                            brainzPlayerViewModel.appPreferences.currentPlayable?.songs?.toMutableList()
-                                ?.remove(song)
+                        val currentPlayable = brainzPlayerViewModel.appPreferences.currentPlayable
+                        val updatedSongs = currentPlayable?.songs?.toMutableList()?.apply {
+                            removeAll(checkedSongs)
                         }
-                        brainzPlayerViewModel.appPreferences.currentPlayable?.songs?.let {
+                        updatedSongs?.let {
                             brainzPlayerViewModel.changePlayable(
                                 it,
                                 PlayableType.ALL_SONGS,
-                                brainzPlayerViewModel.appPreferences.currentPlayable?.id ?: 0,
-                                brainzPlayerViewModel.appPreferences.currentPlayable?.songs?.indexOfFirst { it.mediaID == currentlyPlayingSong.mediaID }
-                                    ?: 0, brainzPlayerViewModel.songCurrentPosition.value
+                                currentPlayable.id,
+                                it.indexOfFirst { song -> song.mediaID == currentlyPlayingSong.mediaID }.coerceAtLeast(0),
+                                brainzPlayerViewModel.songCurrentPosition.value
                             )
                         }
                         brainzPlayerViewModel.queueChanged(


### PR DESCRIPTION
This PR resolves a bug where songs were not being deleted from the playlist in the BrainzPlayer screen. The following changes were made.

- Updated the logic in `BrainzPlayerBackDropScreen.kt` to properly remove the selected songs (checkedSongs) from the playlist.
- Ensured that the `currentPlayable`'s song list is mutable and modified correctly during the deletion process.

These updates ensure a smoother user experience when managing playlist in the BrainzPlayer feature.

**Before:**

https://github.com/user-attachments/assets/fe542c04-80c4-4e1d-a483-fa6fcb7af186



**Fixed:**


https://github.com/user-attachments/assets/bbb86c7d-c833-4b15-9f59-317ea720c893

Let me know if there are any changes needed!
