### PR TITLE
Feat: fixed the player screen and mini player pager

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/service/BrainzPlayerEventListener.kt
+++ b/app/src/main/java/org/listenbrainz/android/service/BrainzPlayerEventListener.kt
@@ -4,6 +4,8 @@ import android.app.Service.STOP_FOREGROUND_DETACH
 import android.os.Build
 import com.google.android.exoplayer2.PlaybackException
 import com.google.android.exoplayer2.Player
+import com.google.android.exoplayer2.Player.DISCONTINUITY_REASON_AUTO_TRANSITION
+import com.google.android.exoplayer2.Player.DISCONTINUITY_REASON_SEEK_ADJUSTMENT
 import org.listenbrainz.android.util.Log
 
 class BrainzPlayerEventListener(
@@ -26,10 +28,15 @@ class BrainzPlayerEventListener(
         reason: Int
     ) {
         super.onPositionDiscontinuity(oldPosition, newPosition, reason)
-        //updating current playing index when song auto transitions
-        if (reason == Player.DISCONTINUITY_REASON_AUTO_TRANSITION) {
-            brainzPlayerService.appPreferences.currentPlayable =
-                brainzPlayerService.appPreferences.currentPlayable?.copy(currentSongIndex = newPosition.mediaItemIndex)
+
+        //updating current playing index when song auto transitions or song change from notification
+        when (reason) {
+            DISCONTINUITY_REASON_SEEK_ADJUSTMENT, DISCONTINUITY_REASON_AUTO_TRANSITION -> {
+                brainzPlayerService.appPreferences.currentPlayable =
+                    brainzPlayerService.appPreferences.currentPlayable?.copy(currentSongIndex = newPosition.mediaItemIndex)
+            }
+
+            else -> {}
         }
     }
 

--- a/app/src/main/java/org/listenbrainz/android/service/BrainzPlayerEventListener.kt
+++ b/app/src/main/java/org/listenbrainz/android/service/BrainzPlayerEventListener.kt
@@ -7,17 +7,30 @@ import com.google.android.exoplayer2.Player
 import org.listenbrainz.android.util.Log
 
 class BrainzPlayerEventListener(
-    private val brainzPlayerService : BrainzPlayerService
+    private val brainzPlayerService: BrainzPlayerService
 ) : Player.Listener {
     override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
         if (reason == Player.STATE_IDLE && !playWhenReady) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                 brainzPlayerService.stopForeground(STOP_FOREGROUND_DETACH)
-            }else {
+            } else {
                 brainzPlayerService.stopForeground(false)
             }
         }
         super.onPlayWhenReadyChanged(playWhenReady, reason)
+    }
+
+    override fun onPositionDiscontinuity(
+        oldPosition: Player.PositionInfo,
+        newPosition: Player.PositionInfo,
+        reason: Int
+    ) {
+        super.onPositionDiscontinuity(oldPosition, newPosition, reason)
+        //updating current playing index when song auto transitions
+        if (reason == Player.DISCONTINUITY_REASON_AUTO_TRANSITION) {
+            brainzPlayerService.appPreferences.currentPlayable =
+                brainzPlayerService.appPreferences.currentPlayable?.copy(currentSongIndex = newPosition.mediaItemIndex)
+        }
     }
 
     override fun onPlayerError(error: PlaybackException) {

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
@@ -215,11 +215,8 @@ fun PlayerScreen(
         )
     }
     //For handling song change by pager
-    LaunchedEffect(pagerState) {
-        // Collect from the a snapshotFlow reading the currentPage
-        snapshotFlow { pagerState.currentPage }.collect { page ->
-            brainzPlayerViewModel.handleSongChangeFromPager(page)
-        }
+    LaunchedEffect(pagerState.currentPage) {
+        brainzPlayerViewModel.handleSongChangeFromPager(pagerState.currentPage)
     }
     if (backdropScaffoldState.isConcealed) {
         BackHandler {

--- a/app/src/main/java/org/listenbrainz/android/util/SongViewPager.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/SongViewPager.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
@@ -96,6 +97,18 @@ fun SongViewPager(
             } catch (e: Exception) {
                 Log.e(e)
             }
+        }
+    }
+
+    LaunchedEffect(viewModel.appPreferences.currentPlayable?.currentSongIndex) {
+        pagerState.scrollToPage(
+            viewModel.appPreferences.currentPlayable?.currentSongIndex ?: 0
+        )
+    }
+    LaunchedEffect(pagerState) {
+        // Collect from the a snapshotFlow reading the currentPage
+        snapshotFlow { pagerState.currentPage }.collect { page ->
+            viewModel.handleSongChangeFromPager(page)
         }
     }
 

--- a/app/src/main/java/org/listenbrainz/android/util/SongViewPager.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/SongViewPager.kt
@@ -105,11 +105,8 @@ fun SongViewPager(
             viewModel.appPreferences.currentPlayable?.currentSongIndex ?: 0
         )
     }
