### PR TITLE
Fixed crash for add queue option

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/viewmodel/BrainzPlayerViewModel.kt
+++ b/app/src/main/java/org/listenbrainz/android/viewmodel/BrainzPlayerViewModel.kt
@@ -354,13 +354,18 @@ class BrainzPlayerViewModel @Inject constructor(
             appPreferences.currentPlayable?.copy(
                 songs = currentSongs ?: emptyList()
             )
+        var currentSongIndex = appPreferences.currentPlayable?.songs?.indexOfFirst { song -> song.mediaID == currentlyPlayingSong.value.toSong.mediaID } ?: 0
+        if (currentSongIndex == -1) {
+            currentSongIndex = 0
+        }
+
         appPreferences.currentPlayable?.songs?.let {
             changePlayable(
                 it,
                 PlayableType.ALL_SONGS,
                 appPreferences.currentPlayable?.id ?: 0,
-                appPreferences.currentPlayable?.songs?.indexOfFirst { song -> song.mediaID == currentlyPlayingSong.value.toSong.mediaID }
-                    ?: 0, songCurrentPosition.value
+                currentSongIndex,
+                songCurrentPosition.value
             )
         }
         queueChanged(


### PR DESCRIPTION
This PR fixes an issue where the app crashes when adding a song to the queue while no song is currently playing. The crash occurs because mediaID matching fails, causing indexOfFirst to return -1. Since -1 is an invalid index, this leads to an error.

The matching fails because initially, no song is playing. To fix this, I have set currentSongIndex to 0 when indexOfFirst returns -1, ensuring a valid index and preventing the crash. Now, songs can be added to the queue even if no song is currently playing

**Before**

https://github.com/user-attachments/assets/1a7e0d7d-cb34-430c-9c0e-9f40236366cd

**After**


https://github.com/user-attachments/assets/82feedc3-be9f-41d4-a90b-e92d4c617915

