### PR TITLE
MOBILE-214: Create-Edit Playlist Screen implementation

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/model/AppNavigationItem.kt
+++ b/app/src/main/java/org/listenbrainz/android/model/AppNavigationItem.kt
@@ -12,6 +12,6 @@ sealed class AppNavigationItem(val route: String, @DrawableRes val iconUnselecte
     object About: AppNavigationItem("about", R.drawable.ic_info, R.drawable.ic_info, "About")
     object Artist: AppNavigationItem("artist", R.drawable.ic_artist, R.drawable.ic_artist,"Artist")
     object Album: AppNavigationItem("album", R.drawable.ic_album, R.drawable.ic_album, "Artist > Album")
-    object AddEditPlaylistScreen: AppNavigationItem("addEditPlaylistScreen", R.drawable.playlist_listview, R.drawable.playlist_listview, "Add/Edit Playlist")
+    object AddEditPlaylistScreen: AppNavigationItem("addEditPlaylistScreen", R.drawable.ic_queue_music, R.drawable.ic_queue_music, "Playlist")
 }
 

--- a/app/src/main/java/org/listenbrainz/android/model/AppNavigationItem.kt
+++ b/app/src/main/java/org/listenbrainz/android/model/AppNavigationItem.kt
@@ -12,5 +12,6 @@ sealed class AppNavigationItem(val route: String, @DrawableRes val iconUnselecte
     object About: AppNavigationItem("about", R.drawable.ic_info, R.drawable.ic_info, "About")
     object Artist: AppNavigationItem("artist", R.drawable.ic_artist, R.drawable.ic_artist,"Artist")
     object Album: AppNavigationItem("album", R.drawable.ic_album, R.drawable.ic_album, "Artist > Album")
+    object AddEditPlaylistScreen: AppNavigationItem("addEditPlaylistScreen", R.drawable.playlist_listview, R.drawable.playlist_listview, "Add/Edit Playlist")
 }
 

--- a/app/src/main/java/org/listenbrainz/android/model/playlist/AddCopyPlaylistResponse.kt
+++ b/app/src/main/java/org/listenbrainz/android/model/playlist/AddCopyPlaylistResponse.kt
@@ -3,9 +3,14 @@ package org.listenbrainz.android.model.playlist
 
 import com.google.gson.annotations.SerializedName
 
