### PR TITLE
FIX: Fetching cover Art in User Playlist screen

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/playlists/CollabPlaylistPagingSource.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/playlists/CollabPlaylistPagingSource.kt
@@ -19,7 +19,6 @@ class CollabPlaylistPagingSource(
     private val username: String?,
     private val onError: (error: ResponseError?) -> Unit,
     private val playlistDataRepository: PlaylistDataRepository,
-    private val shouldFetchCoverArt: Boolean = true,
     private val ioDispatcher: CoroutineDispatcher
 ) : PagingSource<Int, UserPlaylist>() {
     override fun getRefreshKey(state: PagingState<Int, UserPlaylist>): Int? {
@@ -51,15 +50,7 @@ class CollabPlaylistPagingSource(
                 val data = (result.data?.playlists ?: emptyList()).map { it.playlist }
                 val nextKey = if (data.isEmpty()) null else params.key?.plus(params.loadSize)
                 LoadResult.Page(
-                    data = if (shouldFetchCoverArt) withContext(ioDispatcher) {
-                        data.map { playlist ->
-                            async {
-                                val coverArtResult = playlist.getPlaylistMBID()
-                                    ?.let { it1 -> playlistDataRepository.getPlaylistCoverArt(it1) }
-                                playlist.copy(coverArt = coverArtResult?.data)
-                            }
-                        }.awaitAll()
-                    } else data,
+                    data = data,
                     prevKey = null,
                     nextKey = nextKey
                 )

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/playlists/UserPlaylistPagingSource.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/playlists/UserPlaylistPagingSource.kt
@@ -3,24 +3,16 @@ package org.listenbrainz.android.ui.screens.profile.playlists
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.last
-import kotlinx.coroutines.flow.lastOrNull
 import kotlinx.coroutines.withContext
 import org.listenbrainz.android.model.ResponseError
 import org.listenbrainz.android.model.userPlaylist.UserPlaylist
 import org.listenbrainz.android.repository.playlists.PlaylistDataRepository
-import org.listenbrainz.android.repository.user.UserRepository
 import org.listenbrainz.android.util.Resource
 
 class UserPlaylistPagingSource(
     private val username: String?,
     private val onError: (error: ResponseError?) -> Unit,
     private val playlistRepository: PlaylistDataRepository,
-    private val shouldFetchCoverArt: Boolean = true,
     private val ioDispatcher: CoroutineDispatcher
 ) : PagingSource<Int, UserPlaylist>() {
     override fun getRefreshKey(state: PagingState<Int, UserPlaylist>): Int? {
@@ -52,16 +44,7 @@ class UserPlaylistPagingSource(
                 val data = (result.data?.playlists ?: emptyList()).map { it.playlist }
                 val nextKey = if (data.isEmpty()) null else params.key?.plus(params.loadSize)
                 LoadResult.Page(
-                    data = if (shouldFetchCoverArt) withContext(ioDispatcher) {
-                        data.map { playlist ->
-                            async {
-                                val coverArtResult = playlist.getPlaylistMBID()
-                                    ?.let { it1 -> playlistRepository.getPlaylistCoverArt(it1) }
-                                playlist.copy(coverArt = coverArtResult?.data)
-                            }
-                        }.awaitAll()
-                    }
-                    else data,
+                    data = data,
                     prevKey = null,
                     nextKey = nextKey
                 )

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/playlists/UserPlaylistScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/playlists/UserPlaylistScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -112,6 +113,9 @@ fun UserPlaylistScreen(
         collabPlaylistDataSize = collabPlaylistsData.itemCount,
         getUserPlaylist = { index ->
             userPlaylistsData[index]
+        },
+        getPlaylistCoverArt = { userPlaylist, callback ->
+            userViewModel.fetchCoverArt(userPlaylist, callback)
         },
         getCollabPlaylist = { index ->
             collabPlaylistsData[index]
@@ -209,6 +213,7 @@ private fun UserPlaylistScreenBase(
     userPlaylistDataSize: Int,
     collabPlaylistDataSize: Int,
     isCurrentScreenCollab: Boolean,
+    getPlaylistCoverArt: (UserPlaylist, (String?) -> Unit) -> Unit,
     getUserPlaylist: (Int) -> UserPlaylist?,
     getCollabPlaylist: (Int) -> UserPlaylist?,
     currentPlaylistView: PlaylistView,
@@ -252,6 +257,14 @@ private fun UserPlaylistScreenBase(
                                                 index
                                             )
                                         if (playlist != null) {
+                                            var coverArt by remember(playlist) {
+                                                mutableStateOf<String?>(null)
+                                            }
+                                            LaunchedEffect(Unit) {
+                                                getPlaylistCoverArt(playlist) { coverArtUrl ->
+                                                    coverArt = coverArtUrl
+                                                }
+                                            }
                                             PlaylistListViewCard(
                                                 modifier = Modifier,
                                                 title = playlist.title ?: "",
@@ -261,7 +274,7 @@ private fun UserPlaylistScreenBase(
                                                     showTime = false
                                                 ),
                                                 onClickCard = { onClickPlaylist(playlist) },
-                                                coverArt = playlist.coverArt,
+                                                coverArt = coverArt,
                                                 onDropdownClick = {
                                                     onDropdownItemClick(it, playlist)
                                                 },
@@ -285,6 +298,14 @@ private fun UserPlaylistScreenBase(
                                                 index
                                             )
                                         if (playlist != null) {
+                                            var coverArt by remember(playlist) {
+                                                mutableStateOf<String?>(null)
+                                            }
+                                            LaunchedEffect(Unit) {
+                                                getPlaylistCoverArt(playlist) { coverArtUrl ->
+                                                    coverArt = coverArtUrl
+                                                }
+                                            }
                                             PlaylistGridViewCard(
                                                 modifier = Modifier,
                                                 title = playlist.title ?: "",
@@ -294,7 +315,7 @@ private fun UserPlaylistScreenBase(
                                                     showTime = false
                                                 ),
                                                 onClickCard = { onClickPlaylist(playlist) },
-                                                coverArt = playlist.coverArt,
+                                                coverArt = coverArt,
                                                 onDropdownClick = {
                                                     onDropdownItemClick(it, playlist)
                                                 },
@@ -442,6 +463,7 @@ fun UserPlaylistScreenPreview() {
             isCurrentScreenCollab = true,
             currentPlaylistView = PlaylistView.GRID,
             onPlaylistSectionClick = {},
+            getPlaylistCoverArt = {_,_->},
             onCollabSectionClick = {},
             onClickPlaylistViewChange = { },
             onClickPlaylist = { },

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/playlists/UserPlaylistScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/playlists/UserPlaylistScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.produceState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -58,6 +59,7 @@ import org.listenbrainz.android.ui.screens.playlist.CreateEditPlaylistScreen
 import org.listenbrainz.android.ui.screens.profile.createdforyou.formatDateLegacy
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.ui.theme.lb_purple_night
+import org.listenbrainz.android.util.Log
 import org.listenbrainz.android.util.Utils.shareLink
 import org.listenbrainz.android.viewmodel.PlaylistDataViewModel
 import org.listenbrainz.android.viewmodel.UserViewModel
@@ -257,12 +259,9 @@ private fun UserPlaylistScreenBase(
                                                 index
                                             )
                                         if (playlist != null) {
-                                            var coverArt by remember(playlist) {
-                                                mutableStateOf<String?>(null)
-                                            }
-                                            LaunchedEffect(Unit) {
-                                                getPlaylistCoverArt(playlist) { coverArtUrl ->
-                                                    coverArt = coverArtUrl
+                                            val coverArt by produceState<String?>(initialValue = null, key1 = playlist){
+                                                getPlaylistCoverArt(playlist){
+                                                    value = it
                                                 }
                                             }
                                             PlaylistListViewCard(
@@ -298,12 +297,9 @@ private fun UserPlaylistScreenBase(
                                                 index
                                             )
                                         if (playlist != null) {
-                                            var coverArt by remember(playlist) {
-                                                mutableStateOf<String?>(null)
-                                            }
-                                            LaunchedEffect(Unit) {
-                                                getPlaylistCoverArt(playlist) { coverArtUrl ->
-                                                    coverArt = coverArtUrl
+                                            val coverArt by produceState<String?>(initialValue = null, key1 = playlist){
+                                                getPlaylistCoverArt(playlist){
+                                                    value = it
                                                 }
                                             }
                                             PlaylistGridViewCard(

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/playlists/UserPlaylistScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/playlists/UserPlaylistScreen.kt
@@ -116,9 +116,7 @@ fun UserPlaylistScreen(
         getUserPlaylist = { index ->
             userPlaylistsData[index]
         },
-        getPlaylistCoverArt = { userPlaylist, callback ->
-            userViewModel.fetchCoverArt(userPlaylist, callback)
-        },
+        getPlaylistCoverArt = userViewModel::fetchCoverArt,
         getCollabPlaylist = { index ->
             collabPlaylistsData[index]
         },
@@ -215,7 +213,7 @@ private fun UserPlaylistScreenBase(
     userPlaylistDataSize: Int,
     collabPlaylistDataSize: Int,
     isCurrentScreenCollab: Boolean,
-    getPlaylistCoverArt: (UserPlaylist, (String?) -> Unit) -> Unit,
+    getPlaylistCoverArt: suspend (UserPlaylist) -> String?,
     getUserPlaylist: (Int) -> UserPlaylist?,
     getCollabPlaylist: (Int) -> UserPlaylist?,
     currentPlaylistView: PlaylistView,
@@ -260,9 +258,7 @@ private fun UserPlaylistScreenBase(
                                             )
                                         if (playlist != null) {
                                             val coverArt by produceState<String?>(initialValue = null, key1 = playlist){
-                                                getPlaylistCoverArt(playlist){
-                                                    value = it
-                                                }
+                                                value = getPlaylistCoverArt(playlist)
                                             }
                                             PlaylistListViewCard(
                                                 modifier = Modifier,
@@ -298,9 +294,7 @@ private fun UserPlaylistScreenBase(
                                             )
                                         if (playlist != null) {
                                             val coverArt by produceState<String?>(initialValue = null, key1 = playlist){
-                                                getPlaylistCoverArt(playlist){
-                                                    value = it
-                                                }
+                                                value = getPlaylistCoverArt(playlist)
                                             }
                                             PlaylistGridViewCard(
                                                 modifier = Modifier,
@@ -459,7 +453,7 @@ fun UserPlaylistScreenPreview() {
             isCurrentScreenCollab = true,
             currentPlaylistView = PlaylistView.GRID,
             onPlaylistSectionClick = {},
-            getPlaylistCoverArt = {_,_->},
+            getPlaylistCoverArt = {null},
             onCollabSectionClick = {},
             onClickPlaylistViewChange = { },
             onClickPlaylist = { },

--- a/app/src/main/java/org/listenbrainz/android/viewmodel/PlaylistDataViewModel.kt
+++ b/app/src/main/java/org/listenbrainz/android/viewmodel/PlaylistDataViewModel.kt
@@ -622,7 +622,6 @@ class PlaylistDataViewModel @Inject constructor(
             onError = {
                 emitError(it)
             },
-            shouldFetchCoverArt = false,
             playlistRepository = repository,
             ioDispatcher = ioDispatcher
         )
@@ -638,7 +637,6 @@ class PlaylistDataViewModel @Inject constructor(
         CollabPlaylistPagingSource(
             username = username,
             onError = {emitError(it)},
-            shouldFetchCoverArt = false,
             playlistDataRepository = repository,
             ioDispatcher = ioDispatcher
         )

--- a/app/src/main/java/org/listenbrainz/android/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/org/listenbrainz/android/viewmodel/UserViewModel.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
+import kotlinx.coroutines.withContext
 import org.listenbrainz.android.di.IoDispatcher
 import org.listenbrainz.android.model.Listen
 import org.listenbrainz.android.model.playlist.PlaylistData
@@ -129,10 +130,12 @@ class UserViewModel @Inject constructor(
             return coverArtCache[userPlaylist]
         }
         return coverArtSemaphore.withPermit {
-            userPlaylist.getPlaylistMBID()?.let {
-                val result = playlistDataRepository.getPlaylistCoverArt(it)
-                coverArtCache[userPlaylist] = result.data
-                result.data
+            withContext(ioDispatcher) {
+                userPlaylist.getPlaylistMBID()?.let {
+                    val result = playlistDataRepository.getPlaylistCoverArt(it)
+                    coverArtCache[userPlaylist] = result.data
+                    result.data
+                }
             }
         }
     }

--- a/app/src/main/java/org/listenbrainz/android/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/org/listenbrainz/android/viewmodel/UserViewModel.kt
@@ -129,6 +129,7 @@ class UserViewModel @Inject constructor(
                 userPlaylist.getPlaylistMBID()?.let {
                     val result = playlistDataRepository.getPlaylistCoverArt(it)
                     coverArtCache[userPlaylist] = result.data
+                    fetchCallback(result.data)
                 }
             }
         }


### PR DESCRIPTION
Fetching all playlist cover arts at once for users with multiple playlists leads to HitRateLimitExceeded error. 
To avoid this, I removed the previous async calls to fetch the cover art, and instead used Semaphores(2) allowing only two calls to fetch cover arts at the same time.
