### PR TITLE
Fix playlist create/edit behavior 

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/ui/screens/playlist/AddEditPlaylistScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/playlist/AddEditPlaylistScreen.kt
@@ -94,15 +94,14 @@ fun CreateEditPlaylistScreen(
         }
     }
 
-    LaunchedEffect(Unit) {
-        viewModel.getInitialDataInCreatePlaylistScreen(mbid)
-    }
-
     LaunchedEffect(uiState.createEditScreenUIState.isSearching) {
         sheetState.expand()
     }
 
-    if (isVisible)
+    if (isVisible) {
+        LaunchedEffect(Unit) {
+            viewModel.getInitialDataInCreatePlaylistScreen(mbid)
+        }
         Box(
             modifier = Modifier.fillMaxSize()
         ) {
@@ -174,6 +173,7 @@ fun CreateEditPlaylistScreen(
                 viewModel.clearErrorFlow()
             }
         }
+    }
 }
 
 @OptIn(ExperimentalLayoutApi::class)


### PR DESCRIPTION
Fixes #638 

This PR fixes the bug in the create/edit behavior of a playlist in the **Playlist** tab under the **Profile** screen.

I moved the `LaunchedEffect` which contains `getInitialDataInCreatePlaylistScreen`, inside the `CreateEditPlaylistScreen` within the pre-existing if/else guard used to render the composable. As a result, the `LaunchedEffect`, even with Unit as its key, now runs only once when `isVisible` is toggled on. Hence resulting in proper flow of states of the Modal Bottom Sheet i.e:- Create State for creating a new playlist and Edit State for editing a particular playlist.

Screen Recording:-

https://github.com/user-attachments/assets/ea3ade97-4000-4400-82ce-aee0d817ad9a

