### PR TITLE
Chore: removed dropdown functionality from the BP tabs

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/ui/components/BrainzPlayerListenCard.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/components/BrainzPlayerListenCard.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext

--- a/app/src/main/java/org/listenbrainz/android/ui/components/BrainzPlayerListenCard.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/components/BrainzPlayerListenCard.kt
@@ -1,11 +1,7 @@
 package org.listenbrainz.android.ui.components
 
 import androidx.annotation.DrawableRes
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -20,8 +16,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -56,7 +50,6 @@ fun BrainzPlayerListenCard(
     mediaId: Long? = null,
     viewModel: BrainzPlayerViewModel = hiltViewModel()
 ) {
-    val isPlaying by viewModel.isPlaying.collectAsState()
     val currentlyPlayingSong = viewModel.currentlyPlayingSong.collectAsStateWithLifecycle().value.toSong
     val titleColor = if (currentlyPlayingSong.mediaID == mediaId) {
         Color(0xFFB94FE5)
@@ -66,7 +59,8 @@ fun BrainzPlayerListenCard(
 
     Surface(
         modifier = modifier
-            .fillMaxWidth(),
+            .fillMaxWidth()
+            .clickable { onPlayIconClick() },
         shape = ListenBrainzTheme.shapes.listenCardSmall,
         shadowElevation = 4.dp,
         color = ListenBrainzTheme.colorScheme.level1
@@ -100,19 +94,9 @@ fun BrainzPlayerListenCard(
                 Box(modifier = Modifier
                     .fillMaxWidth(0.275f)
                     .align(Alignment.CenterEnd)){
-                    DropdownButton (modifier = Modifier.align(Alignment.Center), onDropdownIconClick = onDropdownIconClick)
+                    DropdownButton (modifier = Modifier.align(Alignment.CenterEnd), onDropdownIconClick = onDropdownIconClick)
                     if(dropDownState) dropDown()
-                    PlayButton(
-                        modifier = Modifier.align(Alignment.CenterEnd),
-                        isPlaying = currentlyPlayingSong.mediaID == mediaId && isPlaying,
-                        onPlayIconClick = onPlayIconClick
-                    )
                 }
-
-
-
-
-
             }
         }
     }
@@ -131,28 +115,6 @@ private fun DropdownButton(modifier: Modifier = Modifier, onDropdownIconClick: (
             tint = ListenBrainzTheme.colorScheme.hint,
             modifier = Modifier.padding(horizontal = ListenBrainzTheme.paddings.insideCard)
         )
-    }
-}
-
-@Composable
-private fun PlayButton(modifier: Modifier = Modifier, onPlayIconClick: () -> Unit, isPlaying: Boolean) {
-    IconButton(
-        modifier = modifier,
-        onClick = onPlayIconClick
-    ) {
-        AnimatedContent(
-            targetState = isPlaying,
-            transitionSpec = {
-                fadeIn(animationSpec = tween(200)) togetherWith fadeOut(animationSpec = tween(300))
-            }
-        ) { targetState ->
-            Icon(
-                painter = painterResource(id = if (targetState) R.drawable.ic_pause else R.drawable.brainz_player_play_button),
-                contentDescription = "",
-                tint = ListenBrainzTheme.colorScheme.hint,
-                modifier = Modifier.padding(horizontal = ListenBrainzTheme.paddings.insideCard)
-            )
-        }
     }
 }
 
@@ -179,5 +141,3 @@ private fun AlbumArt(
         contentDescription = "Album Cover Art"
     )
 }
-
-

