### PR TITLE
Minor-UI-Logic-Bug

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/listens/ListensScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/listens/ListensScreen.kt
@@ -223,7 +223,7 @@ fun ListensScreen(
                                 modifier = Modifier,
                                 isFollowedState = uiState.listensTabUiState.isFollowing,
                                 onClick = {
-                                    if (uiState.listensTabUiState.isFollowing) {
+                                    if (!uiState.listensTabUiState.isFollowing) {
                                         onFollowButtonClick(username ?: "", false)
                                     } else {
                                         onFollowButtonClick(username ?: "", true)


### PR DESCRIPTION
This PR resolves the issue of following and unfollowing a user. Previously, in the onFollowButtonClick function, the isFollowing status was passed . If the status was false, the followUser function would be called, even if the user was already following, leading to redundant actions. I have updated the logic so that if the user is not following, false will be passed to unfollow, and if the user is already following, true will be passed to unfollow the user.

**Before**
 
[Bug_Follow_Button_Before.webm](https://github.com/user-attachments/assets/7182a673-af2d-4066-aa6a-4f91f1cd5061)
**After**
[Bug_Follow_Button_After.webm](https://github.com/user-attachments/assets/5209758e-4782-4350-a177-126f7e3fe31d)

