### PR TITLE
Moved card Link logic to viewModel

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/ui/screens/album/AlbumScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/album/AlbumScreen.kt
@@ -52,6 +52,7 @@ import org.listenbrainz.android.ui.screens.profile.listens.LoadMoreButton
 import org.listenbrainz.android.ui.screens.profile.stats.ArtistCard
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.ui.theme.new_app_bg_light
+import org.listenbrainz.android.util.LinkUtils.fetchLinks
 import org.listenbrainz.android.viewmodel.AlbumViewModel
 import org.listenbrainz.android.viewmodel.FeedViewModel
 import org.listenbrainz.android.viewmodel.SocialViewModel
@@ -124,8 +125,7 @@ private fun AlbumScreen(
                         false -> null
                     }
                     Links(
-                        artistMbid = artistMbid,
-                        links = links
+                        fetchLinks(artistMbid, links)
                     )
                 }
                 item {

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/album/AlbumScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/album/AlbumScreen.kt
@@ -1,8 +1,6 @@
 package org.listenbrainz.android.ui.screens.album
 
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
@@ -52,7 +50,7 @@ import org.listenbrainz.android.ui.screens.profile.listens.LoadMoreButton
 import org.listenbrainz.android.ui.screens.profile.stats.ArtistCard
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.ui.theme.new_app_bg_light
-import org.listenbrainz.android.util.LinkUtils.fetchLinks
+import org.listenbrainz.android.util.LinkUtils.parseLinks
 import org.listenbrainz.android.viewmodel.AlbumViewModel
 import org.listenbrainz.android.viewmodel.FeedViewModel
 import org.listenbrainz.android.viewmodel.SocialViewModel
@@ -125,7 +123,7 @@ private fun AlbumScreen(
                         false -> null
                     }
                     Links(
-                        fetchLinks(artistMbid, links)
+                        parseLinks(artistMbid, links)
                     )
                 }
                 item {

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/artist/ArtistScreen.kt
@@ -5,11 +5,6 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.Toast
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.AnimationConstants.DefaultDurationMillis
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -18,18 +13,14 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredWidthIn
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
@@ -68,7 +59,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -79,7 +69,6 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.gowtham.ratingbar.RatingBar
 import com.gowtham.ratingbar.RatingBarStyle
-import com.patrykandpatrick.vico.compose.cartesian.fullWidth
 import org.listenbrainz.android.R
 import org.listenbrainz.android.model.Listen
 import org.listenbrainz.android.model.MbidMapping
@@ -111,7 +100,6 @@ import org.listenbrainz.android.ui.theme.app_bg_mid
 import org.listenbrainz.android.ui.theme.lb_purple
 import org.listenbrainz.android.ui.theme.lb_purple_night
 import org.listenbrainz.android.ui.theme.new_app_bg_light
-import org.listenbrainz.android.util.Constants.MB_BASE_URL
 import org.listenbrainz.android.util.Utils
 import org.listenbrainz.android.util.Utils.measureSize
 import org.listenbrainz.android.util.Utils.showToast
@@ -183,7 +171,7 @@ private fun ArtistScreen(
                     )
                 }
                 item {
-                    Links(artistMbid = artistMbid, links = uiState.links)
+                    Links(uiState.linksMap)
                 }
                 item {
                     PopularTracks(uiState = uiState, goToArtistPage = goToArtistPage)
@@ -499,77 +487,12 @@ private fun BioTag(tag: String, count: Int) {
     }
 }
 
