### PR TITLE
Fixed Orientation Issue & Implemented Share Song Function

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/ui/components/BrainzPlayerDropDownMenu.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/components/BrainzPlayerDropDownMenu.kt
@@ -15,7 +15,7 @@ fun BrainzPlayerDropDownMenu(
     onPlayNext: () -> Unit = {},
     onAddToQueue: () -> Unit = {},
     onShareAudio: () -> Unit = {},
-    isSongOverviewScreen: Boolean = false
+    showShareOption: Boolean = false
 ) {
     DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
         DropdownMenuItem(onClick = {
@@ -37,7 +37,7 @@ fun BrainzPlayerDropDownMenu(
             onAddToQueue()
             onDismiss()
         }, text = { Text(text = "Add to queue") })
-        if (isSongOverviewScreen) {
+        if (showShareOption) {
             DropdownMenuItem(onClick = {
                 onShareAudio()
                 onDismiss()

--- a/app/src/main/java/org/listenbrainz/android/ui/components/BrainzPlayerDropDownMenu.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/components/BrainzPlayerDropDownMenu.kt
@@ -8,30 +8,41 @@ import androidx.compose.runtime.Composable
 
 @Composable
 fun BrainzPlayerDropDownMenu(
-    expanded : Boolean ,
-    onDismiss : () -> Unit = {},
-    onAddToNewPlaylist : () -> Unit = {},
-    onAddToExistingPlaylist : () -> Unit = {},
-    onPlayNext : () -> Unit = {},
-    onAddToQueue : () -> Unit = {},
-){
+    expanded: Boolean,
+    onDismiss: () -> Unit = {},
+    onAddToNewPlaylist: () -> Unit = {},
+    onAddToExistingPlaylist: () -> Unit = {},
+    onPlayNext: () -> Unit = {},
+    onAddToQueue: () -> Unit = {},
+    onShareAudio: () -> Unit = {},
+    isSongOverviewScreen: Boolean = false
+) {
     DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
         DropdownMenuItem(onClick = {
             onAddToNewPlaylist()
             onDismiss()
-        }, text = {Text(text = "Add to new playlist")})
+        }, text = { Text(text = "Add to new playlist") })
+
         DropdownMenuItem(onClick = {
             onAddToExistingPlaylist()
             onDismiss()
-        }, text = {Text(text = "Add to existing playlist")})
+        }, text = { Text(text = "Add to existing playlist") })
+
         DropdownMenuItem(onClick = {
             onPlayNext()
             onDismiss()
-        }, text = {Text(text = "Play next")})
+        }, text = { Text(text = "Play next") })
+
         DropdownMenuItem(onClick = {
             onAddToQueue()
             onDismiss()
-        }, text = {Text(text = "Add to queue")})
+        }, text = { Text(text = "Add to queue") })
+        if (isSongOverviewScreen) {
+            DropdownMenuItem(onClick = {
+                onShareAudio()
+                onDismiss()
+            }, text = { Text(text = "Share") })
+        }
     }
-
 }