-    LaunchedEffect(pagerState) {
-        // Collect from the a snapshotFlow reading the currentPage
-        snapshotFlow { pagerState.currentPage }.collect { page ->
-            viewModel.handleSongChangeFromPager(page)
-        }
+    LaunchedEffect(pagerState.currentPage) {
+        viewModel.handleSongChangeFromPager(pagerState.currentPage)
     }
 
     HorizontalPager(
@@ -214,7 +211,7 @@ fun SongViewPager(
                         }
                         Text(
                             text = when {
-                                currentlyPlayingSong.artist == "null" && currentlyPlayingSong.title == "null"-> ""
+                                currentlyPlayingSong.artist == "null" && currentlyPlayingSong.title == "null" -> ""
                                 currentlyPlayingSong.artist == "null" -> currentlyPlayingSong.title
                                 currentlyPlayingSong.title == "null" -> currentlyPlayingSong.artist
                                 else -> currentlyPlayingSong.artist + "  -  " + currentlyPlayingSong.title

--- a/app/src/main/java/org/listenbrainz/android/viewmodel/BrainzPlayerViewModel.kt
+++ b/app/src/main/java/org/listenbrainz/android/viewmodel/BrainzPlayerViewModel.kt
@@ -1,7 +1,6 @@
 package org.listenbrainz.android.viewmodel
 
 import android.content.Context
-import android.graphics.Color.parseColor
 import android.graphics.drawable.BitmapDrawable
 import android.support.v4.media.MediaBrowserCompat
 import android.support.v4.media.session.PlaybackStateCompat.REPEAT_MODE_ALL
@@ -9,11 +8,11 @@ import android.support.v4.media.session.PlaybackStateCompat.REPEAT_MODE_NONE
 import android.support.v4.media.session.PlaybackStateCompat.REPEAT_MODE_ONE
 import android.support.v4.media.session.PlaybackStateCompat.SHUFFLE_MODE_ALL
 import android.support.v4.media.session.PlaybackStateCompat.SHUFFLE_MODE_NONE
+import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.palette.graphics.Palette
@@ -135,6 +134,16 @@ class BrainzPlayerViewModel @Inject constructor(
         }
     }
 
+    fun handleSongChangeFromPager(position:Int){
+        Log.d("PAGER", "handleSongChangeFromPager:$position , ${appPreferences.currentPlayable?.currentSongIndex} ")
+        if(position > appPreferences.currentPlayable?.currentSongIndex!!){
+            skipToNextSong()
+        }
+        else if(position < appPreferences.currentPlayable?.currentSongIndex!!){
+            skipToPreviousSong()
+        }
+    }
+
     fun skipToNextSong() {
         brainzPlayerServiceConnection.transportControls.skipToNext()
         // Updating currently playing song.
@@ -145,6 +154,7 @@ class BrainzPlayerViewModel @Inject constructor(
     }
 
     fun skipToPreviousSong() {
+        brainzPlayerServiceConnection.transportControls.seekTo(0) // Always reset to the start since the song won't change if playing time exceeds a certain threshold.
         brainzPlayerServiceConnection.transportControls.skipToPrevious()
         // Updating currently playing song.
         appPreferences.currentPlayable = appPreferences.currentPlayable


### PR DESCRIPTION
This pull request includes updates to the `BrainzPlayer` feature in the ListenBrainz Android app.

### Improvements to song transition handling:
* Added `onPositionDiscontinuity` method to update the current song index when a song auto transitions.
* Introduced `handleSongChangeFromPager` method to manage song changes from the pager.
* updated `skipToPreviousSong` to reset the song to the start.This was done since the song won't change if playing time exceeds a certain threshold.
### UI component updates:
* Replaced `mediaItem.collectAsState()` with `appPreferences.currentPlayable` for song list retrieval and added `LaunchedEffect` to handle song changes via list or buttons and pager.
* Added `Crossfade` animation for album art transitions in `AlbumArtViewPager`.

working video

https://github.com/user-attachments/assets/ca33b443-d800-4848-bef5-59ac5ed95d4d