--- a/app/src/main/java/org/listenbrainz/android/ui/components/BrainzPlayerListenCard.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/components/BrainzPlayerListenCard.kt
@@ -15,20 +15,26 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import org.listenbrainz.android.R
 import org.listenbrainz.android.model.feed.FeedListenArtist
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
+import org.listenbrainz.android.viewmodel.BrainzPlayerViewModel
 
 @Composable
 fun BrainzPlayerListenCard(
@@ -40,8 +46,16 @@ fun BrainzPlayerListenCard(
     onDropdownIconClick: () -> Unit = {},
     dropDown: @Composable () -> Unit = {},
     dropDownState: Boolean = false,
-    onPlayIconClick: () -> Unit
+    onPlayIconClick: () -> Unit,
+    viewModel: BrainzPlayerViewModel = hiltViewModel()
 ) {
+    val currentlyPlayingTitle by viewModel.currentlyPlayingTitle.collectAsState()
+    val titleColor = if (currentlyPlayingTitle == title) {
+        colorResource(id = R.color.bp_color_primary)
+    } else {
+        ListenBrainzTheme.colorScheme.listenText
+    }
+
     Surface(
         modifier = modifier
             .fillMaxWidth(),
@@ -72,6 +86,7 @@ fun BrainzPlayerListenCard(
                         title = title,
                         goToArtistPage = {},
                         artists = listOf(FeedListenArtist(subTitle, null, "")),
+                        titleColor = titleColor
                     )
                 }
                 Box(modifier = Modifier

--- a/app/src/main/java/org/listenbrainz/android/ui/components/BrainzPlayerListenCard.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/components/BrainzPlayerListenCard.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -50,7 +51,8 @@ fun BrainzPlayerListenCard(
 ) {
     val currentlyPlayingTitle by viewModel.currentlyPlayingTitle.collectAsState()
     val titleColor = if (currentlyPlayingTitle == title) {
-        colorResource(id = R.color.bp_color_primary)
+        //Once color is confirmed, I will add to Color.kt (Temporarily hardcoded here)
+        Color(0xFFB94FE5)
     } else {
         ListenBrainzTheme.colorScheme.listenText
     }

--- a/app/src/main/java/org/listenbrainz/android/ui/components/BrainzPlayerListenCard.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/components/BrainzPlayerListenCard.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -55,7 +54,7 @@ fun BrainzPlayerListenCard(
     viewModel: BrainzPlayerViewModel = hiltViewModel()
 ) {
     val isPlaying by viewModel.isPlaying.collectAsState()
-    val currentlyPlayingTitle by viewModel.currentlyPlayingTitle.collectAsState()
+    val currentlyPlayingTitle by viewModel.currentlyPlayingTitle.collectAsState(initial = "")
     val titleColor = if (currentlyPlayingTitle == title) {
         Color(0xFFB94FE5)
     } else {

--- a/app/src/main/java/org/listenbrainz/android/ui/components/BrainzPlayerListenCard.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/components/BrainzPlayerListenCard.kt
@@ -33,11 +33,13 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import org.listenbrainz.android.R
 import org.listenbrainz.android.model.feed.FeedListenArtist
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
+import org.listenbrainz.android.util.BrainzPlayerExtensions.toSong
 import org.listenbrainz.android.viewmodel.BrainzPlayerViewModel
 
 @Composable
@@ -51,11 +53,12 @@ fun BrainzPlayerListenCard(
     dropDown: @Composable () -> Unit = {},
     dropDownState: Boolean = false,
     onPlayIconClick: () -> Unit,
+    mediaId: Long? = null,
     viewModel: BrainzPlayerViewModel = hiltViewModel()
 ) {
     val isPlaying by viewModel.isPlaying.collectAsState()
-    val currentlyPlayingTitle by viewModel.currentlyPlayingTitle.collectAsState(initial = "")
-    val titleColor = if (currentlyPlayingTitle == title) {
+    val currentlyPlayingSong = viewModel.currentlyPlayingSong.collectAsStateWithLifecycle().value.toSong
+    val titleColor = if (currentlyPlayingSong.mediaID == mediaId) {
         Color(0xFFB94FE5)
     } else {
         ListenBrainzTheme.colorScheme.listenText
@@ -101,7 +104,7 @@ fun BrainzPlayerListenCard(
                     if(dropDownState) dropDown()
                     PlayButton(
                         modifier = Modifier.align(Alignment.CenterEnd),
-                        isPlaying = currentlyPlayingTitle == title && isPlaying,
+                        isPlaying = currentlyPlayingSong.mediaID == mediaId && isPlaying,
                         onPlayIconClick = onPlayIconClick
                     )
                 }

--- a/app/src/main/java/org/listenbrainz/android/ui/components/BrainzPlayerListenCard.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/components/BrainzPlayerListenCard.kt
@@ -12,8 +12,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.GenericShape
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -43,9 +41,6 @@ fun BrainzPlayerListenCard(
     subTitle: String,
     coverArtUrl: String?,
     @DrawableRes errorAlbumArt: Int = R.drawable.ic_coverartarchive_logo_no_text,
-    onDropdownIconClick: () -> Unit = {},
-    dropDown: @Composable () -> Unit = {},
-    dropDownState: Boolean = false,
     onPlayIconClick: () -> Unit,
     mediaId: Long? = null,
     viewModel: BrainzPlayerViewModel = hiltViewModel()
@@ -84,37 +79,15 @@ fun BrainzPlayerListenCard(
                     Spacer(modifier = Modifier.width(ListenBrainzTheme.paddings.coverArtAndTextGap))
 
                     TitleAndSubtitle(
-                        modifier = Modifier.padding(end = 6.dp),
+                        modifier = Modifier,
                         title = title,
                         goToArtistPage = {},
                         artists = listOf(FeedListenArtist(subTitle, null, "")),
                         titleColor = titleColor
                     )
                 }
-                Box(modifier = Modifier
-                    .fillMaxWidth(0.275f)
-                    .align(Alignment.CenterEnd)){
-                    DropdownButton (modifier = Modifier.align(Alignment.CenterEnd), onDropdownIconClick = onDropdownIconClick)
-                    if(dropDownState) dropDown()
-                }
             }
         }
-    }
-}
-
-@Composable
-private fun DropdownButton(modifier: Modifier = Modifier, onDropdownIconClick: () -> Unit) {
-
-    IconButton(
-        modifier = modifier,
-        onClick = onDropdownIconClick
-    ) {
-        Icon(
-            painter = painterResource(id = R.drawable.ic_options),
-            contentDescription = "",
-            tint = ListenBrainzTheme.colorScheme.hint,
-            modifier = Modifier.padding(horizontal = ListenBrainzTheme.paddings.insideCard)
-        )
     }
 }
 

--- a/app/src/main/java/org/listenbrainz/android/ui/components/BrainzPlayerListenCard.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/components/BrainzPlayerListenCard.kt
@@ -1,6 +1,11 @@
 package org.listenbrainz.android.ui.components
 
 import androidx.annotation.DrawableRes
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -49,9 +54,9 @@ fun BrainzPlayerListenCard(
     onPlayIconClick: () -> Unit,
     viewModel: BrainzPlayerViewModel = hiltViewModel()
 ) {
+    val isPlaying by viewModel.isPlaying.collectAsState()
     val currentlyPlayingTitle by viewModel.currentlyPlayingTitle.collectAsState()
     val titleColor = if (currentlyPlayingTitle == title) {
-        //Once color is confirmed, I will add to Color.kt (Temporarily hardcoded here)
         Color(0xFFB94FE5)
     } else {
         ListenBrainzTheme.colorScheme.listenText
@@ -95,9 +100,11 @@ fun BrainzPlayerListenCard(
                     .align(Alignment.CenterEnd)){
                     DropdownButton (modifier = Modifier.align(Alignment.Center), onDropdownIconClick = onDropdownIconClick)
                     if(dropDownState) dropDown()
-                    PlayButton (modifier = Modifier.align(Alignment.CenterEnd)) {
-                        onPlayIconClick()
-                    }
+                    PlayButton(
+                        modifier = Modifier.align(Alignment.CenterEnd),
+                        isPlaying = currentlyPlayingTitle == title && isPlaying,
+                        onPlayIconClick = onPlayIconClick
+                    )
                 }
 
 
@@ -126,18 +133,24 @@ private fun DropdownButton(modifier: Modifier = Modifier, onDropdownIconClick: (
 }
 
 @Composable
-private fun PlayButton(modifier: Modifier = Modifier, onPlayIconClick: () -> Unit) {
-
+private fun PlayButton(modifier: Modifier = Modifier, onPlayIconClick: () -> Unit, isPlaying: Boolean) {
     IconButton(
         modifier = modifier,
         onClick = onPlayIconClick
     ) {
-        Icon(
-            painter = painterResource(id = R.drawable.brainz_player_play_button),
-            contentDescription = "",
-            tint = ListenBrainzTheme.colorScheme.hint,
-            modifier = Modifier.padding(horizontal = ListenBrainzTheme.paddings.insideCard)
-        )
+        AnimatedContent(
+            targetState = isPlaying,
+            transitionSpec = {
+                fadeIn(animationSpec = tween(200)) togetherWith fadeOut(animationSpec = tween(300))
+            }
+        ) { targetState ->
+            Icon(
+                painter = painterResource(id = if (targetState) R.drawable.ic_pause else R.drawable.brainz_player_play_button),
+                contentDescription = "",
+                tint = ListenBrainzTheme.colorScheme.hint,
+                modifier = Modifier.padding(horizontal = ListenBrainzTheme.paddings.insideCard)
+            )
+        }
     }
 }
 

--- a/app/src/main/java/org/listenbrainz/android/ui/navigation/BottomNavigationBar.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/navigation/BottomNavigationBar.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -34,6 +35,7 @@ import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 fun BottomNavigationBar(
     modifier: Modifier = Modifier,
     navController: NavController = rememberNavController(),
+    backgroundColor: Color = ListenBrainzTheme.colorScheme.nav,
     backdropScaffoldState: BackdropScaffoldState = rememberBackdropScaffoldState(initialValue = BackdropValue.Revealed),
     scrollToTop: () -> Unit,
     username : String?,
@@ -46,7 +48,7 @@ fun BottomNavigationBar(
     )
     BottomNavigation(
         modifier = modifier,
-        backgroundColor = ListenBrainzTheme.colorScheme.nav,
+        backgroundColor = backgroundColor,
         elevation = 0.dp
     ) {
         val coroutineScope = rememberCoroutineScope()

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerScreen.kt
@@ -38,7 +38,6 @@ import org.listenbrainz.android.ui.screens.brainzplayer.overview.OverviewScreen
 import org.listenbrainz.android.ui.screens.brainzplayer.overview.RecentPlaysScreen
 import org.listenbrainz.android.ui.screens.brainzplayer.overview.SongsOverviewScreen
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
-import org.listenbrainz.android.util.BrainzPlayerExtensions.toSong
 import org.listenbrainz.android.viewmodel.BPAlbumViewModel
 import org.listenbrainz.android.viewmodel.BPArtistViewModel
 import org.listenbrainz.android.viewmodel.BrainzPlayerViewModel
@@ -103,9 +102,6 @@ fun BrainzPlayerHomeScreen(
 ) {
 
     val currentTab : MutableState<Int> = remember {mutableStateOf(0)}
-    val currentlyPlayingSong =
-        brainzPlayerViewModel.currentlyPlayingSong.collectAsState().value.toSong
-    val isPlaying = brainzPlayerViewModel.isPlaying
     Column {
         Row(
             modifier = Modifier
@@ -175,65 +171,6 @@ fun BrainzPlayerHomeScreen(
                         0L
                     )
                     brainzPlayerViewModel.playOrToggleSong(song,true)
-                },
-                onAddToQueue = {
-                    song ->
-                    val currentSongs = brainzPlayerViewModel.appPreferences.currentPlayable?.songs?.toMutableList()
-                    currentSongs?.add(currentSongs.size, song)
-                    brainzPlayerViewModel.appPreferences.currentPlayable = brainzPlayerViewModel.appPreferences.currentPlayable?.copy(songs = currentSongs ?: emptyList())
-                    brainzPlayerViewModel.appPreferences.currentPlayable?.songs?.let {
-                        brainzPlayerViewModel.changePlayable(
-                            it,
-                            PlayableType.ALL_SONGS,
-                            brainzPlayerViewModel.appPreferences.currentPlayable?.id ?: 0,
-                            brainzPlayerViewModel.appPreferences.currentPlayable?.songs?.indexOfFirst { song -> song.mediaID==currentlyPlayingSong.mediaID   } ?: 0,brainzPlayerViewModel.songCurrentPosition.value
-                        )
-                    }
-                    brainzPlayerViewModel.queueChanged(
-                        currentlyPlayingSong,
-                        brainzPlayerViewModel.isPlaying.value
-                    )
-                },
-                onPlayNext = {
-                    song ->
-                    val currentSongIndex =
-                        brainzPlayerViewModel.appPreferences.currentPlayable?.songs?.indexOfFirst { song -> song.mediaID==currentlyPlayingSong.mediaID   }
-                            ?.plus(1)
-                    if (isPlaying.value && currentSongIndex != null) {
-                        val currentSongs = brainzPlayerViewModel.appPreferences.currentPlayable?.songs?.toMutableList()
-                        currentSongs?.add(currentSongIndex, song)
-                        brainzPlayerViewModel.appPreferences.currentPlayable = brainzPlayerViewModel.appPreferences.currentPlayable?.copy(songs = currentSongs ?: emptyList())
-                        brainzPlayerViewModel.appPreferences.currentPlayable?.songs?.let {
-                            brainzPlayerViewModel.changePlayable(
-                                it,
-                                PlayableType.ALL_SONGS,
-                                brainzPlayerViewModel.appPreferences.currentPlayable?.id ?: 0,
-                                brainzPlayerViewModel.appPreferences.currentPlayable?.songs?.indexOfFirst { song -> song.mediaID==currentlyPlayingSong.mediaID   } ?: 0,brainzPlayerViewModel.songCurrentPosition.value
-                            )
-                        }
-                        brainzPlayerViewModel.queueChanged(
-                            currentlyPlayingSong,
-                            brainzPlayerViewModel.isPlaying.value
-                        )
-                    }
-                    else{
-                        // No song is playing, so start playing the selected song
-                        brainzPlayerViewModel.changePlayable(
-                            listOf(song),
-                            PlayableType.SONG,
-                            song.mediaID,
-                            0,
-                            0L
-                        )
-                        brainzPlayerViewModel.playOrToggleSong(song, true)
-                    }
-
-                },
-                onAddToExistingPlaylist = {
-                    song ->
-                },
-                onAddToNewPlaylist = {
-                    song ->
                 }
             )
             2 -> ArtistsOverviewScreen(
@@ -248,63 +185,6 @@ fun BrainzPlayerHomeScreen(
                         0L
                     )
                     brainzPlayerViewModel.playOrToggleSong(artist.songs[0], true)
-                },
-                onPlayNext = {
-                    artist ->
-                    val currentSongIndex =
-                        brainzPlayerViewModel.appPreferences.currentPlayable?.songs?.indexOfFirst { song -> song.mediaID==currentlyPlayingSong.mediaID   }
-                            ?.plus(1)
-                    if (isPlaying.value && currentSongIndex != null) {
-                        val currentSongs = brainzPlayerViewModel.appPreferences.currentPlayable?.songs?.toMutableList()
-                        currentSongs?.addAll(currentSongIndex, artist.songs)
-                        brainzPlayerViewModel.appPreferences.currentPlayable = brainzPlayerViewModel.appPreferences.currentPlayable?.copy(songs = currentSongs ?: emptyList())
-                        brainzPlayerViewModel.appPreferences.currentPlayable?.songs?.let {
-                            brainzPlayerViewModel.changePlayable(
-                                it,
-                                PlayableType.ALL_SONGS,
-                                brainzPlayerViewModel.appPreferences.currentPlayable?.id ?: 0,
-                                brainzPlayerViewModel.appPreferences.currentPlayable?.songs?.indexOfFirst { song -> song.mediaID==currentlyPlayingSong.mediaID   } ?: 0,brainzPlayerViewModel.songCurrentPosition.value
-                            )
-                        }
-                        brainzPlayerViewModel.queueChanged(
-                            currentlyPlayingSong,
-                            brainzPlayerViewModel.isPlaying.value
-                        )
-                    }
-                    else{
-                        brainzPlayerViewModel.changePlayable(
-                            artist.songs,
-                            PlayableType.ARTIST,
-                            artist.id,
-                            0,
-                            0L
-                        )
-                        brainzPlayerViewModel.playOrToggleSong(artist.songs[0], true)
-                    }
-                },
-                onAddToQueue = {
-                    artist ->
-                    val currentSongs = brainzPlayerViewModel.appPreferences.currentPlayable?.songs?.toMutableList()
-                    currentSongs?.addAll(currentSongs.size, artist.songs)
-                    brainzPlayerViewModel.appPreferences.currentPlayable = brainzPlayerViewModel.appPreferences.currentPlayable?.copy(songs = currentSongs ?: emptyList())
-                    brainzPlayerViewModel.appPreferences.currentPlayable?.songs?.let {
-                        brainzPlayerViewModel.changePlayable(
-                            it,
-                            PlayableType.ALL_SONGS,
-                            brainzPlayerViewModel.appPreferences.currentPlayable?.id ?: 0,
-                            brainzPlayerViewModel.appPreferences.currentPlayable?.songs?.indexOfFirst { song -> song.mediaID==currentlyPlayingSong.mediaID   } ?: 0,brainzPlayerViewModel.songCurrentPosition.value
-                        )
-                    }
-                    brainzPlayerViewModel.queueChanged(
-                        currentlyPlayingSong,
-                        brainzPlayerViewModel.isPlaying.value
-                    )
-                },
-                onAddToNewPlaylist = {
-                    artist ->  
-                },
-                onAddToExistingPlaylist = {
-                    artist ->  
                 }
             )
             3 -> AlbumsOverViewScreen(albums = albums, onPlayIconClick = {

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/AlbumsOverviewScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/AlbumsOverviewScreen.kt
@@ -54,14 +54,21 @@ fun AlbumsOverViewScreen(
                     )
                     for (j in 1..albumsStarting[startingLetter]!!.size) {
                         val coverArt = albumsStarting[startingLetter]!![j - 1].albumArt
-                        BrainzPlayerListenCard(title = albumsStarting[startingLetter]!![j - 1].title, subTitle = albumsStarting[startingLetter]!![j - 1].artist, coverArtUrl = coverArt, errorAlbumArt = R.drawable.ic_erroralbumart, modifier = Modifier.padding(
-                            start = 10.dp,
-                            end = 10.dp,
-                            top = 3.dp,
-                            bottom = 3.dp
-                        ), onPlayIconClick = {
-                            onPlayIconClick(albumsStarting[startingLetter]!![j-1])
-                        })
+                        BrainzPlayerListenCard(
+                            title = albumsStarting[startingLetter]!![j - 1].title,
+                            subTitle = albumsStarting[startingLetter]!![j - 1].artist,
+                            coverArtUrl = coverArt,
+                            errorAlbumArt = R.drawable.ic_erroralbumart,
+                            modifier = Modifier.padding(
+                                start = 10.dp,
+                                end = 10.dp,
+                                top = 3.dp,
+                                bottom = 3.dp
+                            ),
+                            onPlayIconClick = {
+                                onPlayIconClick(albumsStarting[startingLetter]!![j-1])
+                            }
+                        )
                         Spacer(modifier = Modifier.height(10.dp))
                     }
                 }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/ArtistsOverviewScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/ArtistsOverviewScreen.kt
@@ -71,12 +71,30 @@ fun ArtistsOverviewScreen(
                         val artist = artistsStarting[startingLetter]!![j-1]
                         if (artistsStarting[startingLetter]!![j - 1].albums.isNotEmpty())
                             coverArt = artistsStarting[startingLetter]!![j - 1].albums[0].albumArt
-                        BrainzPlayerListenCard(title = artistsStarting[startingLetter]!![j - 1].name, subTitle = when (artistsStarting[startingLetter]!![j - 1].songs.size) {
-                            1 -> "1 track"
-                            else -> "${artistsStarting[startingLetter]!![j - 1].songs.size} tracks"
-                        }, coverArtUrl = coverArt, errorAlbumArt = R.drawable.ic_artist, onPlayIconClick = {
-                            onPlayClick(artistsStarting[startingLetter]!![j-1])
-                        }, modifier = Modifier.padding(start = 10.dp, end = 10.dp), dropDown = { BrainzPlayerDropDownMenu(onAddToNewPlaylist = {onAddToNewPlaylist(artist)}, onAddToExistingPlaylist = {onAddToExistingPlaylist(artist)},onAddToQueue = {onAddToQueue(artist)}, onPlayNext = {onPlayNext(artist)},expanded = dropdownState == Pair(i,j-1), onDismiss = {dropdownState = Pair(-1,-1)})}, onDropdownIconClick = {dropdownState = Pair(i,j-1)}, dropDownState = dropdownState == Pair(i,j-1))
+                        BrainzPlayerListenCard(
+                            title = artistsStarting[startingLetter]!![j - 1].name,
+                            subTitle = when (artistsStarting[startingLetter]!![j - 1].songs.size) {
+                                1 -> "1 track"
+                                else -> "${artistsStarting[startingLetter]!![j - 1].songs.size} tracks"
+                            },
+                            coverArtUrl = coverArt,
+                            errorAlbumArt = R.drawable.ic_artist,
+                            onPlayIconClick = {
+                                onPlayClick(artistsStarting[startingLetter]!![j-1])
+                            },
+                            modifier = Modifier.padding(start = 10.dp, end = 10.dp),
+                            dropDown = {
+                                BrainzPlayerDropDownMenu(
+                                    onAddToNewPlaylist = {onAddToNewPlaylist(artist)},
+                                    onAddToExistingPlaylist = {onAddToExistingPlaylist(artist)},
+                                    onAddToQueue = {onAddToQueue(artist)},
+                                    onPlayNext = {onPlayNext(artist)},
+                                    expanded = dropdownState == Pair(i,j-1),
+                                    onDismiss = {dropdownState = Pair(-1,-1)}
+                                )
+                            },
+                            onDropdownIconClick = {dropdownState = Pair(i,j-1)}, dropDownState = dropdownState == Pair(i,j-1)
+                        )
                         Spacer(modifier = Modifier.height(10.dp))
                     }
                 }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/ArtistsOverviewScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/ArtistsOverviewScreen.kt
@@ -9,10 +9,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
@@ -21,23 +17,15 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.listenbrainz.android.R
 import org.listenbrainz.android.model.Artist
-import org.listenbrainz.android.ui.components.BrainzPlayerDropDownMenu
 import org.listenbrainz.android.ui.components.BrainzPlayerListenCard
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 
 @Composable
 fun ArtistsOverviewScreen(
     artists: List<Artist>,
-    onPlayClick : (Artist) -> Unit,
-    onPlayNext : (Artist) -> Unit,
-    onAddToQueue : (Artist) -> Unit,
-    onAddToExistingPlaylist : (Artist) -> Unit,
-    onAddToNewPlaylist : (Artist) -> Unit,
+    onPlayClick : (Artist) -> Unit
 ) {
     val artistsStarting: MutableMap<Char, MutableList<Artist>> = mutableMapOf()
-    var dropdownState by remember {
-        mutableStateOf(Pair(-1,-1))
-    }
     for (i in 0..25) {
         artistsStarting['A' + i] = mutableListOf()
     }
@@ -68,7 +56,6 @@ fun ArtistsOverviewScreen(
                     )
                     for (j in 1..artistsStarting[startingLetter]!!.size) {
                         var coverArt: String? = null
-                        val artist = artistsStarting[startingLetter]!![j-1]
                         if (artistsStarting[startingLetter]!![j - 1].albums.isNotEmpty())
                             coverArt = artistsStarting[startingLetter]!![j - 1].albums[0].albumArt
                         BrainzPlayerListenCard(
@@ -82,18 +69,7 @@ fun ArtistsOverviewScreen(
                             onPlayIconClick = {
                                 onPlayClick(artistsStarting[startingLetter]!![j-1])
                             },
-                            modifier = Modifier.padding(start = 10.dp, end = 10.dp),
-                            dropDown = {
-                                BrainzPlayerDropDownMenu(
-                                    onAddToNewPlaylist = {onAddToNewPlaylist(artist)},
-                                    onAddToExistingPlaylist = {onAddToExistingPlaylist(artist)},
-                                    onAddToQueue = {onAddToQueue(artist)},
-                                    onPlayNext = {onPlayNext(artist)},
-                                    expanded = dropdownState == Pair(i,j-1),
-                                    onDismiss = {dropdownState = Pair(-1,-1)}
-                                )
-                            },
-                            onDropdownIconClick = {dropdownState = Pair(i,j-1)}, dropDownState = dropdownState == Pair(i,j-1)
+                            modifier = Modifier.padding(start = 10.dp, end = 10.dp)
                         )
                         Spacer(modifier = Modifier.height(10.dp))
                     }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/RecentPlaysOverviewScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/RecentPlaysOverviewScreen.kt
@@ -43,7 +43,7 @@ fun RecentPlaysScreen(
                 .background(
                     brush = ListenBrainzTheme.colorScheme.gradientBrush
                 )
-                .padding(top = 15.dp, bottom = 15.dp, start = 10.dp)) {
+                .padding(top = 15.dp, bottom = 15.dp, start = 10.dp, end = 10.dp)) {
                 Text(
                     "Played Today",
                     color = ListenBrainzTheme.colorScheme.lbSignature,
@@ -58,7 +58,7 @@ fun RecentPlaysScreen(
                 .background(
                     brush = ListenBrainzTheme.colorScheme.gradientBrush
                 )
-                .padding(top = 15.dp, bottom = 15.dp, start = 10.dp)) {
+                .padding(top = 15.dp, bottom = 15.dp, start = 10.dp, end = 10.dp)) {
                 Text(
                     "Played This Week",
                     color = ListenBrainzTheme.colorScheme.lbSignature,

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/RecentPlaysOverviewScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/RecentPlaysOverviewScreen.kt
@@ -12,15 +12,11 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.listenbrainz.android.R
 import org.listenbrainz.android.model.Song
-import org.listenbrainz.android.ui.components.BrainzPlayerDropDownMenu
 import org.listenbrainz.android.ui.components.BrainzPlayerListenCard
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 
@@ -29,12 +25,7 @@ fun RecentPlaysScreen(
     songsPlayedToday: List<Song>,
     songsPlayedThisWeek: List<Song>,
     onPlayIconClick: (Song) -> Unit,
-    onAddToQueue : (Song) -> Unit,
-    onPlayNext : (Song) -> Unit,
-    onAddToNewPlaylist : (Song) -> Unit,
-    onAddToExistingPlaylist : (Song) -> Unit
 ) {
-    val dropdownState : MutableState<Pair<Int,Int>> = remember {mutableStateOf(Pair(-1,-1))}
     Column (modifier = Modifier
         .verticalScroll(rememberScrollState())
         .fillMaxSize()) {
@@ -50,7 +41,7 @@ fun RecentPlaysScreen(
                     fontSize = 25.sp
                 )
                 Spacer(modifier = Modifier.height(10.dp))
-                PlayedToday(songsPlayedToday = songsPlayedToday, onPlayIconClick = onPlayIconClick, dropDownState = dropdownState,  onAddToQueue = onAddToQueue, onAddToNewPlaylist = onAddToNewPlaylist, onAddToExistingPlaylist = onAddToExistingPlaylist, onPlayNext = onPlayNext)
+                PlayedToday(songsPlayedToday = songsPlayedToday, onPlayIconClick = onPlayIconClick)
             }
         }
         if(songsPlayedThisWeek.isNotEmpty()) {
@@ -65,20 +56,16 @@ fun RecentPlaysScreen(
                     fontSize = 25.sp
                 )
                 Spacer(modifier = Modifier.height(10.dp))
-                PlayedThisWeek(songsPlayedThisWeek = songsPlayedThisWeek, onPlayIconClick = onPlayIconClick, dropDownState = dropdownState, onAddToQueue = onAddToQueue, onAddToNewPlaylist = onAddToNewPlaylist, onAddToExistingPlaylist = onAddToExistingPlaylist, onPlayNext = onPlayNext)
+                PlayedThisWeek(songsPlayedThisWeek = songsPlayedThisWeek, onPlayIconClick = onPlayIconClick)
             }
         }
     }
 }
+
 @Composable
 private fun PlayedToday(
     songsPlayedToday: List<Song>,
     onPlayIconClick: (Song) -> Unit,
-    dropDownState : MutableState<Pair<Int,Int>>,
-    onAddToQueue: (Song) -> Unit,
-    onPlayNext: (Song) -> Unit,
-    onAddToExistingPlaylist: (Song) -> Unit,
-    onAddToNewPlaylist: (Song) -> Unit
 ){
     var heightConstraint = ListenBrainzTheme.sizes.listenCardHeight * songsPlayedToday.size + 20.dp
     if(songsPlayedToday.size > 4) heightConstraint = 250.dp
@@ -93,18 +80,6 @@ private fun PlayedToday(
                 coverArtUrl = it.albumArt,
                 errorAlbumArt = R.drawable.ic_erroralbumart,
                 onPlayIconClick = { onPlayIconClick(it) },
-                onDropdownIconClick = {dropDownState.value = Pair(1,index)},
-                dropDownState = dropDownState.value == Pair(1,index),
-                dropDown = {
-                    BrainzPlayerDropDownMenu(
-                        expanded = dropDownState.value == Pair(1,index),
-                        onDismiss = {dropDownState.value = Pair(-1,-1)},
-                        onAddToQueue = {onAddToQueue(it)},
-                        onPlayNext =  {onPlayNext(it)},
-                        onAddToExistingPlaylist = {onAddToExistingPlaylist(it)},
-                        onAddToNewPlaylist = {onAddToNewPlaylist(it)}
-                    )
-                },
                 mediaId = it.mediaID
             )
             Spacer(modifier = Modifier.height(5.dp))
@@ -116,12 +91,7 @@ private fun PlayedToday(
 @Composable
 private fun PlayedThisWeek(
     songsPlayedThisWeek: List<Song>,
-    onPlayIconClick: (Song) -> Unit,
-    dropDownState : MutableState<Pair<Int,Int>>,
-    onAddToQueue: (Song) -> Unit,
-    onPlayNext: (Song) -> Unit,
-    onAddToExistingPlaylist: (Song) -> Unit,
-    onAddToNewPlaylist: (Song) -> Unit
+    onPlayIconClick: (Song) -> Unit
 ){
     var heightConstraint = ListenBrainzTheme.sizes.listenCardHeight * songsPlayedThisWeek.size + 20.dp
     if(songsPlayedThisWeek.size > 4) heightConstraint = 250.dp
@@ -135,19 +105,7 @@ private fun PlayedThisWeek(
                 subTitle = it.artist,
                 coverArtUrl = it.albumArt,
                 errorAlbumArt = R.drawable.ic_erroralbumart,
-                onPlayIconClick = { onPlayIconClick(it) },
-                onDropdownIconClick = { dropDownState.value = Pair(2,index) },
-                dropDownState = dropDownState.value == Pair(2,index),
-                dropDown = {
-                    BrainzPlayerDropDownMenu(
-                        expanded = dropDownState.value == Pair(2,index),
-                        onDismiss = {dropDownState.value = Pair(-1,-1)},
-                        onAddToQueue = {onAddToQueue(it)},
-                        onPlayNext =  {onPlayNext(it)},
-                        onAddToExistingPlaylist = {onAddToExistingPlaylist(it)},
-                        onAddToNewPlaylist = {onAddToNewPlaylist(it)}
-                    )
-                }
+                onPlayIconClick = { onPlayIconClick(it) }
             )
             Spacer(modifier = Modifier.height(5.dp))
         }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/RecentPlaysOverviewScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/RecentPlaysOverviewScreen.kt
@@ -87,14 +87,25 @@ private fun PlayedToday(
     )) {
         itemsIndexed(songsPlayedToday){
             index, it ->
-            BrainzPlayerListenCard(title = it.title, subTitle = it.artist, coverArtUrl = it.albumArt, errorAlbumArt = R.drawable.ic_erroralbumart, onPlayIconClick = {onPlayIconClick(it)}, onDropdownIconClick = {dropDownState.value = Pair(1,index)}, dropDownState = dropDownState.value == Pair(1,index),dropDown = {BrainzPlayerDropDownMenu(
-                expanded = dropDownState.value == Pair(1,index),
-                onDismiss = {dropDownState.value = Pair(-1,-1)},
-                onAddToQueue = {onAddToQueue(it)},
-                onPlayNext =  {onPlayNext(it)},
-                onAddToExistingPlaylist = {onAddToExistingPlaylist(it)},
-                onAddToNewPlaylist = {onAddToNewPlaylist(it)}
-            )})
+            BrainzPlayerListenCard(
+                title = it.title,
+                subTitle = it.artist,
+                coverArtUrl = it.albumArt,
+                errorAlbumArt = R.drawable.ic_erroralbumart,
+                onPlayIconClick = { onPlayIconClick(it) },
+                onDropdownIconClick = {dropDownState.value = Pair(1,index)},
+                dropDownState = dropDownState.value == Pair(1,index),
+                dropDown = {
+                    BrainzPlayerDropDownMenu(
+                        expanded = dropDownState.value == Pair(1,index),
+                        onDismiss = {dropDownState.value = Pair(-1,-1)},
+                        onAddToQueue = {onAddToQueue(it)},
+                        onPlayNext =  {onPlayNext(it)},
+                        onAddToExistingPlaylist = {onAddToExistingPlaylist(it)},
+                        onAddToNewPlaylist = {onAddToNewPlaylist(it)}
+                    )
+                }
+            )
             Spacer(modifier = Modifier.height(5.dp))
         }
 
@@ -118,14 +129,25 @@ private fun PlayedThisWeek(
     )) {
         itemsIndexed(songsPlayedThisWeek){
             index, it ->
-            BrainzPlayerListenCard(title = it.title, subTitle = it.artist, coverArtUrl = it.albumArt, errorAlbumArt = R.drawable.ic_erroralbumart, onPlayIconClick = {onPlayIconClick(it)}, onDropdownIconClick = {dropDownState.value = Pair(2,index)}, dropDownState = dropDownState.value == Pair(2,index),dropDown = {BrainzPlayerDropDownMenu(
-                expanded = dropDownState.value == Pair(2,index),
-                onDismiss = {dropDownState.value = Pair(-1,-1)},
-                onAddToQueue = {onAddToQueue(it)},
-                onPlayNext =  {onPlayNext(it)},
-                onAddToExistingPlaylist = {onAddToExistingPlaylist(it)},
-                onAddToNewPlaylist = {onAddToNewPlaylist(it)}
-            )})
+            BrainzPlayerListenCard(
+                title = it.title,
+                subTitle = it.artist,
+                coverArtUrl = it.albumArt,
+                errorAlbumArt = R.drawable.ic_erroralbumart,
+                onPlayIconClick = { onPlayIconClick(it) },
+                onDropdownIconClick = { dropDownState.value = Pair(2,index) },
+                dropDownState = dropDownState.value == Pair(2,index),
+                dropDown = {
+                    BrainzPlayerDropDownMenu(
+                        expanded = dropDownState.value == Pair(2,index),
+                        onDismiss = {dropDownState.value = Pair(-1,-1)},
+                        onAddToQueue = {onAddToQueue(it)},
+                        onPlayNext =  {onPlayNext(it)},
+                        onAddToExistingPlaylist = {onAddToExistingPlaylist(it)},
+                        onAddToNewPlaylist = {onAddToNewPlaylist(it)}
+                    )
+                }
+            )
             Spacer(modifier = Modifier.height(5.dp))
         }
     }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/RecentPlaysOverviewScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/RecentPlaysOverviewScreen.kt
@@ -104,7 +104,8 @@ private fun PlayedToday(
                         onAddToExistingPlaylist = {onAddToExistingPlaylist(it)},
                         onAddToNewPlaylist = {onAddToNewPlaylist(it)}
                     )
-                }
+                },
+                mediaId = it.mediaID
             )
             Spacer(modifier = Modifier.height(5.dp))
         }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/SongsOverviewScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/SongsOverviewScreen.kt
@@ -56,9 +56,14 @@ fun SongsOverviewScreen(
                         val song: Song = songsStarting[startingLetter]!![j-1]
                         var coverArt: String? = null
                         coverArt = songsStarting[startingLetter]!![j - 1].albumArt
-                        BrainzPlayerListenCard(modifier = Modifier.padding(start= 10.dp, end = 10.dp),title = songsStarting[startingLetter]!![j - 1].title, subTitle = songsStarting[startingLetter]!![j - 1].artist, coverArtUrl = coverArt, errorAlbumArt = R.drawable.ic_erroralbumart){
-                            onPlayIconClick(song,songsStarting[startingLetter]!!)
-                        }
+                        BrainzPlayerListenCard(
+                            modifier = Modifier.padding(start = 10.dp, end = 10.dp),
+                            title = songsStarting[startingLetter]!![j - 1].title,
+                            subTitle = songsStarting[startingLetter]!![j - 1].artist,
+                            coverArtUrl = coverArt,
+                            errorAlbumArt = R.drawable.ic_erroralbumart,
+                            onPlayIconClick = { onPlayIconClick(song, songsStarting[startingLetter]!!) }
+                        )
                         Spacer(modifier = Modifier.height(10.dp))
                     }
                 }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/SongsOverviewScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/SongsOverviewScreen.kt
@@ -62,7 +62,8 @@ fun SongsOverviewScreen(
                             subTitle = songsStarting[startingLetter]!![j - 1].artist,
                             coverArtUrl = coverArt,
                             errorAlbumArt = R.drawable.ic_erroralbumart,
-                            onPlayIconClick = { onPlayIconClick(song, songsStarting[startingLetter]!!) }
+                            onPlayIconClick = { onPlayIconClick(song, songsStarting[startingLetter]!!) },
+                            mediaId = song.mediaID
                         )
                         Spacer(modifier = Modifier.height(10.dp))
                     }

--- a/app/src/main/java/org/listenbrainz/android/util/SongViewPager.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/SongViewPager.kt
@@ -103,7 +103,7 @@ fun SongViewPager(
         state = pagerState,
         modifier = modifier
             .fillMaxWidth()
-            .dynamicBackgroundFromAlbumArt(currentlyPlayingSong.albumArt)
+            .background(viewModel.playerBackGroundColor)
     ) {
         Column(
             modifier = Modifier

--- a/app/src/main/java/org/listenbrainz/android/viewmodel/BrainzPlayerViewModel.kt
+++ b/app/src/main/java/org/listenbrainz/android/viewmodel/BrainzPlayerViewModel.kt
@@ -1,27 +1,22 @@
 package org.listenbrainz.android.viewmodel
 
-import android.os.Build
 import android.support.v4.media.MediaBrowserCompat
 import android.support.v4.media.session.PlaybackStateCompat.REPEAT_MODE_ALL
 import android.support.v4.media.session.PlaybackStateCompat.REPEAT_MODE_NONE
 import android.support.v4.media.session.PlaybackStateCompat.REPEAT_MODE_ONE
 import android.support.v4.media.session.PlaybackStateCompat.SHUFFLE_MODE_ALL
 import android.support.v4.media.session.PlaybackStateCompat.SHUFFLE_MODE_NONE
-import androidx.annotation.RequiresApi
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.listenbrainz.android.model.Playable
 import org.listenbrainz.android.model.PlayableType
@@ -36,12 +31,9 @@ import org.listenbrainz.android.util.BrainzPlayerExtensions.currentPlaybackPosit
 import org.listenbrainz.android.util.BrainzPlayerExtensions.isPlayEnabled
 import org.listenbrainz.android.util.BrainzPlayerExtensions.isPlaying
 import org.listenbrainz.android.util.BrainzPlayerExtensions.isPrepared
-import org.listenbrainz.android.util.BrainzPlayerExtensions.title
 import org.listenbrainz.android.util.BrainzPlayerExtensions.toSong
 import org.listenbrainz.android.util.BrainzPlayerUtils.MEDIA_ROOT_ID
 import org.listenbrainz.android.util.Resource
-import org.listenbrainz.android.util.Transformer.toSongEntity
-import java.time.Instant
 import javax.inject.Inject
 
 @HiltViewModel
@@ -68,7 +60,6 @@ class BrainzPlayerViewModel @Inject constructor(
     val playButton = brainzPlayerServiceConnection.playButtonState
     val repeatMode = brainzPlayerServiceConnection.repeatModeState
     var isSearching by mutableStateOf(false)
-    val currentlyPlayingTitle = brainzPlayerServiceConnection.currentPlayingSong.map { it.title }
 
     init {
         updatePlayerPosition()

--- a/app/src/main/java/org/listenbrainz/android/viewmodel/BrainzPlayerViewModel.kt
+++ b/app/src/main/java/org/listenbrainz/android/viewmodel/BrainzPlayerViewModel.kt
@@ -71,6 +71,7 @@ class BrainzPlayerViewModel @Inject constructor(
     var isSearching by mutableStateOf(false)
 
     var playerBackGroundColor by mutableStateOf(Color.Transparent)
+        private set
 
     init {
         updatePlayerPosition()


### PR DESCRIPTION
This PR focuses on removing the dropdown functionality from the BrainzPlayer tabs to address the buggy behavior and improve the overall user experience. The changes ensure a cleaner and more consistent UI across the affected screens.

**Updated files:**
- ArtistsOverviewScreen.kt
- BrainzPlayerListenCard.kt
- BrainzPlayerScreen.kt
- RecentPlaysOverviewScreen.kt


**Screenshot:**
<img src="https://github.com/user-attachments/assets/f1285596-4d4e-4096-aa6a-588a2fef547a" height="700">

Let me know if further adjustments are needed!

**Note:** Please merge this PR after PR #518.