### PR TITLE
Updated Bottom NavigationBar with NullSafety

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/ui/navigation/BottomNavigationBar.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/navigation/BottomNavigationBar.kt
@@ -89,7 +89,7 @@ fun BottomNavigationBar(
 
                         when (item.route) {
                             AppNavigationItem.Profile.route -> {
-                                navController.navigate("profile/${username}"){
+                                navController.navigate(if (!username.isNullOrBlank()) "profile/${username}" else "profile/guest"){
                                     // Avoid building large backstack
                                     popUpTo(AppNavigationItem.Feed.route){
                                         saveState = true


### PR DESCRIPTION
This pull request is about resolving the crash caused by java.lang.IllegalArgumentException related to navigation in the app.

Issue:
The crash occurred due to the NavController trying to navigate to a destination that did not exist in the navigation graph. Specifically, the app attempted to navigate to a destination with a URI of android-app://androidx.navigation/profile/, which was not defined in the navigation graph.

Changes Made:
Introduced a condition to handle cases where the username is null or blank.
If the username is null or blank, the app now passes "guest" as the username to the profile route.

**Before**
[Before.webm](https://github.com/user-attachments/assets/04c06157-eeb5-4779-804b-27edb26f4403)


**After**
[After.webm](https://github.com/user-attachments/assets/9c159a89-4527-4558-8aa7-290cdaa125e5)