+

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -115,7 +116,7 @@ fun BrainzPlayerHomeScreen(
     albumSongsMap: MutableMap<Album, List<Song>>,
     brainzPlayerViewModel: BrainzPlayerViewModel = hiltViewModel(),
 ) {
-    val currentTab = remember { mutableIntStateOf(0) }
+    val currentTab = rememberSaveable { mutableIntStateOf(0) }
 
     Column {
         Row(

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/ArtistsOverviewScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/ArtistsOverviewScreen.kt
@@ -88,7 +88,7 @@ fun ArtistsOverviewScreen(
                                     onPlayNext = {onPlayNext(artist)},
                                     expanded = dropdownState == Pair(i,j-1),
                                     onDismiss = {dropdownState = Pair(-1,-1)},
-                                    isSongOverviewScreen = false
+                                    showShareOption = false
                                 )
                             },
                             onDropdownIconClick = { dropdownState = Pair(i,j-1) },

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/ArtistsOverviewScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/ArtistsOverviewScreen.kt
@@ -87,7 +87,8 @@ fun ArtistsOverviewScreen(
                                     onAddToQueue = {onAddToQueue(artist)},
                                     onPlayNext = {onPlayNext(artist)},
                                     expanded = dropdownState == Pair(i,j-1),
-                                    onDismiss = {dropdownState = Pair(-1,-1)}
+                                    onDismiss = {dropdownState = Pair(-1,-1)},
+                                    isSongOverviewScreen = false
                                 )
                             },
                             onDropdownIconClick = { dropdownState = Pair(i,j-1) },

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/RecentPlaysOverviewScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/RecentPlaysOverviewScreen.kt
@@ -113,7 +113,7 @@ private fun PlayedThisWeek(
                         onPlayNext =  {onPlayNext(it)},
                         onAddToExistingPlaylist = {onAddToExistingPlaylist(it)},
                         onAddToNewPlaylist = {onAddToNewPlaylist(it)},
-                        isSongOverviewScreen = false
+                        showShareOption = false
                     )
                 },
                 isPlaying = it.mediaID == currentlyPlayingSong.mediaID

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/RecentPlaysOverviewScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/RecentPlaysOverviewScreen.kt
@@ -112,7 +112,8 @@ private fun PlayedThisWeek(
                         onAddToQueue = {onAddToQueue(it)},
                         onPlayNext =  {onPlayNext(it)},
                         onAddToExistingPlaylist = {onAddToExistingPlaylist(it)},
-                        onAddToNewPlaylist = {onAddToNewPlaylist(it)}
+                        onAddToNewPlaylist = {onAddToNewPlaylist(it)},
+                        isSongOverviewScreen = false
                     )
                 },
                 isPlaying = it.mediaID == currentlyPlayingSong.mediaID

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/SongsOverviewScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/SongsOverviewScreen.kt
@@ -1,5 +1,8 @@
 package org.listenbrainz.android.ui.screens.brainzplayer.overview
 
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -33,6 +36,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.listenbrainz.android.R
+import org.listenbrainz.android.application.App.Companion.context
 import org.listenbrainz.android.model.Song
 import org.listenbrainz.android.ui.components.BrainzPlayerDropDownMenu
 import org.listenbrainz.android.ui.components.ListenCardSmall
@@ -137,8 +141,13 @@ fun SongsOverviewScreen(
                                         onPlayNext = {
                                             onPlayNext(song)
                                         },
+                                        onShareAudio = {
+                                            val uri = Uri.parse(song.uri)
+                                            shareAudio(context,uri)
+                                        },
                                         expanded = showDropdown,
-                                        onDismiss = { showDropdown = false }
+                                        onDismiss = { showDropdown = false },
+                                        isSongOverviewScreen = true
                                     )
                                 }
                             )
@@ -161,3 +170,16 @@ fun SongsOverviewScreen(
         }
     }
 }
+fun shareAudio(context: Context, audioUri: Uri) {
+    if (audioUri != Uri.EMPTY) {
+        val shareIntent = Intent(Intent.ACTION_SEND).apply {
+            type = "audio/*"
+            putExtra(Intent.EXTRA_STREAM, audioUri)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        context.applicationContext.startActivity(Intent.createChooser(shareIntent, "Share audio").apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        })
+    }
+}
+

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/SongsOverviewScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/SongsOverviewScreen.kt
@@ -147,7 +147,7 @@ fun SongsOverviewScreen(
                                         },
                                         expanded = showDropdown,
                                         onDismiss = { showDropdown = false },
-                                        isSongOverviewScreen = true
+                                        showShareOption = true
                                     )
                                 }
                             )


### PR DESCRIPTION
This PR fixes the Screen Reset Issue in the BrainzPlayerScreen by preserving the current tab position. Additionally  introduces a new feature to share songs in SongsOverviewScreen  via Android's native sharing options.

**Before**

https://github.com/user-attachments/assets/ede995f8-a57b-4a66-948f-79a3d16e6393

**After**

https://github.com/user-attachments/assets/e54b4373-42dc-453b-9baa-88541c7e0832

