### PR TITLE
Swipe Issue in landscape mode

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
@@ -139,7 +139,7 @@ fun BrainzPlayerBackDropScreen(
 
     /** 56.dp is default bottom navigation height */
     val headerHeight by animateDpAsState(
-        targetValue = if (isLandscape) 0.dp else
+        targetValue = if (isLandscape) 28.dp else
             if (isNothingPlaying)
                 56.dp
             else
@@ -189,8 +189,10 @@ fun BrainzPlayerBackDropScreen(
             if (!isLandscape) {
                 SongViewPager(
                     modifier = Modifier.graphicsLayer {
-                        alpha =
-                            (backdropScaffoldState.requireOffset() / (maxDelta - headerHeight.toPx()))
+                        val safeMaxDelta = maxDelta.coerceAtLeast(1f)
+                        val safeHeaderHeight = headerHeight.toPx().coerceAtLeast(1f) 
+                        alpha = (backdropScaffoldState.requireOffset() / (safeMaxDelta - safeHeaderHeight))
+                            .coerceIn(0f, 1f)
                     },
                     songList = songList,
                     backdropScaffoldState = backdropScaffoldState,
@@ -198,6 +200,7 @@ fun BrainzPlayerBackDropScreen(
                     isLandscape = false
                 )
             }
+
         })
 }
 


### PR DESCRIPTION
This PR fixes an issue in BrainzPlayerBackDropScreen where in landscape mode there was nothing to pull/swipe up it also refines alpha calculation in SongViewPager to prevent division by zero and applies safe constraints using .coerceAtLeast(1f) to avoid negative values

**Before**

https://github.com/user-attachments/assets/b9f03c24-317f-4e9a-9572-bde5583a232c

**After**


https://github.com/user-attachments/assets/04ed25ab-e2a5-49f4-a8a8-99b045ce579b

