### PR TITLE
Feat: Dropdown songs card for AlbumsOverViewScreen & ArtistsOverviewScreen

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerScreen.kt
@@ -301,10 +301,21 @@ fun BrainzPlayerHomeScreen(
                     )
                 },
                 onAddToNewPlaylist = {
-                    artist ->  
+                    artist ->
                 },
                 onAddToExistingPlaylist = {
-                    artist ->  
+                    artist ->
+                },
+                onSongClick = {
+                    song ->
+                    brainzPlayerViewModel.changePlayable(
+                        listOf(song),
+                        PlayableType.SONG,
+                        song.mediaID,
+                        0,
+                        0L
+                    )
+                    brainzPlayerViewModel.playOrToggleSong(song, true)
                 }
             )
             3 -> AlbumsOverViewScreen(albums = albums, onPlayIconClick = {

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.ElevatedSuggestionChip
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SuggestionChipDefaults
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
@@ -134,7 +135,7 @@ fun BrainzPlayerHomeScreen(
                     shape = ListenBrainzTheme.shapes.chips,
                     elevation = SuggestionChipDefaults.elevatedSuggestionChipElevation(elevation = 4.dp),
                     label = {
-                        androidx.compose.material3.Text(
+                        Text(
                             text = when (position) {
                                 0 -> "Overview"
                                 1 -> "Recent"
@@ -318,33 +319,46 @@ fun BrainzPlayerHomeScreen(
                     brainzPlayerViewModel.playOrToggleSong(song, true)
                 }
             )
-            3 -> AlbumsOverViewScreen(albums = albums, onPlayIconClick = {
-                album ->
-                val albumSongs = albumSongsMap[album]!!
-                brainzPlayerViewModel.changePlayable(
-                    albumSongs.sortedBy { it.trackNumber },
-                    PlayableType.ALBUM,
-                    album.albumId,
-                    albumSongs
-                        .sortedBy { it.trackNumber }
-                        .indexOf (albumSongs[0]),
-                    0L
-                )
-                brainzPlayerViewModel.playOrToggleSong(albumSongs[0],true)
-
-
-            })
-            4 -> SongsOverviewScreen(songs = songs, onPlayIconClick = {
-                    song , newPlayables ->
-                brainzPlayerViewModel.changePlayable(
-                    newPlayables,
-                    PlayableType.ALL_SONGS,
-                    song.mediaID,
-                    newPlayables.sortedBy { it.discNumber }.indexOf(song),
-                    0L
-                )
-                brainzPlayerViewModel.playOrToggleSong(song,true)
-            })
+            3 -> AlbumsOverViewScreen(
+                albums = albums,
+                onPlayIconClick = { album ->
+                    val albumSongs = albumSongsMap[album]!!
+                    brainzPlayerViewModel.changePlayable(
+                        albumSongs.sortedBy { it.trackNumber },
+                        PlayableType.ALBUM,
+                        album.albumId,
+                        albumSongs
+                            .sortedBy { it.trackNumber }
+                            .indexOf(albumSongs[0]),
+                        0L
+                    )
+                    brainzPlayerViewModel.playOrToggleSong(albumSongs[0], true)
+                },
+                onSongClick = { song ->
+                    brainzPlayerViewModel.changePlayable(
+                        listOf(song),
+                        PlayableType.SONG,
+                        song.mediaID,
+                        0,
+                        0L
+                    )
+                    brainzPlayerViewModel.playOrToggleSong(song, true)
+                },
+                albumSongsMap = albumSongsMap
+            )
+            4 -> SongsOverviewScreen(
+                songs = songs,
+                onPlayIconClick = { song , newPlayables ->
+                    brainzPlayerViewModel.changePlayable(
+                        newPlayables,
+                        PlayableType.ALL_SONGS,
+                        song.mediaID,
+                        newPlayables.sortedBy { it.discNumber }.indexOf(song),
+                        0L
+                    )
+                   brainzPlayerViewModel.playOrToggleSong(song,true)
+                }
+            )
         }
     }
 }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/AlbumsOverviewScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/AlbumsOverviewScreen.kt
@@ -1,5 +1,10 @@
 package org.listenbrainz.android.ui.screens.brainzplayer.overview
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -88,7 +93,11 @@ fun AlbumsOverViewScreen(
                                 onPlayIconClick(album)
                             }
                         )
-                        if (expandedAlbum == album) {
+                        AnimatedVisibility(
+                            visible = expandedAlbum == album,
+                            enter = fadeIn() + expandVertically(),
+                            exit = fadeOut() + shrinkVertically()
+                        ) {
                             val albumSongs = albumSongsMap[album]!!.sortedBy { it.trackNumber }
                             Row(modifier = Modifier.fillMaxWidth()) {
                                 Spacer(modifier = Modifier.weight(0.5f))

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/AlbumsOverviewScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/AlbumsOverviewScreen.kt
@@ -1,14 +1,21 @@
 package org.listenbrainz.android.ui.screens.brainzplayer.overview
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
@@ -17,15 +24,22 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.listenbrainz.android.R
 import org.listenbrainz.android.model.Album
+import org.listenbrainz.android.model.Song
+import org.listenbrainz.android.model.feed.FeedListenArtist
 import org.listenbrainz.android.ui.components.BrainzPlayerListenCard
+import org.listenbrainz.android.ui.components.ListenCardSmall
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 
 @Composable
 fun AlbumsOverViewScreen(
     albums : List<Album>,
-    onPlayIconClick: (Album) -> Unit
+    albumSongsMap: Map<Album, List<Song>>,
+    onPlayIconClick: (Album) -> Unit,
+    onSongClick: (Song) -> Unit
 ) {
     val albumsStarting: MutableMap<Char, MutableList<Album>> = mutableMapOf()
+    var expandedAlbum by remember { mutableStateOf<Album?>(null) }
+
     for (i in 0..25) {
         albumsStarting['A' + i] = mutableListOf()
     }
@@ -54,14 +68,52 @@ fun AlbumsOverViewScreen(
                     )
                     for (j in 1..albumsStarting[startingLetter]!!.size) {
                         val coverArt = albumsStarting[startingLetter]!![j - 1].albumArt
-                        BrainzPlayerListenCard(title = albumsStarting[startingLetter]!![j - 1].title, subTitle = albumsStarting[startingLetter]!![j - 1].artist, coverArtUrl = coverArt, errorAlbumArt = R.drawable.ic_erroralbumart, modifier = Modifier.padding(
-                            start = 10.dp,
-                            end = 10.dp,
-                            top = 3.dp,
-                            bottom = 3.dp
-                        ), onPlayIconClick = {
-                            onPlayIconClick(albumsStarting[startingLetter]!![j-1])
-                        })
+                        val album = albumsStarting[startingLetter]!![j - 1]
+                        BrainzPlayerListenCard(
+                            title = album.title,
+                            subTitle = album.artist,
+                            coverArtUrl = coverArt,
+                            errorAlbumArt = R.drawable.ic_erroralbumart,
+                            modifier = Modifier
+                                .padding(
+                                    start = 10.dp,
+                                    end = 10.dp,
+                                    top = 3.dp,
+                                    bottom = 3.dp
+                                )
+                                .clickable {
+                                expandedAlbum = if (expandedAlbum == album) null else album
+                            },
+                            onPlayIconClick = {
+                                onPlayIconClick(album)
+                            }
+                        )
+                        if (expandedAlbum == album) {
+                            val albumSongs = albumSongsMap[album]!!.sortedBy { it.trackNumber }
+                            Row(modifier = Modifier.fillMaxWidth()) {
+                                Spacer(modifier = Modifier.weight(0.5f))
+                                Column(
+                                    modifier = Modifier
+                                        .weight(3.5f)
+                                        .padding(horizontal = ListenBrainzTheme.paddings.horizontal)
+                                ) {
+                                    albumSongs.forEach { song ->
+                                        ListenCardSmall(
+                                            modifier = Modifier
+                                                .padding(vertical = 6.dp)
+                                                .fillMaxWidth(),
+                                            trackName = song.title,
+                                            artists = listOf(FeedListenArtist(song.artist, null, "")),
+                                            coverArtUrl = song.albumArt,
+                                            errorAlbumArt = R.drawable.ic_erroralbumart,
+                                            goToArtistPage = {}
+                                        ) {
+                                            onSongClick(song)
+                                        }
+                                    }
+                                }
+                            }
+                        }
                         Spacer(modifier = Modifier.height(10.dp))
                     }
                 }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/ArtistsOverviewScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/ArtistsOverviewScreen.kt
@@ -1,5 +1,10 @@
 package org.listenbrainz.android.ui.screens.brainzplayer.overview
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -111,7 +116,11 @@ fun ArtistsOverviewScreen(
                                 onDropdownIconClick = { dropdownState = Pair(i, j - 1) },
                                 dropDownState = dropdownState == Pair(i, j - 1)
                             )
-                            if (expandedArtist == artist) {
+                            AnimatedVisibility(
+                                visible = expandedArtist == artist,
+                                enter = fadeIn() + expandVertically(),
+                                exit = fadeOut() + shrinkVertically()
+                            ) {
                                 Row(modifier = Modifier.fillMaxWidth()) {
                                     Spacer(modifier = Modifier.weight(0.5f))
                                     Column(


### PR DESCRIPTION
This PR introduces a dropdown feature in the `ArtistsOverviewScreen` and `AlbumsOverViewScreen` to enhance the user experience by allowing users to view songs in each artist and album.

**Changes:**

- Added a dropdown to display the list of songs for each artist and album.
- Utilized `AnimatedVisibility` to animate the dropdown with fade-in and fade-out effects, as well as vertical expansion and shrinkage.
- Used `ListenCardSmall` to display the corresponding songs within the dropdown.

Result:

https://github.com/user-attachments/assets/6712f3b2-0046-40f8-87e3-5a7d6c7ad13f

