### PR TITLE
make the full description a little more detailed

### DIFF
--- a/fastlane/metadata/android/de-DE/full_description.txt
+++ b/fastlane/metadata/android/de-DE/full_description.txt
@@ -1,3 +1,7 @@
-ListenBrainz erfasst die Musik, die du hörst, und bietet dir Einblicke in deine Hörgewohnheiten.
-Mit unseren Visualisierungen kannst du ListenBrainz nutzen, um deine Musikhörgewohnheiten zu verfolgen und deinen Geschmack mit anderen zu teilen.
-Basierend auf deinem Hörverhalten empfehlen wir dir Musik, die dir gefallen könnte, neue Musik, die du von deinen Lieblingskünstlern verpasst hast, und was ähnliche Nutzer gehört haben.
+<i>ListenBrainz</i> verfolgt die Musik, die du hörst, und gibt dir Einblicke in deine Hörgewohnheiten.
+
+Mithilfe unserer Visualisierungen kannst du ListenBrainz verwenden, um deine Musikhörgewohnheiten zu verfolgen und deinen Geschmack mit anderen zu teilen.
+
+Basierend auf deinem Hörverlauf empfehlen wir Musik, die dir gefallen könnte, neue Musik von deinen Lieblingskünstlern, die du verpasst hast, und was ähnliche Benutzer gehört haben.
+
+Wenn du die ListenBrainz Android-App verwendest, musst du ein Konto bei ListenBrainz erstellen, und dein Hörverlauf wird mit diesem Konto verknüpft. Diese Daten werden nicht auf dem Gerät gespeichert, sondern an den ListenBrainz-Server übertragen. Die gesammelten Daten werden zur Verbesserung der Empfehlungen verwendet und sind für andere Nutzer zugänglich.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,3 +1,7 @@
-ListenBrainz keeps track of the music you listen to and provides you with insights into your listening habits.
+<i>ListenBrainz</i> keeps track of the music you listen to and provides you with insights into your listening habits.
+
 Using our visualizations, you can use ListenBrainz to track your music listening habits and share your taste with others.
+
 Based on your listening history we recommend music you might like, new music you missed out on from your favorite artists, and what similar users have been listening to.
+
+When you use the ListenBrainz Android app, you need to create an account with ListenBrainz, and your listening history will be associated with this account. This data is not kept on the device but is transmitted to the ListenBrainz server. The data collected is used to improve the recommendations and is accessible to other users.


### PR DESCRIPTION
This PR adds some details to the EN full description, making it clearer what the app is about. It also slightly adjusts formatting, making it possible to render it as Markdown (supported e.g. at IzzyOnDroid) while keeping it compatible with places not supporting it (e.g. F-Droid.org, PlayStore).