-data class CopyPlaylistResponse(
+data class AddCopyPlaylistResponse(
     @SerializedName("playlist_mbid")
     val playlistMbid: String,
+    @SerializedName("status")
+    val status: String
+)
+
+data class EditPlaylistResponse(
     @SerializedName("status")
     val status: String
 )

--- a/app/src/main/java/org/listenbrainz/android/model/playlist/PlaylistExtensionData.kt
+++ b/app/src/main/java/org/listenbrainz/android/model/playlist/PlaylistExtensionData.kt
@@ -13,5 +13,7 @@ data class PlaylistExtensionData(
     @SerializedName("last_modified_at")
     val lastModifiedAt: String? = null,
     @SerializedName("public")
-    val `public`: Boolean? = null
+    val `public`: Boolean? = null,
+    @SerializedName("collaborators")
+    val collaborators: List<String> = emptyList(),
 )

--- a/app/src/main/java/org/listenbrainz/android/repository/playlists/PlaylistDataRepository.kt
+++ b/app/src/main/java/org/listenbrainz/android/repository/playlists/PlaylistDataRepository.kt
@@ -1,6 +1,7 @@
 package org.listenbrainz.android.repository.playlists
 
-import org.listenbrainz.android.model.playlist.CopyPlaylistResponse
+import org.listenbrainz.android.model.playlist.AddCopyPlaylistResponse
+import org.listenbrainz.android.model.playlist.EditPlaylistResponse
 import org.listenbrainz.android.model.playlist.PlaylistPayload
 import org.listenbrainz.android.util.Resource
 
@@ -10,7 +11,7 @@ interface PlaylistDataRepository {
     suspend fun fetchPlaylist(playlistMbid: String?): Resource<PlaylistPayload?>
 
     //Duplicates the playlist with the given MBID and returns the new playlist MBID
-    suspend fun copyPlaylist(playlistMbid: String?): Resource<CopyPlaylistResponse?>
+    suspend fun copyPlaylist(playlistMbid: String?): Resource<AddCopyPlaylistResponse?>
 
     suspend fun deletePlaylist(playlistMbid: String?): Resource<Unit>
 
@@ -20,6 +21,14 @@ interface PlaylistDataRepository {
         dimension: Int = DEFAULT_PLAYLIST_GRID_SIZE,
         layout: Int = DEFAULT_LAYOUT
     ): Resource<String?>
+
+    //Function to add a playlist
+    suspend fun addPlaylist(playlistPayload: PlaylistPayload):
+            Resource<AddCopyPlaylistResponse?>
+
+    //Edit a playlist
+    suspend fun editPlaylist(playlistPayload: PlaylistPayload, playlistMbid: String?):
+            Resource<EditPlaylistResponse?>
 
     companion object {
         const val DEFAULT_PLAYLIST_GRID_SIZE = 3

--- a/app/src/main/java/org/listenbrainz/android/repository/playlists/PlaylistDataRepositoryImpl.kt
+++ b/app/src/main/java/org/listenbrainz/android/repository/playlists/PlaylistDataRepositoryImpl.kt
@@ -2,7 +2,8 @@ package org.listenbrainz.android.repository.playlists
 
 import jakarta.inject.Inject
 import org.listenbrainz.android.model.ResponseError
-import org.listenbrainz.android.model.playlist.CopyPlaylistResponse
+import org.listenbrainz.android.model.playlist.AddCopyPlaylistResponse
+import org.listenbrainz.android.model.playlist.EditPlaylistResponse
 import org.listenbrainz.android.model.playlist.PlaylistPayload
 import org.listenbrainz.android.service.PlaylistService
 import org.listenbrainz.android.util.Resource
@@ -19,7 +20,7 @@ class PlaylistDataRepositoryImpl @Inject constructor(
             playlistService.getPlaylist(playlistMbid)
         }
 
-    override suspend fun copyPlaylist(playlistMbid: String?): Resource<CopyPlaylistResponse?> =
+    override suspend fun copyPlaylist(playlistMbid: String?): Resource<AddCopyPlaylistResponse?> =
         parseResponse {
             if (playlistMbid.isNullOrEmpty()) return ResponseError.BAD_REQUEST.asResource()
             playlistService.copyPlaylist(playlistMbid)
@@ -47,6 +48,25 @@ class PlaylistDataRepositoryImpl @Inject constructor(
             }
         } catch (e: Exception) {
             Resource(Resource.Status.FAILED, null)
+        }
+    }
+
+    override suspend fun addPlaylist(playlistPayload: PlaylistPayload): Resource<AddCopyPlaylistResponse?> {
+        return parseResponse {
+            if(playlistPayload.playlist.title.isNullOrEmpty())
+                return ResponseError.BAD_REQUEST.asResource()
+            playlistService.createPlaylist(playlistPayload)
+        }
+    }
+
+    override suspend fun editPlaylist(
+        playlistPayload: PlaylistPayload,
+        playlistMbid: String?
+    ): Resource<EditPlaylistResponse?> {
+        return parseResponse {
+            if(playlistMbid.isNullOrEmpty())
+                return ResponseError.BAD_REQUEST.asResource()
+            playlistService.editPlaylist(playlistPayload, playlistMbid)
         }
     }
 

--- a/app/src/main/java/org/listenbrainz/android/service/PlaylistService.kt
+++ b/app/src/main/java/org/listenbrainz/android/service/PlaylistService.kt
@@ -1,10 +1,12 @@
 package org.listenbrainz.android.service
 
 import okhttp3.ResponseBody
-import org.listenbrainz.android.model.playlist.CopyPlaylistResponse
+import org.listenbrainz.android.model.playlist.AddCopyPlaylistResponse
+import org.listenbrainz.android.model.playlist.EditPlaylistResponse
 import org.listenbrainz.android.model.playlist.PlaylistPayload
 import retrofit2.Call
 import retrofit2.Response
+import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
@@ -15,7 +17,7 @@ interface PlaylistService {
     suspend fun getPlaylist(@Path("playlist_mbid") playlistMbid: String): Response<PlaylistPayload?>
 
     @POST("playlist/{playlist_mbid}/copy")
-    suspend fun copyPlaylist(@Path("playlist_mbid") playlistMbid: String): Response<CopyPlaylistResponse?>
+    suspend fun copyPlaylist(@Path("playlist_mbid") playlistMbid: String): Response<AddCopyPlaylistResponse?>
 
     @POST("art/playlist/{playlist_mbid}/{dimension}/{layout}")
     fun getPlaylistCoverArt(
@@ -26,4 +28,13 @@ interface PlaylistService {
 
     @POST("playlist/{playlist_mbid}/delete")
     suspend fun deletePlaylist(@Path("playlist_mbid") playlistMbid: String): Response<Unit>
+
+    @POST("playlist/create")
+    suspend fun createPlaylist(@Body playlistPayload: PlaylistPayload): Response<AddCopyPlaylistResponse?>
+
+    @POST("playlist/edit/{playlist_mbid}")
+    suspend fun editPlaylist(
+        @Body playlistPayload: PlaylistPayload,
+        @Path("playlist_mbid") playlistMbid: String
+    ): Response<EditPlaylistResponse?>
 }

--- a/app/src/main/java/org/listenbrainz/android/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/navigation/AppNavigation.kt
@@ -28,7 +28,6 @@ import org.listenbrainz.android.ui.screens.artist.ArtistScreen
 import org.listenbrainz.android.ui.screens.brainzplayer.BrainzPlayerScreen
 import org.listenbrainz.android.ui.screens.explore.ExploreScreen
 import org.listenbrainz.android.ui.screens.feed.FeedScreen
-import org.listenbrainz.android.ui.screens.playlist.CreateEditPlaylistScreen
 import org.listenbrainz.android.ui.screens.profile.LoginScreen
 import org.listenbrainz.android.ui.screens.profile.ProfileScreen
 import org.listenbrainz.android.ui.screens.settings.SettingsScreen
@@ -64,12 +63,6 @@ fun AppNavigation(
 
     fun goToAlbumPage(mbid: String) {
         navController.navigate("album/${mbid}") {
-            defaultNavOptions()
-        }
-    }
-
-    fun goToAddEditPlaylistScreen(mbid: String?) {
-        navController.navigate("${AppNavigationItem.AddEditPlaylistScreen.route}/${mbid}"){
             defaultNavOptions()
         }
     }
@@ -121,7 +114,6 @@ fun AppNavigation(
                 snackbarState = snackbarState,
                 goToUserProfile = ::goToUserProfile,
                 goToArtistPage = ::goToArtistPage,
-                goToAddEditPlaylistScreen = ::goToAddEditPlaylistScreen
             )
         }
         appComposable(
@@ -168,25 +160,6 @@ fun AppNavigation(
             } else {
                 AlbumScreen(albumMbid = albumMbid, snackBarState = snackbarState)
             }
-        }
-
-        appComposable(
-            route = "${AppNavigationItem.AddEditPlaylistScreen.route}/{mbid}",
-            arguments = listOf(
-                navArgument("mbid") {
-                    type = NavType.StringType
-                    nullable = true
-                }
-            )
-        ) {
-            val playlistMbid = it.arguments?.getString("mbid")
-            CreateEditPlaylistScreen(
-                mbid = playlistMbid,
-                onNavigateUP = {
-                    navController.navigateUp()
-                },
-                snackbarHostState = snackbarState
-            )
         }
     }
 }

--- a/app/src/main/java/org/listenbrainz/android/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/navigation/AppNavigation.kt
@@ -1,8 +1,6 @@
 package org.listenbrainz.android.ui.navigation
 
 import androidx.compose.animation.AnimatedContentScope
-import androidx.compose.animation.EnterTransition
-import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -23,20 +21,18 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
-import androidx.navigation.navigation
 import kotlinx.coroutines.flow.first
-import okhttp3.Route
 import org.listenbrainz.android.model.AppNavigationItem
 import org.listenbrainz.android.ui.screens.album.AlbumScreen
 import org.listenbrainz.android.ui.screens.artist.ArtistScreen
 import org.listenbrainz.android.ui.screens.brainzplayer.BrainzPlayerScreen
 import org.listenbrainz.android.ui.screens.explore.ExploreScreen
 import org.listenbrainz.android.ui.screens.feed.FeedScreen
+import org.listenbrainz.android.ui.screens.playlist.CreateEditPlaylistScreen
 import org.listenbrainz.android.ui.screens.profile.LoginScreen
 import org.listenbrainz.android.ui.screens.profile.ProfileScreen
 import org.listenbrainz.android.ui.screens.settings.SettingsScreen
 import org.listenbrainz.android.viewmodel.DashBoardViewModel
-import org.listenbrainz.android.viewmodel.UserViewModel
 
 @Composable
 fun AppNavigation(
@@ -68,6 +64,12 @@ fun AppNavigation(
 
     fun goToAlbumPage(mbid: String) {
         navController.navigate("album/${mbid}") {
+            defaultNavOptions()
+        }
+    }
+
+    fun goToAddEditPlaylistScreen(mbid: String?) {
+        navController.navigate("${AppNavigationItem.AddEditPlaylistScreen.route}/${mbid}"){
             defaultNavOptions()
         }
     }
@@ -119,6 +121,7 @@ fun AppNavigation(
                 snackbarState = snackbarState,
                 goToUserProfile = ::goToUserProfile,
                 goToArtistPage = ::goToArtistPage,
+                goToAddEditPlaylistScreen = ::goToAddEditPlaylistScreen
             )
         }
         appComposable(
@@ -165,6 +168,25 @@ fun AppNavigation(
             } else {
                 AlbumScreen(albumMbid = albumMbid, snackBarState = snackbarState)
             }
+        }
+
+        appComposable(
+            route = "${AppNavigationItem.AddEditPlaylistScreen.route}/{mbid}",
+            arguments = listOf(
+                navArgument("mbid") {
+                    type = NavType.StringType
+                    nullable = true
+                }
+            )
+        ) {
+            val playlistMbid = it.arguments?.getString("mbid")
+            CreateEditPlaylistScreen(
+                mbid = playlistMbid,
+                onNavigateUP = {
+                    navController.navigateUp()
+                },
+                snackbarHostState = snackbarState
+            )
         }
     }
 }

--- a/app/src/main/java/org/listenbrainz/android/ui/navigation/TopBar.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/navigation/TopBar.kt
@@ -46,6 +46,7 @@ fun TopBar(
             AppNavigationItem.About.route -> AppNavigationItem.About.title
             "${AppNavigationItem.Artist.route}/{mbid}" -> AppNavigationItem.Artist.title
             "${AppNavigationItem.Album.route}/{mbid}" -> AppNavigationItem.Album.title
+            "${AppNavigationItem.AddEditPlaylistScreen.route}/{mbid}" -> AppNavigationItem.AddEditPlaylistScreen.title
             else -> ""
         }
     } ?: "ListenBrainz"

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/playlist/AddEditPlaylistScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/playlist/AddEditPlaylistScreen.kt
@@ -32,10 +32,12 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.SheetState
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -64,10 +66,12 @@ import org.listenbrainz.android.ui.theme.lb_purple
 import org.listenbrainz.android.ui.theme.lb_purple_night
 import org.listenbrainz.android.viewmodel.PlaylistDataViewModel
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CreateEditPlaylistScreen(
     viewModel: PlaylistDataViewModel = hiltViewModel(),
     snackbarHostState: SnackbarHostState,
+    bottomSheetState: SheetState,
     mbid: String?,
     onNavigateUP: () -> Unit
 ) {
@@ -83,6 +87,10 @@ fun CreateEditPlaylistScreen(
             if (uiState.error != null)
                 snackbarHostState.showSnackbar(uiState.error?.toast ?: "Some error occurred")
         }
+    }
+
+    LaunchedEffect(uiState.createEditScreenUIState.isSearching) {
+        bottomSheetState.expand()
     }
 
     AnimatedContent(uiState.createEditScreenUIState.isLoading) { isLoading ->
@@ -135,7 +143,12 @@ fun CreateEditPlaylistScreen(
                 }
             }
         } else {
-            LoadingAnimation()
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.Center
+            ) {
+                LoadingAnimation()
+            }
         }
     }
 }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/playlist/AddEditPlaylistScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/playlist/AddEditPlaylistScreen.kt
