### PR TITLE
Fixed UI State Loss In BrainzPlayerSearchScreen 

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/ui/screens/search/BrainzPlayerSearchScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/search/BrainzPlayerSearchScreen.kt
@@ -78,7 +78,6 @@ fun BrainzPlayerSearchScreen(
             onQueryChange = { newValue: String ->
                 val updatedQuery = TextFieldValue(newValue, selection = brainzplayerQueryState.selection)
                 viewModel.updateSearchQuery(updatedQuery)
-                viewModel.searchSongs(newValue)
             },
             onClear = {
                 viewModel.clearSearchResults()

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/search/BrainzPlayerSearchScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/search/BrainzPlayerSearchScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -26,6 +27,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.hilt.navigation.compose.hiltViewModel
 import org.listenbrainz.android.R
 import org.listenbrainz.android.model.PlayableType
@@ -46,21 +48,15 @@ fun BrainzPlayerSearchScreen(
     deactivate: () -> Unit,
 ) {
     val context = LocalContext.current
-    var brainzplayerQueryState by remember {
-        mutableStateOf("")
-    }
-
-    val searchItems = remember {
-        mutableStateListOf<Song>()
-    }
+    val brainzplayerQueryState by viewModel.searchQuery.collectAsState()
+    val searchItems by viewModel.searchItems.collectAsState()
 
     var error by remember {
         mutableStateOf<ResponseError?>(null)
     }
 
     fun onDismiss() {
-        searchItems.clear()
-        brainzplayerQueryState = ""
+        viewModel.clearSearchResults()
         error = null
         deactivate()
     }
@@ -71,20 +67,22 @@ fun BrainzPlayerSearchScreen(
         exit = fadeOut()
     ) {
         SearchScreen(
-            uiState = remember(searchItems, brainzplayerQueryState, error) {
+            uiState = remember(searchItems, brainzplayerQueryState.text, error) {
                 SearchUiState(
-                    query = brainzplayerQueryState,
+                    query = brainzplayerQueryState.text,
                     result = searchItems,
                     error = error
                 )
             },
             onDismiss = ::onDismiss,
-            onQueryChange = { newValue  ->
-                brainzplayerQueryState = newValue
-                searchItems.clear()
-                searchItems.addAll(viewModel.searchSongs(brainzplayerQueryState) ?: emptyList())
+            onQueryChange = { newValue: String ->
+                val updatedQuery = TextFieldValue(newValue, selection = brainzplayerQueryState.selection)
+                viewModel.updateSearchQuery(updatedQuery)
+                viewModel.searchSongs(newValue)
             },
-            onClear = searchItems::clear,
+            onClear = {
+                viewModel.clearSearchResults()
+            },
             onErrorShown = { error = null },
             placeholderText = "Search your music library"
         ) {
@@ -102,7 +100,12 @@ fun BrainzPlayerSearchScreen(
                         onDropdownSuccess = { context.showToast(it) },
                         onDropdownError = { error = it }
                     ) {
-                        viewModel.changePlayable(listOf(song), PlayableType.SONG, song.mediaID, 0)
+                        viewModel.changePlayable(
+                            listOf(song),
+                            PlayableType.SONG,
+                            song.mediaID,
+                            0
+                        )
                         viewModel.playOrToggleSong(song, true)
                         onDismiss()
                     }

--- a/app/src/main/java/org/listenbrainz/android/viewmodel/BrainzPlayerViewModel.kt
+++ b/app/src/main/java/org/listenbrainz/android/viewmodel/BrainzPlayerViewModel.kt
@@ -72,7 +72,6 @@ class BrainzPlayerViewModel @Inject constructor(
     val isPlaying = brainzPlayerServiceConnection.isPlaying
     val playButton = brainzPlayerServiceConnection.playButtonState
     val repeatMode = brainzPlayerServiceConnection.repeatModeState
-    var isSearching by mutableStateOf(false)
 
     var playerBackGroundColor by mutableStateOf(Color.Transparent)
 
@@ -219,11 +218,9 @@ class BrainzPlayerViewModel @Inject constructor(
     private fun SearchSong(query: String) {
         val listToSearch = _mediaItems.value.data
         if (query.isEmpty()) {
-            isSearching = false
             _searchItems.value = emptyList()
             return
         }
-        isSearching = true
         val result: List<Song>? = listToSearch?.filter {
             it.title.contains(query.trim(), ignoreCase = true)
         }


### PR DESCRIPTION
This PR resolves the issue of UI state loss in BrainzPlayerSearchScreen during screen orientation changes. Previously, the search query and UI state were reset when the screen rotated. This issue has been fixed by introducing state retention in BrainzPlayerViewModel and ensuring that the UI state, including the search query and results, is preserved across orientation changes.

**Before**

https://github.com/user-attachments/assets/791c61e9-cf2b-4ae1-a9d0-42021e313007

**After**

https://github.com/user-attachments/assets/89b85ead-3c7d-4a90-96e4-1f12da8c6632