-class LinkCardData(val iconResId: ImageVector, val label: String, val url: String) {}
+class LinkCardData(val iconResId: Int, val label: String, val url: String) {}
 
 @Composable
 fun Links(
-    artistMbid: String?,
-    links: Rels? = null,
+    linksMap: Map<ArtistLinksEnum, List<LinkCardData>>
 ) {
-    //TODO: Move this logic to vm and get map to ui state
-    val allLinkCards: MutableList<LinkCardData> = mutableListOf()
-    val mainLinkCards: MutableList<LinkCardData> = mutableListOf()
-    val streamingLinkCards: MutableList<LinkCardData> = mutableListOf()
-    val socialMediaLinkCards: MutableList<LinkCardData> = mutableListOf()
-    val lyricsLinkCards: MutableList<LinkCardData> = mutableListOf()
-    if (links?.wikidata != null) {
-        val wikidata = LinkCardData(
-            ImageVector.vectorResource(id = R.drawable.wiki_data),
-            "Wikidata",
-            links.wikidata
-        )
-        allLinkCards.add(wikidata)
-        mainLinkCards.add(wikidata)
-    }
-    if (links?.lyrics != null) {
-        val lyrics = LinkCardData(Icons.Default.SettingsVoice, "Lyrics", links.lyrics)
-        allLinkCards.add(lyrics)
-        lyricsLinkCards.add(lyrics)
-    }
-    if (links?.officialHomePage != null) {
-        val homePage = LinkCardData(
-            ImageVector.vectorResource(id = R.drawable.home_icon),
-            "Homepage",
-            links.officialHomePage
-        )
-        allLinkCards.add(homePage)
-        mainLinkCards.add(homePage)
-    }
-    if (links?.purchaseForDownload != null) {
-        val purchase = LinkCardData(
-            ImageVector.vectorResource(id = R.drawable.mail_order),
-            "Purchase for Download",
-            links.purchaseForDownload
-        )
-        allLinkCards.add(purchase)
-        streamingLinkCards.add(purchase)
-    }
-    if (links?.purchaseForMailOrder != null) {
-        val mailOrder = LinkCardData(
-            ImageVector.vectorResource(id = R.drawable.mail_order),
-            "Purchase for mail order",
-            links.purchaseForMailOrder
-        )
-        allLinkCards.add(mailOrder)
-        streamingLinkCards.add(mailOrder)
-    }
-    if (artistMbid != null) {
-        mainLinkCards.add(
-            LinkCardData(
-                ImageVector.vectorResource(id = R.drawable.musicbrainz_logo),
-                "Edit",
-                MB_BASE_URL + "artist/${artistMbid}"
-            )
-        )
-    }
-
-    val linksMap: Map<ArtistLinksEnum, List<LinkCardData>> = mapOf(
-        ArtistLinksEnum.ALL to allLinkCards,
-        ArtistLinksEnum.MAIN to mainLinkCards,
-        ArtistLinksEnum.LYRICS to lyricsLinkCards,
-        ArtistLinksEnum.STREAMING to streamingLinkCards,
-        ArtistLinksEnum.SOCIAL_MEDIA to socialMediaLinkCards
-    )
     val linkOptionSelectionState: MutableState<ArtistLinksEnum> = remember {
         mutableStateOf(ArtistLinksEnum.MAIN)
     }
@@ -653,7 +576,7 @@ fun Links(
                     ) {
                         rowItems.forEach { item ->
                             LinkCard(
-                                icon = item.iconResId,
+                                icon = ImageVector.vectorResource(item.iconResId),
                                 label = item.label,
                                 url = item.url,
                             )

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/artist/ArtistUIState.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/artist/ArtistUIState.kt
@@ -1,5 +1,6 @@
 package org.listenbrainz.android.ui.screens.artist
 
+import ArtistLinksEnum
 import org.listenbrainz.android.model.artist.CBReview
 import org.listenbrainz.android.model.artist.ArtistWikiExtract
 import org.listenbrainz.android.model.artist.Listeners
@@ -20,6 +21,7 @@ data class ArtistUIState(
     val wikiExtract: ArtistWikiExtract? = null,
     val tags: Tag? = null,
     val links: Rels? = null,
+    val linksMap: Map<ArtistLinksEnum, List<LinkCardData>> = emptyMap(),
     val popularTracks: List<PopularRecording?>? = listOf(),
     val albums: List<ReleaseGroup?>? = listOf(),
     val appearsOn: List<ReleaseGroup?>? = listOf(),

--- a/app/src/main/java/org/listenbrainz/android/util/LinksUtil.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/LinksUtil.kt
@@ -1,0 +1,77 @@
+package org.listenbrainz.android.util
+
+
+import ArtistLinksEnum
+import org.listenbrainz.android.R
+import org.listenbrainz.android.model.artist.Rels
+import org.listenbrainz.android.ui.screens.artist.LinkCardData
+import org.listenbrainz.android.util.Constants.MB_BASE_URL
+
+object LinkUtils {
+    fun fetchLinks(artistMbid: String?, links: Rels?): Map<ArtistLinksEnum, List<LinkCardData>> {
+        val allLinkCards: MutableList<LinkCardData> = mutableListOf()
+        val mainLinkCards: MutableList<LinkCardData> = mutableListOf()
+        val streamingLinkCards: MutableList<LinkCardData> = mutableListOf()
+        val socialMediaLinkCards: MutableList<LinkCardData> = mutableListOf()
+        val lyricsLinkCards: MutableList<LinkCardData> = mutableListOf()
+
+        if (links?.wikidata != null) {
+            val wikidata = LinkCardData(
+                R.drawable.wiki_data,
+                "Wikidata",
+                links.wikidata
+            )
+            allLinkCards.add(wikidata)
+            mainLinkCards.add(wikidata)
+        }
+        if (links?.lyrics != null) {
+            val lyrics = LinkCardData(R.drawable.settings_voice, "Lyrics", links.lyrics)
+            allLinkCards.add(lyrics)
+            lyricsLinkCards.add(lyrics)
+        }
+        if (links?.officialHomePage != null) {
+            val homePage = LinkCardData(
+                R.drawable.home_icon,
+                "Homepage",
+                links.officialHomePage
+            )
+            allLinkCards.add(homePage)
+            mainLinkCards.add(homePage)
+        }
+        if (links?.purchaseForDownload != null) {
+            val purchase = LinkCardData(
+                R.drawable.mail_order,
+                "Purchase for Download",
+                links.purchaseForDownload
+            )
+            allLinkCards.add(purchase)
+            streamingLinkCards.add(purchase)
+        }
+        if (links?.purchaseForMailOrder != null) {
+            val mailOrder = LinkCardData(
+                R.drawable.mail_order,
+                "Purchase for mail order",
+                links.purchaseForMailOrder
+            )
+            allLinkCards.add(mailOrder)
+            streamingLinkCards.add(mailOrder)
+        }
+        if (artistMbid != null) {
+            mainLinkCards.add(
+                LinkCardData(
+                    R.drawable.musicbrainz_logo,
+                    "Edit",
+                    MB_BASE_URL + "artist/${artistMbid}"
+                )
+            )
+        }
+
+        return mapOf(
+            ArtistLinksEnum.ALL to allLinkCards,
+            ArtistLinksEnum.MAIN to mainLinkCards,
+            ArtistLinksEnum.LYRICS to lyricsLinkCards,
+            ArtistLinksEnum.STREAMING to streamingLinkCards,
+            ArtistLinksEnum.SOCIAL_MEDIA to socialMediaLinkCards
+        )
+    }
+}

--- a/app/src/main/java/org/listenbrainz/android/util/LinksUtil.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/LinksUtil.kt
@@ -8,7 +8,7 @@ import org.listenbrainz.android.ui.screens.artist.LinkCardData
 import org.listenbrainz.android.util.Constants.MB_BASE_URL
 
 object LinkUtils {
-    fun fetchLinks(artistMbid: String?, links: Rels?): Map<ArtistLinksEnum, List<LinkCardData>> {
+    fun parseLinks(artistMbid: String?, links: Rels?): Map<ArtistLinksEnum, List<LinkCardData>> {
         val allLinkCards: MutableList<LinkCardData> = mutableListOf()
         val mainLinkCards: MutableList<LinkCardData> = mutableListOf()
         val streamingLinkCards: MutableList<LinkCardData> = mutableListOf()

--- a/app/src/main/java/org/listenbrainz/android/viewmodel/ArtistViewModel.kt
+++ b/app/src/main/java/org/listenbrainz/android/viewmodel/ArtistViewModel.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import org.listenbrainz.android.repository.artist.ArtistRepository
 import org.listenbrainz.android.ui.screens.artist.ArtistUIState
-import org.listenbrainz.android.util.LinkUtils.fetchLinks
+import org.listenbrainz.android.util.LinkUtils.parseLinks
 import javax.inject.Inject
 
 @HiltViewModel
@@ -25,7 +25,7 @@ class ArtistViewModel @Inject constructor(
         val appearsOn = artistData?.releaseGroups?.filter { releaseGroup ->
             releaseGroup?.artists?.get(0)?.artistMbid != artistMbid
         }
-        val linksMap = fetchLinks(artistMbid, artistData?.artist?.rels)
+        val linksMap = parseLinks(artistMbid, artistData?.artist?.rels)
         val artistUiState = ArtistUIState(
             isLoading = false,
             name = artistData?.artist?.name,

--- a/app/src/main/java/org/listenbrainz/android/viewmodel/ArtistViewModel.kt
+++ b/app/src/main/java/org/listenbrainz/android/viewmodel/ArtistViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import org.listenbrainz.android.repository.artist.ArtistRepository
 import org.listenbrainz.android.ui.screens.artist.ArtistUIState
+import org.listenbrainz.android.util.LinkUtils.fetchLinks
 import javax.inject.Inject
 
 @HiltViewModel
@@ -24,7 +25,7 @@ class ArtistViewModel @Inject constructor(
         val appearsOn = artistData?.releaseGroups?.filter { releaseGroup ->
             releaseGroup?.artists?.get(0)?.artistMbid != artistMbid
         }
-
+        val linksMap = fetchLinks(artistMbid, artistData?.artist?.rels)
         val artistUiState = ArtistUIState(
             isLoading = false,
             name = artistData?.artist?.name,
@@ -36,6 +37,7 @@ class ArtistViewModel @Inject constructor(
             wikiExtract = artistWikiExtract,
             tags = artistData?.artist?.tag,
             links = artistData?.artist?.rels,
+            linksMap = linksMap,
             popularTracks = artistData?.popularRecordings,
             albums = artistData?.releaseGroups,
             appearsOn = appearsOn,

--- a/app/src/main/res/drawable/settings_voice.xml
+++ b/app/src/main/res/drawable/settings_voice.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:alpha="0.84" android:height="24dp" android:tint="#FFFFFF" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M7,24h2v-2L7,22v2zM12,13c1.66,0 2.99,-1.34 2.99,-3L15,4c0,-1.66 -1.34,-3 -3,-3S9,2.34 9,4v6c0,1.66 1.34,3 3,3zM11,24h2v-2h-2v2zM15,24h2v-2h-2v2zM19,10h-1.7c0,3 -2.54,5.1 -5.3,5.1S6.7,13 6.7,10L5,10c0,3.41 2.72,6.23 6,6.72L11,20h2v-3.28c3.28,-0.49 6,-3.31 6,-6.72z"/>
+    
+</vector>


### PR DESCRIPTION
In this PR, I completed the TODO mentioned in the Artist Screen to move `linksMap` logic to `viewModel`.

`//TODO: Move this logic to vm and get map to ui state`

### The changes made are:
1. The mapping logic is used in both Artist and Album Screen, so I moved it to the `util` package.
2. Used `linksMap` in UiState to get the links.
3. `ImageVector.vectorResource` can be called only in compose function, so I have modifed `LinksCard` data class to contain resource id instead of ImageVector.