@@ -23,6 +23,8 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.AssistChip
@@ -50,9 +52,12 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -167,11 +172,13 @@ private fun CreateEditPlaylistScreenBase(
     onUsernameQueryChange: (String) -> Unit,
     onCancel: () -> Unit
 ) {
+    val localFocusManager = LocalFocusManager.current
     val lazyListState = rememberLazyListState()
 
     LaunchedEffect(uiState.isSearching) {
         lazyListState.animateScrollToItem(
-            lazyListState.layoutInfo.totalItemsCount - 1
+            //Here 4 is the index of the Collaborator Input Field.
+            4
         )
     }
 
@@ -196,7 +203,15 @@ private fun CreateEditPlaylistScreenBase(
                 placeholderText = "Enter playlist name",
                 modifier = Modifier
                     .widthIn(max = 400.dp)
-                    .fillMaxWidth(), isError = uiState.emptyTitleFieldError
+                    .fillMaxWidth(), isError = uiState.emptyTitleFieldError,
+                keyboardOptions = KeyboardOptions.Default.copy(
+                    imeAction = ImeAction.Next
+                ),
+                keyboardActions  = KeyboardActions(
+                    onNext = {
+                        localFocusManager.moveFocus(FocusDirection.Down)
+                    }
+                )
             )
 
             Spacer(modifier = Modifier.height(24.dp))
@@ -233,7 +248,8 @@ private fun CreateEditPlaylistScreenBase(
                     checked = uiState.isPublic,
                     onCheckedChange = onVisibilityChange,
                     colors = CheckboxDefaults.colors().copy(
-                        checkedBoxColor = lb_purple_night
+                        checkedBoxColor = lb_purple_night,
+                        checkedBorderColor = ListenBrainzTheme.colorScheme.listenText
                     )
                 )
                 Text(
@@ -279,7 +295,15 @@ private fun CreateEditPlaylistScreenBase(
                 username = uiState.collaboratorQueryText,
                 onCollaboratorAdded = { onCollaboratorAdded(it) },
                 onUsernameQueryChange = { onUsernameQueryChange(it) },
-                isSearching = uiState.isSearching
+                isSearching = uiState.isSearching,
+                keyboardOptions = KeyboardOptions.Default.copy(
+                    imeAction = ImeAction.Done
+                ),
+                keyboardActions = KeyboardActions(
+                    onDone = {
+                        localFocusManager.clearFocus()
+                    }
+                )
             )
 
             Spacer(modifier = Modifier.height(32.dp))
@@ -379,7 +403,9 @@ fun CollaboratorInputField(
     allUsers: List<String>,
     onCollaboratorAdded: (String) -> Unit,
     onUsernameQueryChange: (String) -> Unit,
-    isSearching: Boolean
+    isSearching: Boolean,
+    keyboardActions: KeyboardActions,
+    keyboardOptions: KeyboardOptions
 ) {
     var expanded by remember { mutableStateOf(false) }
     Column(
@@ -399,7 +425,9 @@ fun CollaboratorInputField(
                 .onFocusChanged {
                     if (!it.hasFocus)
                         expanded = false
-                }
+                },
+            keyboardOptions = keyboardOptions,
+            keyboardActions = keyboardActions
         )
         if (expanded) {
             if (!isSearching)
@@ -438,7 +466,9 @@ private fun PlaylistTextField(
     value: String,
     onValueChange: (String) -> Unit,
     placeholderText: String,
-    isError: Boolean = false
+    isError: Boolean = false,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default
 ) {
     OutlinedTextField(
         modifier = modifier,
@@ -455,7 +485,9 @@ private fun PlaylistTextField(
         supportingText = {
             if (isError)
                 Text("Playlist title must not be empty.")
-        }
+        },
+        keyboardActions = keyboardActions,
+        keyboardOptions = keyboardOptions
     )
 }
 

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/playlist/AddEditPlaylistScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/playlist/AddEditPlaylistScreen.kt
@@ -1,2 +1,3 @@
 package org.listenbrainz.android.ui.screens.playlist
 
+

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/playlist/AddEditPlaylistScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/playlist/AddEditPlaylistScreen.kt
@@ -1,3 +1,489 @@
 package org.listenbrainz.android.ui.screens.playlist
 
+import android.content.res.Configuration
+import android.widget.Toast
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import kotlinx.coroutines.launch
+import org.listenbrainz.android.ui.components.LoadingAnimation
+import org.listenbrainz.android.ui.screens.feed.RetryButton
+import org.listenbrainz.android.ui.theme.ListenBrainzTheme
+import org.listenbrainz.android.ui.theme.lb_orange
+import org.listenbrainz.android.ui.theme.lb_purple
+import org.listenbrainz.android.ui.theme.lb_purple_night
+import org.listenbrainz.android.viewmodel.PlaylistDataViewModel
 
+@Composable
+fun CreateEditPlaylistScreen(
+    viewModel: PlaylistDataViewModel = hiltViewModel(),
+    snackbarHostState: SnackbarHostState,
+    mbid: String?,
+    onNavigateUP: () -> Unit
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(Unit) {
+        viewModel.getInitialData(mbid)
+    }
+    LaunchedEffect(uiState.error) {
+        scope.launch {
+            if (uiState.error != null)
+                snackbarHostState.showSnackbar(uiState.error?.toast ?: "Some error occurred")
+        }
+    }
+
+    AnimatedContent(uiState.createEditScreenUIState.isLoading) { isLoading ->
+        if (!isLoading) {
+            if (uiState.createEditScreenUIState.playlistData != null || uiState.createEditScreenUIState.playlistMBID == null)
+                CreateEditPlaylistScreenBase(
+                    collaborators = uiState.createEditScreenUIState.collaboratorSelected,
+                    onCollaboratorAdded = {
+                        viewModel.editPlaylistScreenData(
+                            collaborators = uiState.createEditScreenUIState.collaboratorSelected + it
+                        )
+                    },
+                    onSave = {
+                        viewModel.saveNewOrEditedPlaylist {
+                            scope.launch {
+                                Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
+                                onNavigateUP()
+                            }
+                        }
+                    },
+                    uiState = uiState.createEditScreenUIState,
+                    onCollaboratorRemove = { user ->
+                        viewModel.editPlaylistScreenData(
+                            collaborators = uiState.createEditScreenUIState.collaboratorSelected.filter { it != user }
+                        )
+                    },
+                    onNameChange = {
+                        viewModel.editPlaylistScreenData(name = it)
+                    },
+                    onDescriptionChange = {
+                        viewModel.editPlaylistScreenData(description = it)
+                    },
+                    onVisibilityChange = {
+                        viewModel.editPlaylistScreenData(isPublic = it)
+                    },
+                    onCancel = {
+                        onNavigateUP()
+                    },
+                    onUsernameQueryChange = {
+                        viewModel.queryCollaborators(it)
+                    }
+                )
+            else {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    RetryButton(
+                        modifier = Modifier.align(Alignment.Center)
+                    ) {
+                        viewModel.getInitialData(mbid)
+                    }
+                }
+            }
+        } else {
+            LoadingAnimation()
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun CreateEditPlaylistScreenBase(
+    uiState: CreateEditScreenUIState,
+    collaborators: List<String>,
+    onCollaboratorAdded: (String) -> Unit,
+    onCollaboratorRemove: (String) -> Unit,
+    onSave: () -> Unit,
+    onNameChange: (String) -> Unit,
+    onDescriptionChange: (String) -> Unit,
+    onVisibilityChange: (Boolean) -> Unit,
+    onUsernameQueryChange: (String) -> Unit,
+    onCancel: () -> Unit
+) {
+    val lazyListState = rememberLazyListState()
+
+    LaunchedEffect(uiState.isSearching) {
+        lazyListState.animateScrollToItem(
+            lazyListState.layoutInfo.totalItemsCount - 1
+        )
+    }
+
+    LazyColumn(
+        state = lazyListState,
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        item {
+            // Name Field
+            Text(
+                "Name",
+                style = ListenBrainzTheme.textStyles.listenTitle,
+                color = ListenBrainzTheme.colorScheme.text,
+                fontSize = 16.sp
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            PlaylistTextField(
+                value = uiState.name,
+                onValueChange = onNameChange,
+                placeholderText = "Enter playlist name",
+                modifier = Modifier
+                    .widthIn(max = 400.dp)
+                    .fillMaxWidth(), isError = uiState.emptyTitleFieldError
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+
+        item {
+
+            // Description Field
+            Text(
+                "Description",
+                style = ListenBrainzTheme.textStyles.listenTitle,
+                color = ListenBrainzTheme.colorScheme.text,
+                fontSize = 16.sp
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            PlaylistTextField(
+                value = uiState.description,
+                onValueChange = onDescriptionChange,
+                placeholderText = "Enter description",
+                modifier = Modifier
+                    .widthIn(max = 400.dp)
+                    .fillMaxWidth()
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+
+        item {
+            // Make Playlist Public Checkbox
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Checkbox(
+                    checked = uiState.isPublic,
+                    onCheckedChange = onVisibilityChange,
+                    colors = CheckboxDefaults.colors().copy(
+                        checkedBoxColor = lb_purple_night
+                    )
+                )
+                Text(
+                    "Make playlist public",
+                    style = ListenBrainzTheme.textStyles.listenTitle,
+                    color = ListenBrainzTheme.colorScheme.text,
+                    fontSize = 16.sp
+                )
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+
+        item {
+            // Collaborators Section
+            Text(
+                "Collaborators",
+                color = ListenBrainzTheme.colorScheme.text,
+                style = ListenBrainzTheme.textStyles.listenTitle,
+                fontSize = 16.sp
+            )
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                collaborators.forEach { user ->
+                    CollaboratorAssistChip(
+                        userName = user,
+                        onRemove = {
+                            onCollaboratorRemove(user)
+                        }
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+
+        item {
+            // Collaborator Input Field with Suggestions
+            CollaboratorInputField(
+                allUsers = uiState.usersSearched.map { it.username },
+                username = uiState.collaboratorQueryText,
+                onCollaboratorAdded = { onCollaboratorAdded(it) },
+                onUsernameQueryChange = { onUsernameQueryChange(it) },
+                isSearching = uiState.isSearching
+            )
+
+            Spacer(modifier = Modifier.height(32.dp))
+        }
+
+
+        item {
+            // Buttons Row
+            Row(
+                modifier = Modifier
+                    .widthIn(max = 600.dp)
+                    .fillMaxWidth()
+                    .padding(8.dp),
+                horizontalArrangement = Arrangement.SpaceEvenly
+            ) {
+                Button(
+                    enabled = !uiState.isSaving,
+                    onClick = { onCancel() },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = Color.Gray,
+                        contentColor = Color.White
+                    )
+                ) {
+                    Text("Cancel")
+                }
+                Spacer(
+                    Modifier
+                        .width(8.dp)
+                        .weight(0.1f)
+                )
+                Button(
+                    onClick = { onSave() },
+                    enabled = !uiState.isSaving,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = if (isSystemInDarkTheme()) lb_orange else lb_purple,
+                        contentColor = Color.White
+                    )
+                ) {
+                    Text(
+                        if (uiState.playlistMBID == null)
+                            "Create"
+                        else "Save"
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun CollaboratorAssistChip(
+    modifier: Modifier = Modifier,
+    userName: String,
+    onRemove: () -> Unit
+) {
+    AssistChip(
+        modifier = modifier,
+        shape = RoundedCornerShape(16.dp),
+        onClick = { onRemove() },
+        colors = AssistChipDefaults.assistChipColors().copy(
+            containerColor = lb_purple_night,
+            labelColor = Color.White
+        ),
+        label = { Text(userName) },
+        trailingIcon = {
+            Box(
+                modifier = Modifier.size(20.dp)
+            ) {
+                Canvas(Modifier.fillMaxSize()) {
+                    drawCircle(
+                        color = Color.White,
+                    )
+                }
+                Icon(
+                    Icons.Default.Close, contentDescription = "Remove",
+                    tint = lb_purple_night,
+                    modifier = Modifier
+                        .fillMaxSize(0.8f)
+                        .align(Alignment.Center)
+                )
+            }
+        }
+    )
+
+}
+
+
+@Composable
+fun CollaboratorInputField(
+    username: String,
+    allUsers: List<String>,
+    onCollaboratorAdded: (String) -> Unit,
+    onUsernameQueryChange: (String) -> Unit,
+    isSearching: Boolean
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Column(
+        modifier = Modifier
+            .widthIn(max = 400.dp)
+            .fillMaxWidth()
+    ) {
+        PlaylistTextField(
+            value = username,
+            onValueChange = {
+                onUsernameQueryChange(it)
+                expanded = it.isNotEmpty()
+            },
+            placeholderText = "Enter Collaborators",
+            modifier = Modifier
+                .fillMaxWidth()
+                .onFocusChanged {
+                    if (!it.hasFocus)
+                        expanded = false
+                }
+        )
+        if (expanded) {
+            if (!isSearching)
+                allUsers.filterIndexed { index, s -> index < 20 }.forEach() { username ->
+                    SearchItem(text = username) {
+                        onCollaboratorAdded(username)
+                        expanded = false
+                    }
+                } else {
+                Box(Modifier.fillMaxWidth()) {
+                    CircularProgressIndicator(
+                        color = ListenBrainzTheme.colorScheme.listenText,
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .padding(8.dp)
+                    )
+                }
+            }
+            if (!isSearching && allUsers.isEmpty()) {
+                Box(Modifier.fillMaxWidth()) {
+                    Text(
+                        "No users found",
+                        modifier = Modifier.align(Alignment.Center),
+                        color = ListenBrainzTheme.colorScheme.text.copy(alpha = 0.8f)
+                    )
+                }
+            }
+        }
+
+    }
+}
+
+@Composable
+private fun PlaylistTextField(
+    modifier: Modifier = Modifier,
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholderText: String,
+    isError: Boolean = false
+) {
+    OutlinedTextField(
+        modifier = modifier,
+        value = value,
+        onValueChange = onValueChange,
+        colors = OutlinedTextFieldDefaults.colors().copy(
+            focusedIndicatorColor = ListenBrainzTheme.colorScheme.text.copy(alpha = 0.5f),
+            cursorColor = ListenBrainzTheme.colorScheme.text.copy(alpha = 0.8f)
+        ),
+        placeholder = {
+            Text(placeholderText)
+        },
+        isError = isError,
+        supportingText = {
+            if (isError)
+                Text("Playlist title must not be empty.")
+        }
+    )
+}
+
+@Composable
+private fun SearchItem(
+    modifier: Modifier = Modifier,
+    text: String,
+    onClick: () -> Unit
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable { onClick() }
+    ) {
+        Text(
+            modifier = Modifier.padding(8.dp),
+            text = text,
+            color = ListenBrainzTheme.colorScheme.text
+        )
+        HorizontalDivider(modifier = Modifier.fillMaxWidth())
+    }
+}
+
+
+@Composable
+@Preview(showBackground = true)
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+fun CreateEditPlaylistScreenPreview() {
+    ListenBrainzTheme {
+        val allUsers = listOf("raven0us", "jasje", "hemang", "musiclover") // Example usernames
+        CreateEditPlaylistScreenBase(
+            collaborators = allUsers,
+            onCollaboratorAdded = {},
+            onSave = {},
+            uiState = CreateEditScreenUIState(),
+            onCollaboratorRemove = { },
+            onNameChange = { },
+            onDescriptionChange = { },
+            onVisibilityChange = { },
+            onCancel = { },
+            onUsernameQueryChange = {},
+        )
+    }
+}

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/playlist/PlaylistDataUIState.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/playlist/PlaylistDataUIState.kt
@@ -1,0 +1,26 @@
+package org.listenbrainz.android.ui.screens.playlist
+
+import org.listenbrainz.android.model.ResponseError
+import org.listenbrainz.android.model.User
+import org.listenbrainz.android.model.playlist.PlaylistData
+
+data class PlaylistDataUIState(
+    val isLoading: Boolean = false,
+    val createEditScreenUIState: CreateEditScreenUIState = CreateEditScreenUIState(),
+    val error: ResponseError? = null
+)
+
+data class CreateEditScreenUIState(
+    val collaboratorQueryText: String = "",
+    val isSaving: Boolean = false,
+    val isSearching: Boolean = false,
+    val isLoading: Boolean = true,
+    val name: String = "",
+    val playlistData: PlaylistData? = null,
+    val description: String = "",
+    val isPublic: Boolean = false,
+    val collaboratorSelected: List<String> = emptyList(),
+    val usersSearched: List<User> = emptyList(),
+    val playlistMBID: String? = null,
+    val emptyTitleFieldError: Boolean = false
+)

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/BaseProfileScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/BaseProfileScreen.kt
@@ -50,6 +50,7 @@ import org.listenbrainz.android.ui.theme.lb_purple
 import org.listenbrainz.android.ui.theme.new_app_bg_light
 import org.listenbrainz.android.viewmodel.FeedViewModel
 import org.listenbrainz.android.viewmodel.ListensViewModel
+import org.listenbrainz.android.viewmodel.PlaylistDataViewModel
 import org.listenbrainz.android.viewmodel.SocialViewModel
 import org.listenbrainz.android.viewmodel.UserViewModel
 
@@ -63,8 +64,8 @@ fun BaseProfileScreen(
     feedViewModel: FeedViewModel = hiltViewModel(),
     listensViewModel: ListensViewModel = hiltViewModel(),
     socialViewModel: SocialViewModel = hiltViewModel(),
-    goToArtistPage: (String) -> Unit,
-    goToAddEditPlaylistScreen: (String?)->Unit
+    playlistDataViewModel: PlaylistDataViewModel = hiltViewModel(),
+    goToArtistPage: (String) -> Unit
 ) {
     val pagerState = rememberPagerState { ProfileScreenTab.entries.size }
     val scope = rememberCoroutineScope()
@@ -228,7 +229,7 @@ fun BaseProfileScreen(
                         ProfileScreenTab.PLAYLISTS.index -> UserPlaylistScreen(
                             snackbarState = snackbarState,
                             userViewModel = viewModel,
-                            goToAddEditPlaylistScreen = goToAddEditPlaylistScreen
+                            playlistViewModel = playlistDataViewModel
                         )
                     }
                 }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/BaseProfileScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/BaseProfileScreen.kt
@@ -64,6 +64,7 @@ fun BaseProfileScreen(
     listensViewModel: ListensViewModel = hiltViewModel(),
     socialViewModel: SocialViewModel = hiltViewModel(),
     goToArtistPage: (String) -> Unit,
+    goToAddEditPlaylistScreen: (String?)->Unit
 ) {
     val pagerState = rememberPagerState { ProfileScreenTab.entries.size }
     val scope = rememberCoroutineScope()
@@ -226,7 +227,8 @@ fun BaseProfileScreen(
 
                         ProfileScreenTab.PLAYLISTS.index -> UserPlaylistScreen(
                             snackbarState = snackbarState,
-                            userViewModel = viewModel
+                            userViewModel = viewModel,
+                            goToAddEditPlaylistScreen = goToAddEditPlaylistScreen
                         )
                     }
                 }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/ProfileScreen.kt
@@ -48,8 +48,7 @@ fun ProfileScreen(
     username: String?,
     snackbarState: SnackbarHostState,
     goToUserProfile: (String) -> Unit,
-    goToArtistPage: (String) -> Unit,
-    goToAddEditPlaylistScreen: (String?) ->Unit
+    goToArtistPage: (String) -> Unit
 ) {
     val scrollState = rememberScrollState()
     val uiState = viewModel.uiState.collectAsState()
@@ -73,8 +72,7 @@ fun ProfileScreen(
                 snackbarState = snackbarState,
                 uiState = uiState.value,
                 goToUserProfile = goToUserProfile,
-                goToArtistPage = goToArtistPage,
-                goToAddEditPlaylistScreen = goToAddEditPlaylistScreen
+                goToArtistPage = goToArtistPage
             )
         }
         else -> LoginScreen {

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/ProfileScreen.kt
@@ -49,6 +49,7 @@ fun ProfileScreen(
     snackbarState: SnackbarHostState,
     goToUserProfile: (String) -> Unit,
     goToArtistPage: (String) -> Unit,
+    goToAddEditPlaylistScreen: (String?) ->Unit
 ) {
     val scrollState = rememberScrollState()
     val uiState = viewModel.uiState.collectAsState()
@@ -72,7 +73,8 @@ fun ProfileScreen(
                 snackbarState = snackbarState,
                 uiState = uiState.value,
                 goToUserProfile = goToUserProfile,
-                goToArtistPage = goToArtistPage
+                goToArtistPage = goToArtistPage,
+                goToAddEditPlaylistScreen = goToAddEditPlaylistScreen
             )
         }
         else -> LoginScreen {

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/playlists/PlaylistCardViews.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/playlists/PlaylistCardViews.kt
@@ -44,7 +44,7 @@ import org.listenbrainz.android.ui.theme.ListenBrainzTheme
  * @param errorCoverArt Int - Image to display when cover art could not be loaded
  * @param onClickCard () -> Unit - Function to be called when card is clicked
  * @param onDropdownClick (PlaylistDropdownItems) -> Unit - Function to be called when dropdown item is clicked
- * @param isUserSelf Tells whether the current profile belongs to the logged in user
+ * @param canUserEdit Tells whether the current profile belongs to the logged in user
  */
 @Composable
 fun PlaylistGridViewCard(
@@ -55,7 +55,7 @@ fun PlaylistGridViewCard(
     @DrawableRes errorCoverArt: Int = R.drawable.playlist_card_bg1,
     onClickCard: () -> Unit,
     onDropdownClick: (PlaylistDropdownItems) -> Unit,
-    isUserSelf: Boolean
+    canUserEdit: Boolean
 ) {
     var isDropdownEnabled by remember {
         mutableStateOf(false)
@@ -121,7 +121,7 @@ fun PlaylistGridViewCard(
                             onDropdownClick(it)
                             isDropdownEnabled = false
                         },
-                        isPrivateAllowed = isUserSelf
+                        isPrivateAllowed = canUserEdit
                     )
                 }
             }
@@ -150,7 +150,7 @@ fun PlaylistListViewCard(
     @DrawableRes errorCoverArt: Int = R.drawable.playlist_card_bg1,
     onDropdownClick: (PlaylistDropdownItems) -> Unit,
     onClickCard: () -> Unit,
-    isUserSelf: Boolean
+    canUserEdit: Boolean
 ) {
     var isDropdownEnabled by remember {
         mutableStateOf(false)
@@ -199,7 +199,7 @@ fun PlaylistListViewCard(
                     onDropdownClick(it)
                     isDropdownEnabled = false
                 },
-                isPrivateAllowed = isUserSelf
+                isPrivateAllowed = canUserEdit
             )
         },
         onDropdownIconClick = {
@@ -221,7 +221,7 @@ fun PlaylistGridViewCardPreview() {
             updatedDate = "Feb 9",
             onClickCard = { },
             onDropdownClick = { },
-            isUserSelf = false
+            canUserEdit = false
         )
     }
 }
@@ -239,7 +239,7 @@ fun PlaylistListViewCardPreview() {
             updatedDate = "Feb 9",
             onClickCard = {},
             onDropdownClick = {},
-            isUserSelf = false
+            canUserEdit = false
         )
     }
 }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/playlists/UserPlaylistScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/playlists/UserPlaylistScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -41,7 +42,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -88,7 +88,9 @@ fun UserPlaylistScreen(
             userPlaylistsData.loadState.refresh is LoadState.Loading
         }
     }
-    val sheetState = rememberModalBottomSheetState()
+    val sheetState = rememberModalBottomSheetState(
+        skipPartiallyExpanded = true
+    )
     var isBottomSheetVisible by rememberSaveable { mutableStateOf(false) }
 
     val pullRefreshState = rememberPullRefreshState(
@@ -198,7 +200,8 @@ fun UserPlaylistScreen(
                 currentMBID = null
                 isBottomSheetVisible = false
             },
-            sheetState = sheetState
+            sheetState = sheetState,
+            modifier = Modifier.statusBarsPadding(),
         ) {
             CreateEditPlaylistScreen(
                 viewModel = playlistViewModel,
@@ -369,7 +372,7 @@ private fun UserPlaylistScreenBase(
             Icon(
                 Icons.Default.Add,
                 contentDescription = "Floating action button to create playlist",
-                tint = Color.White
+                tint = ListenBrainzTheme.colorScheme.onLbSignature
             )
         }
 

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/playlists/UserPlaylistScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/playlists/UserPlaylistScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.icons.Icons
@@ -246,7 +247,7 @@ private fun UserPlaylistScreenBase(
                                                 onDropdownClick = {
                                                     onDropdownItemClick(it, playlist)
                                                 },
-                                                isUserSelf = isUserSelf
+                                                canUserEdit = isUserSelf && !isCurrentScreenCollab
                                             )
                                             Spacer(modifier = Modifier.height(8.dp))
                                         }
@@ -279,7 +280,7 @@ private fun UserPlaylistScreenBase(
                                                 onDropdownClick = {
                                                     onDropdownItemClick(it, playlist)
                                                 },
-                                                isUserSelf = isUserSelf
+                                                canUserEdit = isUserSelf &&!isCurrentScreenCollab
                                             )
                                         }
                                     }
@@ -326,7 +327,9 @@ private fun UserPlaylistScreenBase(
                 onCreatePlaylistClick()
             },
             backgroundColor = lb_purple_night,
+            shape = RoundedCornerShape(16.dp),
             modifier = Modifier.align(Alignment.BottomEnd)
+                .padding(ListenBrainzTheme.paddings.defaultPadding)
         ) {
             Icon(Icons.Default.Add,
                 contentDescription = "Floating action button to create playlist",

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/playlists/UserPlaylistScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/playlists/UserPlaylistScreen.kt
@@ -16,6 +16,9 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.FloatingActionButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.PullRefreshState
 import androidx.compose.material.pullrefresh.pullRefresh
@@ -33,6 +36,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -46,6 +50,7 @@ import org.listenbrainz.android.ui.components.ToggleChips
 import org.listenbrainz.android.ui.screens.feed.RetryButton
 import org.listenbrainz.android.ui.screens.profile.createdforyou.formatDateLegacy
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
+import org.listenbrainz.android.ui.theme.lb_purple_night
 import org.listenbrainz.android.util.Utils.shareLink
 import org.listenbrainz.android.viewmodel.UserViewModel
 
@@ -53,7 +58,8 @@ import org.listenbrainz.android.viewmodel.UserViewModel
 @Composable
 fun UserPlaylistScreen(
     snackbarState: SnackbarHostState,
-    userViewModel: UserViewModel
+    userViewModel: UserViewModel,
+    goToAddEditPlaylistScreen: (String?)->Unit
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -125,6 +131,9 @@ fun UserPlaylistScreen(
             userPlaylistsData.refresh()
         },
         isUserSelf = uiState.isSelf,
+        onCreatePlaylistClick = {
+            goToAddEditPlaylistScreen(null)
+        },
         onDropdownItemClick = { menuItem, playlist ->
             when (menuItem) {
                 PlaylistDropdownItems.DUPLICATE -> {
@@ -164,11 +173,7 @@ fun UserPlaylistScreen(
                 }
 
                 PlaylistDropdownItems.EDIT -> {
-                    Toast.makeText(
-                        context,
-                        "Yet to be implemented",
-                        Toast.LENGTH_SHORT
-                    ).show()
+                    goToAddEditPlaylistScreen(playlist.getPlaylistMBID())
                 }
             }
         }
@@ -193,7 +198,8 @@ private fun UserPlaylistScreenBase(
     onClickPlaylistViewChange: () -> Unit,
     onClickPlaylist: (UserPlaylist) -> Unit,
     onRetry: () -> Unit,
-    onDropdownItemClick: (PlaylistDropdownItems, UserPlaylist) -> Unit
+    onDropdownItemClick: (PlaylistDropdownItems, UserPlaylist) -> Unit,
+    onCreatePlaylistClick: ()->Unit
 ) {
     Box(
         modifier = Modifier
@@ -314,6 +320,18 @@ private fun UserPlaylistScreenBase(
             backgroundColor = ListenBrainzTheme.colorScheme.level1,
             state = pullRefreshState
         )
+        
+        FloatingActionButton(
+            onClick = {
+                onCreatePlaylistClick()
+            },
+            backgroundColor = lb_purple_night,
+            modifier = Modifier.align(Alignment.BottomEnd)
+        ) {
+            Icon(Icons.Default.Add,
+                contentDescription = "Floating action button to create playlist",
+                tint = Color.White)
+        }
 
     }
 }
@@ -413,7 +431,8 @@ fun UserPlaylistScreenPreview() {
             onRetry = {},
             onDropdownItemClick = { it, it2 ->
             },
-            isUserSelf = true
+            isUserSelf = true,
+            onCreatePlaylistClick = { },
         )
     }
 }

--- a/app/src/main/java/org/listenbrainz/android/util/CoverArtImageLinkExtractor.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/CoverArtImageLinkExtractor.kt
@@ -4,21 +4,74 @@ package org.listenbrainz.android.util
 //This class extracts the image links from the SVG
 object CoverArtImageLinkExtractor {
 
-    // Function to count the number of images inside anchor tags
+    //We are extracting no of images by counting <image> tags inside anchor tags.
     fun getImageCount(svg: String): Int {
-        val regex = "<a\\s+href=.*?>\\s*<image\\s+".toRegex()
-        return regex.findAll(svg).count()
+        var count = 0
+        var index = 0
+
+        while (true) {
+            index = svg.indexOf("<a", index)
+            if (index == -1) break  // No more <a> tags
+
+            val endIndex = svg.indexOf("</a>", index)
+            if (endIndex == -1) break  // Invalid tag structure
+
+            // Look for <image> tags within the <a> tag
+            var imageIndex = index
+            while (true) {
+                imageIndex = svg.indexOf("<image", imageIndex)
+                if (imageIndex == -1 || imageIndex > endIndex) break
+                count++
+                imageIndex++
+            }
+
+            index = endIndex
+        }
+
+        return count
     }
 
-    // Function to extract image links inside <a> tags
+    // In this function, we are extracting image links from <image> tags
     fun extractImageLinks(svg: String): List<String> {
-        val regex = """<a\s+href=.*?>\s*<image[^>]+?href=["'](.*?)["']""".toRegex()
-        return regex.findAll(svg).map { it.groupValues[1] }.toList()
+        val imageLinks = mutableListOf<String>()
+        var index = 0
+
+        while (true) {
+            index = svg.indexOf("<image", index)
+            if (index == -1) break  // No more <image> tags, exit the loop
+
+            val hrefIndex = svg.indexOf("href=\"", index)
+            if (hrefIndex != -1) {
+                val start = hrefIndex + 6  // Skip 'href="', i.e. move to start of the link
+                val end = svg.indexOf("\"", start)
+                if (end != -1) {
+                    imageLinks.add(svg.substring(start, end))
+                }
+            }
+            index++ // Move to the next occurrence of image tag
+        }
+
+        return imageLinks
     }
 
-    // Function to extract anchor links from <a> tags
+    //In this function we are extracting anchor links from <a> tags, which is used to make the images clickable
     fun extractAnchorLinks(svg: String): List<String> {
-        val regex = """<a\s+href=["'](.*?)["']""".toRegex()
-        return regex.findAll(svg).map { it.groupValues[1] }.toList()
+        val anchorLinks = mutableListOf<String>()
+        var index = 0
+        while (true) {
+            index = svg.indexOf("<a", index)
+            if (index == -1) break  // No more <a> tags
+
+            val hrefIndex = svg.indexOf("href=\"", index)
+            if (hrefIndex != -1) {
+                val start = hrefIndex + 6  // Skip 'href="'
+                val end = svg.indexOf("\"", start)
+                if (end != -1) {
+                    anchorLinks.add(svg.substring(start, end))
+                }
+            }
+            index++
+        }
+        return anchorLinks
     }
 }

--- a/app/src/main/java/org/listenbrainz/android/viewmodel/PlaylistDataViewModel.kt
+++ b/app/src/main/java/org/listenbrainz/android/viewmodel/PlaylistDataViewModel.kt
@@ -1,0 +1,289 @@
+package org.listenbrainz.android.viewmodel
+
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import org.listenbrainz.android.di.IoDispatcher
+import org.listenbrainz.android.model.ResponseError
+import org.listenbrainz.android.model.User
+import org.listenbrainz.android.model.playlist.Extension
+import org.listenbrainz.android.model.playlist.PlaylistData
+import org.listenbrainz.android.model.playlist.PlaylistExtensionData
+import org.listenbrainz.android.model.playlist.PlaylistPayload
+import org.listenbrainz.android.repository.playlists.PlaylistDataRepository
+import org.listenbrainz.android.repository.social.SocialRepository
+import org.listenbrainz.android.ui.screens.playlist.CreateEditScreenUIState
+import org.listenbrainz.android.ui.screens.playlist.PlaylistDataUIState
+import org.listenbrainz.android.util.Resource
+import org.listenbrainz.android.util.Utils
+
+@HiltViewModel
+class PlaylistDataViewModel @Inject constructor(
+    private val repository: PlaylistDataRepository,
+    private val socialRepository: SocialRepository,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+) : BaseViewModel<PlaylistDataUIState>() {
+
+    private val inputQueryFlow = MutableStateFlow("")
+
+    @OptIn(FlowPreview::class)
+    private val queryFlow = inputQueryFlow.asStateFlow().debounce(500).distinctUntilChanged()
+    private val userListFlow = MutableStateFlow<List<User>>(emptyList())
+    private val playlistData = MutableStateFlow<Map<String, PlaylistData>>(emptyMap())
+
+    private val createEditScreenUIStateFlow: MutableStateFlow<CreateEditScreenUIState> =
+        MutableStateFlow(
+            CreateEditScreenUIState()
+        )
+
+    init {
+        viewModelScope.launch(ioDispatcher) {
+            queryFlow.collectLatest { username ->
+                if (username.isEmpty()) {
+                    return@collectLatest
+                }
+                createEditScreenUIStateFlow.emit(createEditScreenUIStateFlow.value.copy(isSearching = true))
+                val result = socialRepository.searchUser(username)
+                createEditScreenUIStateFlow.emit(createEditScreenUIStateFlow.value.copy(isSearching = false))
+                when (result.status) {
+                    Resource.Status.SUCCESS -> userListFlow.emit(result.data?.users ?: emptyList())
+                    Resource.Status.FAILED -> emitError(result.error)
+                    else -> return@collectLatest
+                }
+            }
+        }
+    }
+
+    fun getInitialData(mbid: String?) {
+        var playlist = PlaylistData()
+
+        viewModelScope.launch(ioDispatcher) {
+            if (mbid == null) {
+                createEditScreenUIStateFlow.emit(createEditScreenUIStateFlow.value.copy(isLoading = false))
+                return@launch
+            }
+            createEditScreenUIStateFlow.emit(createEditScreenUIStateFlow.value.copy(isLoading = true))
+            //First check if data is already fetched
+            if (playlistData.value.containsKey(mbid)) {
+                playlist = playlistData.value[mbid]!!
+                createEditScreenUIStateFlow.emit(
+                    createEditScreenUIStateFlow.value.copy(
+                        playlistData = playlist,
+                        isLoading = false,
+                        name = playlist.title ?: "",
+                        description = Utils.removeHtmlTags(playlist.annotation ?: ""),
+                        isPublic = playlist.extension.playlistExtensionData.public ?: false,
+                        playlistMBID = mbid,
+                        collaboratorSelected = playlist.extension.playlistExtensionData.collaborators
+                    )
+                )
+            } else {
+                //Fetch data from API
+                getDataOfPlaylist(mbid, onError = {
+                    emitError(it)
+                }, onSuccess = {
+                    playlist->
+                    createEditScreenUIStateFlow.emit(
+                        createEditScreenUIStateFlow.value.copy(
+                            playlistData = playlist,
+                            isLoading = false,
+                            name = playlist.title ?: "",
+                            description = Utils.removeHtmlTags(playlist.annotation ?: ""),
+                            isPublic = playlist.extension.playlistExtensionData.public ?: false,
+                            playlistMBID = mbid,
+                            collaboratorSelected = playlist.extension.playlistExtensionData.collaborators
+                        )
+                    )
+                })
+            }
+        }
+    }
+
+    private fun getDataOfPlaylist(
+        mbid: String?, onError: suspend (ResponseError?) -> Unit,
+        onSuccess: suspend (PlaylistData) -> Unit
+    ) {
+        viewModelScope.launch(ioDispatcher) {
+            val result = repository.fetchPlaylist(mbid)
+            when (result.status) {
+                Resource.Status.SUCCESS -> {
+                    if (mbid == null) return@launch
+                    if (result.data?.playlist == null) onError(ResponseError.UNKNOWN)
+                    playlistData.emit(playlistData.value + (mbid to result.data?.playlist!!))
+                    onSuccess(result.data.playlist)
+                }
+
+                Resource.Status.FAILED -> onError(result.error)
+                else -> return@launch
+            }
+        }
+    }
+
+    fun editPlaylistScreenData(
+        name: String? = null,
+        description: String? = null,
+        isPublic: Boolean? = null,
+        collaborators: List<String>? = null
+    ) {
+        viewModelScope.launch {
+            createEditScreenUIStateFlow.emit(
+                createEditScreenUIStateFlow.value.copy(
+                    name = name ?: createEditScreenUIStateFlow.value.name,
+                    description = description ?: createEditScreenUIStateFlow.value.description,
+                    isPublic = isPublic ?: createEditScreenUIStateFlow.value.isPublic,
+                    collaboratorSelected = collaborators
+                        ?: createEditScreenUIStateFlow.value.collaboratorSelected,
+                    emptyTitleFieldError = false
+                )
+            )
+        }
+    }
+
+    fun queryCollaborators(query: String) {
+        viewModelScope.launch {
+            inputQueryFlow.emit(query)
+        }
+    }
+
+    fun saveNewOrEditedPlaylist(onSuccess: (String) -> Unit) {
+        viewModelScope.launch(ioDispatcher) {
+            if(createEditScreenUIStateFlow.value.name.isEmpty()){
+                createEditScreenUIStateFlow.emit(createEditScreenUIStateFlow.value.copy(emptyTitleFieldError = true))
+                return@launch
+            }
+            createEditScreenUIStateFlow.emit(createEditScreenUIStateFlow.value.copy(isSaving = true))
+
+            val playlist = PlaylistData(
+                title = createEditScreenUIStateFlow.value.name,
+                annotation = createEditScreenUIStateFlow.value.description,
+                extension = Extension(
+                    playlistExtensionData = PlaylistExtensionData(
+                        public = createEditScreenUIStateFlow.value.isPublic,
+                        collaborators = createEditScreenUIStateFlow.value.collaboratorSelected
+                    )
+                )
+            )
+
+            if (createEditScreenUIStateFlow.value.playlistMBID == null)
+                createPlaylist(playlist, onSuccess = {
+                    createEditScreenUIStateFlow.emit(
+                        createEditScreenUIStateFlow.value.copy(
+                            isSaving = false
+                        )
+                    )
+                    onSuccess("Playlist Saved Successfully!!")
+                },
+                    onError = {
+                        createEditScreenUIStateFlow.emit(
+                            createEditScreenUIStateFlow.value.copy(
+                                isSaving = false
+                            )
+                        )
+                        emitError(it)
+                    })
+            else
+                savePlaylist(
+                    playlist,
+                    createEditScreenUIStateFlow.value.playlistMBID!!,
+                    onSuccess = {
+                        createEditScreenUIStateFlow.emit(
+                            createEditScreenUIStateFlow.value.copy(
+                                isSaving = false
+                            )
+                        )
+                        onSuccess("Playlist Saved Successfully!!")
+                        //Saving data to in-memory cache
+                        val playlists = playlistData.value.toMutableMap()
+                        playlists[createEditScreenUIStateFlow.value.playlistMBID!!] = playlist
+                        playlistData.emit(playlists)
+                    },
+                    onError = {
+                        emitError(it)
+                        createEditScreenUIStateFlow.emit(
+                            createEditScreenUIStateFlow.value.copy(
+                                isSaving = false
+                            )
+                        )
+                    })
+        }
+    }
+
+    private fun savePlaylist(
+        playlistData: PlaylistData, playlistMbid: String, onSuccess: suspend () -> Unit,
+        onError: suspend (ResponseError?) -> Unit
+    ) {
+        viewModelScope.launch(ioDispatcher) {
+            val result = repository.editPlaylist(
+                PlaylistPayload(playlist = playlistData),
+                playlistMbid = playlistMbid
+            )
+            when (result.status) {
+                Resource.Status.SUCCESS -> {
+                    onSuccess()
+                }
+
+                Resource.Status.FAILED -> {
+                    onError(result.error)
+                }
+
+                else -> return@launch
+            }
+        }
+    }
+
+    private fun createPlaylist(
+        playlistData: PlaylistData,
+        onSuccess: suspend () -> Unit,
+        onError: suspend (ResponseError?) -> Unit
+    ) {
+        viewModelScope.launch(ioDispatcher) {
+            val result = repository.addPlaylist(PlaylistPayload(playlist = playlistData))
+            when (result.status) {
+                Resource.Status.SUCCESS -> {
+                    onSuccess()
+                }
+
+                Resource.Status.FAILED -> {
+                    onError(result.error)
+                }
+
+                else -> return@launch
+            }
+        }
+    }
+
+    override val uiState: StateFlow<PlaylistDataUIState> = createUiStateFlow()
+
+    override fun createUiStateFlow(): StateFlow<PlaylistDataUIState> {
+        return combine(
+            createEditScreenUIStateFlow,
+            inputQueryFlow,
+            userListFlow,
+            errorFlow
+        ) { createUiState, inputQuery, users, errorFlow ->
+            PlaylistDataUIState(
+                error = errorFlow,
+                createEditScreenUIState = createUiState.copy(
+                    collaboratorQueryText = inputQuery,
+                    usersSearched = users
+                )
+            )
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            PlaylistDataUIState()
+        )
+    }
+}

--- a/app/src/main/java/org/listenbrainz/android/viewmodel/PlaylistDataViewModel.kt
+++ b/app/src/main/java/org/listenbrainz/android/viewmodel/PlaylistDataViewModel.kt
@@ -73,7 +73,7 @@ class PlaylistDataViewModel @Inject constructor(
         viewModelScope.launch(ioDispatcher) {
             username = appPreferences.username.get()
             if (mbid == null) {
-                createEditScreenUIStateFlow.emit(createEditScreenUIStateFlow.value.copy(isLoading = false))
+                createEditScreenUIStateFlow.emit(CreateEditScreenUIState(isLoading = false))
                 return@launch
             }
             createEditScreenUIStateFlow.emit(createEditScreenUIStateFlow.value.copy(isLoading = true))

--- a/sharedTest/src/main/java/org/listenbrainz/sharedtest/mocks/MockPlaylistDataRepository.kt
+++ b/sharedTest/src/main/java/org/listenbrainz/sharedtest/mocks/MockPlaylistDataRepository.kt
@@ -1,6 +1,6 @@
 package org.listenbrainz.sharedtest.mocks
 
-import org.listenbrainz.android.model.playlist.CopyPlaylistResponse
+import org.listenbrainz.android.model.playlist.AddCopyPlaylistResponse
 import org.listenbrainz.android.model.playlist.PlaylistPayload
 import org.listenbrainz.android.repository.playlists.PlaylistDataRepository
 import org.listenbrainz.android.util.Resource
@@ -13,10 +13,10 @@ class MockPlaylistDataRepository : PlaylistDataRepository {
         return Resource(Resource.Status.SUCCESS, playlistDetailsTestData)
     }
 
-    override suspend fun copyPlaylist(playlistMbid: String?): Resource<CopyPlaylistResponse?> {
+    override suspend fun copyPlaylist(playlistMbid: String?): Resource<AddCopyPlaylistResponse?> {
         return Resource(
             Resource.Status.SUCCESS,
-            CopyPlaylistResponse("new_playlist_mbid", "Playlist copied successfully")
+            AddCopyPlaylistResponse("new_playlist_mbid", "Playlist copied successfully")
         )
     }
 


### PR DESCRIPTION
In this PR,
1. Implemented Add and Edit playlist screen.
2. Created only one screen for both. If `null` is provided as `mbid` during navigation, it works like Create playlist screen, otherwise edit playlist screen.
3. Implemented search for `users` to add them as collaborators.
4. Added `PlaylistDataViewModel` which will be the common viewmodel for other playlist related screens.
5. Added FAB in `UserPlaylistScreen` to create playlist.
6. Used in-memory cache in viewmodel to store playlist data, so that the same playlist data need not fetched again and again.

- Planning next PR for PlaylistDetailScreen, then Add track to playlist.
- At last, I would work on enhancing performance of `UserPlaylistScreen`.

Please let me know if any changes are required.

![image](https://github.com/user-attachments/assets/b2575485-4f9a-4ebf-85f2-288f75f5ccf1)
![image](https://github.com/user-attachments/assets/19946a71-3141-4f9c-87ae-57857aeacf77)
