### PR TITLE
Fix search state mismatch between user and player search

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/navigation/AppNavigation.kt
@@ -98,7 +98,7 @@ fun AppNavigation(
         }
         appComposable(route = AppNavigationItem.BrainzPlayer.route) {
             BrainzPlayerScreen(
-                topAppBarActions
+                topBarActions = topAppBarActions
             )
         }
         appComposable(route = AppNavigationItem.Explore.route) {

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/main/HomeScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/main/HomeScreen.kt
@@ -74,7 +74,6 @@ fun HomeScreen(
     var scrollToTopState by remember { mutableStateOf(false) }
     val snackbarState = remember { SnackbarHostState() }
     val searchBarState = rememberSearchBarState()
-    val brainzplayerSearchBarState = rememberSearchBarState()
     val scope = rememberCoroutineScope()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination
@@ -240,8 +239,8 @@ fun HomeScreen(
 
         when (currentDestination?.route) {
             AppNavigationItem.BrainzPlayer.route -> BrainzPlayerSearchScreen(
-                isActive = brainzplayerSearchBarState.isActive,
-                deactivate = brainzplayerSearchBarState::deactivate,
+                isActive = searchBarState.isActive,
+                deactivate = searchBarState::deactivate,
             )
 
             else -> UserSearchScreen(


### PR DESCRIPTION
This PR Fixes #637 
This PR fixes an issue where search behavior was inconsistent due to multiple SearchBarState instances being used. The fix simplifies the logic by using a single SearchBarState to control search visibility and determines whether user search or music library search is shown based on the current navigation route


Screen Recording :

https://github.com/user-attachments/assets/b490c80b-4578-4229-86a4-ff7b5380ec00

