### PR TITLE
MOBILE-220: Gradient fix across all screens

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/artist/ArtistScreen.kt
@@ -236,15 +236,11 @@ fun BioCard(
 ) {
     //Surface is added to make the rounded corner shape of Box visible
     Surface(
-        modifier = Modifier
-            .background(ListenBrainzTheme.colorScheme.background)
+        modifier = Modifier,
+        color = MaterialTheme.colorScheme.background
     ) {
         Box(
             modifier = Modifier
-                .background(
-                    ListenBrainzTheme.colorScheme.artistBioColor,
-                    shape = RoundedCornerShape(bottomStart = 18.dp, bottomEnd = 18.dp)
-                )
                 .fillMaxWidth()
                 .padding(ListenBrainzTheme.paddings.largePadding)
         ) {
@@ -499,7 +495,7 @@ fun Links(
     }
     Box(
         modifier = Modifier
-            .background(brush = ListenBrainzTheme.colorScheme.gradientBrush)
+            .background(brush = ListenBrainzTheme.colorScheme.userPageGradient)
             .fillMaxWidth()
             .padding(ListenBrainzTheme.paddings.largePadding)
     ) {

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/artist/ArtistScreen.kt
@@ -26,8 +26,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.SettingsVoice
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ElevatedSuggestionChip
 import androidx.compose.material3.HorizontalDivider
@@ -79,7 +77,6 @@ import org.listenbrainz.android.model.artist.Artist
 import org.listenbrainz.android.model.artist.ArtistWikiExtract
 import org.listenbrainz.android.model.artist.CBReview
 import org.listenbrainz.android.model.artist.ReleaseGroup
-import org.listenbrainz.android.model.artist.Rels
 import org.listenbrainz.android.model.artist.Tag
 import org.listenbrainz.android.model.feed.FeedListenArtist
 import org.listenbrainz.android.model.feed.ReviewEntityType
@@ -238,7 +235,7 @@ fun BioCard(
     //Surface is added to make the rounded corner shape of Box visible
     Surface(
         modifier = Modifier,
-        color = MaterialTheme.colorScheme.background
+        color = ListenBrainzTheme.colorScheme.background
     ) {
         Box(
             modifier = Modifier

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/artist/ArtistScreen.kt
@@ -83,6 +83,7 @@ import org.listenbrainz.android.model.artist.Rels
 import org.listenbrainz.android.model.artist.Tag
 import org.listenbrainz.android.model.feed.FeedListenArtist
 import org.listenbrainz.android.model.feed.ReviewEntityType
+import org.listenbrainz.android.ui.components.CoverArtComposable
 import org.listenbrainz.android.ui.components.ErrorBar
 import org.listenbrainz.android.ui.components.ListenCardSmall
 import org.listenbrainz.android.ui.components.LoadingAnimation
@@ -316,10 +317,13 @@ fun BioCard(
                 Row {
                     if (coverArt != null) {
                         if (useWebView) {
-                            SvgWithWebView(
-                                svgContent = coverArt,
-                                width = 150.dp,
-                                height = 150.dp
+                            CoverArtComposable(
+                                coverArt = coverArt,
+                                maxGridSize = 3,
+                                modifier = Modifier
+                                    .height(150.dp)
+                                    .width(150.dp)
+                                    .clip(RoundedCornerShape(8.dp))
                             )
                         } else {
                             AsyncImage(
@@ -1061,56 +1065,6 @@ private fun LbRadioButton(
             )
         }
     }
-}
-
-@Composable
-fun SvgWithWebView(svgContent: String, width: Dp, height: Dp) {
-    val context = LocalContext.current
-    val webView = remember { WebView(context) }
-
-    LaunchedEffect(svgContent) {
-        webView.webViewClient = object : WebViewClient() {
-            override fun onPageFinished(view: WebView?, url: String?) {
-                super.onPageFinished(view, url)
-                // Optionally, handle size adjustments or interactions if needed
-            }
-        }
-
-        val htmlContent = """
-            <!DOCTYPE html>
-            <html>
-            <head>
-                <style>
-                    body {
-                        margin: 0;
-                        padding: 0;
-                        overflow: auto; /* Ensure scrollbars appear if necessary */
-                    }
-                    svg {
-                        width: 100%;
-                        height: auto; /* Adjust to fit content */
-                    }
-                </style>
-            </head>
-            <body>
-                <div id="svg-container">
-                    $svgContent
-                </div>
-            </body>
-            </html>
-        """
-
-        webView.loadDataWithBaseURL(null, htmlContent, "text/html", "UTF-8", null)
-    }
-
-    AndroidView(
-        factory = { webView },
-        update = { view -> },
-        modifier = Modifier
-            .width(width)
-            .height(height)
-            .clip(RoundedCornerShape(8.dp))
-    )
 }
 
 

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/artist/ArtistScreen.kt
@@ -1067,6 +1067,74 @@ private fun LbRadioButton(
     }
 }
 
+/**
+ * A Composable function that renders an SVG string using a WebView.
+ *
+ * Previously used to display cover art in Artist and Album screens.
+ * Although currently unused, this function can be reused for rendering inline SVG content
+ * with flexible dimensions in the future.
+ *
+ * @param svgContent The raw SVG markup as a string.
+ * @param width The desired width of the WebView.
+ * @param height The desired height of the WebView.
+ */
+@Composable
+fun SvgWithWebView(svgContent: String, width: Dp, height: Dp) {
+    val context = LocalContext.current
+    val webView = remember { WebView(context) }
+
+    LaunchedEffect(svgContent) {
+        webView.webViewClient = object : WebViewClient() {
+            override fun onPageFinished(view: WebView?, url: String?) {
+                super.onPageFinished(view, url)
+                // Optionally, handle size adjustments or interactions if needed
+            }
+        }
+
+        val htmlContent = """
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <style>
+                    body {
+                        margin: 0;
+                        padding: 0;
+                        overflow: auto; /* Ensure scrollbars appear if necessary */
+                    }
+                    svg {
+                        width: 100%;
+                        height: auto; /* Adjust to fit content */
+                    }
+                </style>
+            </head>
+            <body>
+                <div id="svg-container">
+                    $svgContent
+                </div>
+            </body>
+            </html>
+        """
+
+        webView.loadDataWithBaseURL(
+            null,
+            htmlContent,
+            "text/html",
+            "UTF-8",
+            null
+        )
+    }
+
+    AndroidView(
+        factory = { webView },
+        update = { view -> },
+        modifier = Modifier
+            .width(width)
+            .height(height)
+            .clip(RoundedCornerShape(8.dp))
+    )
+}
+
+
 
 fun formatNumber(input: Int): String {
     return when {

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/playlist/PlaylistDetailScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/playlist/PlaylistDetailScreen.kt
@@ -318,7 +318,9 @@ private fun PlaylistDetailContent(
     val scope = rememberCoroutineScope()
 
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(modifier = Modifier.fillMaxSize()
+        .background(brush = ListenBrainzTheme.colorScheme.userPageGradient)
+    ) {
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
@@ -437,8 +439,11 @@ private fun PlaylistDetailContent(
             item {
                 Row(
                     modifier = Modifier
+                        .background(brush = ListenBrainzTheme.colorScheme.userPageGradient)
                         .padding(vertical = 16.dp)
-                        .fillMaxWidth(),
+                        .fillMaxWidth()
+
+                    ,
                     horizontalArrangement = Arrangement.End
                 ) {
                     //Duplicate button
@@ -595,9 +600,8 @@ fun PlaylistCard(
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(0.dp, 0.dp, 16.dp, 16.dp))
             .background(
-                brush = ListenBrainzTheme.colorScheme.playlistScreenGradient
+                color= ListenBrainzTheme.colorScheme.background
             )
             .padding(top = ListenBrainzTheme.paddings.defaultPadding)
     ) {

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/createdforyou/CreatedForYouScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/createdforyou/CreatedForYouScreen.kt
@@ -138,15 +138,14 @@ private fun CreatedForYouScreen(
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(brush = ListenBrainzTheme.colorScheme.gradientBrush)
         ) {
             LazyColumn {
                 item {
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clip(RoundedCornerShape(0.dp, 0.dp, 16.dp, 16.dp))
                             .background(ListenBrainzTheme.colorScheme.background)
+                            .padding(bottom = 12.dp)
                     ) {
                         Spacer(modifier = Modifier.height(32.dp))
                         PlaylistSelectionCardRow(
@@ -163,7 +162,9 @@ private fun CreatedForYouScreen(
 
                 item {
                     AnimatedContent(
-                        selectedPlaylist
+                        selectedPlaylist,
+                        modifier = Modifier
+                        .background(brush = ListenBrainzTheme.colorScheme.userPageGradient)
                     ) { playlist ->
                         if (playlist == null) {
                             Box(

--- a/app/src/main/java/org/listenbrainz/android/ui/theme/Theme.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/theme/Theme.kt
@@ -73,7 +73,6 @@ data class ColorScheme(
     val followingButtonBorder: BorderStroke?,
     /** Used for Artist Pages **/
     val artistBioColor: Color,
-    val playlistScreenGradient: Brush
 )
 
 
@@ -130,14 +129,6 @@ private val colorSchemeDark = ColorScheme(
             Color.Transparent
         )
     ),
-    playlistScreenGradient = Brush.verticalGradient(
-        listOf(
-            Color(0xFF282828),
-            Color(0xFF313131),
-            Color(0xFF393939),
-            Color(0xFF404040),
-        )
-    ),
     followerChipSelected = lb_purple_night,
     followerChipUnselected = app_bg_dark,
     followerCardColor = app_bg_secondary_dark,
@@ -178,14 +169,6 @@ private val colorSchemeLight = ColorScheme(
             Color(0xFFF4F4F4),
             Color(0xFFF5F5F5),
             Color.Transparent
-        )
-    ),
-    playlistScreenGradient = Brush.verticalGradient(
-        listOf(
-            Color(0xFFFEFEFE),
-            Color(0xFFF5F5F5),
-            Color(0xFFE9E9E9),
-            Color(0xFFDFDFDF),
         )
     ),
     followerChipSelected = lb_purple,


### PR DESCRIPTION
This PR aims to unify the gradient design across the app for a more consistent visual experience.

- Gradients in `ArtistScreen`, `CreatedForYouScreen`, and `PlaylistDetailScreen` have been updated to match the one used in `ListensScreen`.

---

### Artist Screen Improvements

A major issue in the Artist screen was related to the cover art implementation. Previously, it was rendered using a `WebView`, which caused a full reload every time the card left and re-entered the screen—resulting in a poor user experience.

To resolve this, I’ve replaced the `WebView` with the `CoverArtComposable` used in the `PlaylistDetailScreen`. However, the current layout of `CoverArtComposable` shows the cover art in a 3×3 grid, which slightly differs from the web version.

Here’s a reference image:
<br>
<img src="https://github.com/user-attachments/assets/efc393d2-9a36-4378-8dfb-e1f8945407bc" width="300px" />

Let me know if you'd prefer a new composable to better match the website layout.

---

### Screenshots

**Artist Screen (Light)**
<br>
<img src="https://github.com/user-attachments/assets/8f6eaf4f-3caf-4bc6-a91b-b0ca93d5091f" width="300px" />

**Artist Screen (Dark)**
<br>
<img src="https://github.com/user-attachments/assets/a1bbe379-a435-409e-bff9-3ad0e20b5107" width="300px" />

**Playlist Detail Screen (Dark)**
<br>
<img src="https://github.com/user-attachments/assets/c1f6ff40-ba65-4663-9ac9-e5a6289d4eb3" width="300px" />

**Playlist Detail Screen (Light)**
<br>
<img src="https://github.com/user-attachments/assets/e09bc3bc-bd38-413c-8ee4-ade0d347d83c" width="300px" />

**Created For You Screen (Dark)**
<br>
<img src="https://github.com/user-attachments/assets/cc1287c3-ce08-43ce-b5df-edb090751bbc" width="300px" />

**Created For You Screen (Light)**
<br>
<img src="https://github.com/user-attachments/assets/c8981be9-fac4-424b-8f64-815a5373c9f6" width="300px" />
