### PR TITLE
Handle THANKS feed event type to prevent feed failure

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/model/Metadata.kt
+++ b/app/src/main/java/org/listenbrainz/android/model/Metadata.kt
@@ -49,7 +49,27 @@ data class Metadata(
     val user0: String? = null,
     /** Used for follow following taglines. This is the one who was followed. */
     @SerialName("user_name_1")
-    val user1: String? = null
+    val user1: String? = null,
+    // ---- THANKS EVENT FIELDS ----
+
+    @SerialName("thanker_username")
+    val thankerUsername: String? = null,
+
+    @SerialName("thankee_username")
+    val thankeeUsername: String? = null,
+
+    @SerialName("thanker_id")
+    val thankerId: Long? = null,
+
+    @SerialName("thankee_id")
+    val thankeeId: Long? = null,
+
+    @SerialName("original_event_id")
+    val originalEventId: Long? = null,
+
+    @SerialName("original_event_type")
+    val originalEventType: String? = null
+
 ) {
     val sharedTransitionId
         get() = trackMetadata?.sharedTransitionId +

--- a/app/src/main/java/org/listenbrainz/android/model/feed/FeedEventType.kt
+++ b/app/src/main/java/org/listenbrainz/android/model/feed/FeedEventType.kt
@@ -27,6 +27,8 @@ import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.util.Log
 import org.listenbrainz.android.util.TypeConverter
 import org.listenbrainz.android.util.Utils.getArticle
+import org.listenbrainz.android.ui.screens.feed.events.ThanksFeedLayout
+
 
 /**
  * @param icon Feed icon for the event, **must** be of width 19 dp.
@@ -223,7 +225,13 @@ enum class FeedEventType (
                 goToUserPage = goToUserPage,
                 goToArtistPage = goToArtistPage
             )
-            THANKS -> UnknownFeedLayout(event = event)
+   THANKS -> ThanksFeedLayout(
+    event = event,
+    parentUser = parentUser,
+    goToUserPage = goToUserPage
+)
+
+
             UNKNOWN -> UnknownFeedLayout(event = event)
         }
     }
@@ -447,7 +455,23 @@ enum class FeedEventType (
                     }
                 }
             }
+                
+THANKS -> {
+    buildAnnotatedString {
+
+        val thanker = feedEvent.metadata.thankerUsername ?: "Someone"
+        val thankee = feedEvent.metadata.thankeeUsername ?: "someone"
+
+        withStyle(linkStyle) { append(thanker) }
+        withStyle(normalStyle) { append(" thanked ") }
+        withStyle(linkStyle) { append(thankee) }
+        withStyle(normalStyle) { append(".") }
+    }
+}
+
+
             else -> return emptyString
+
         }
         
         return firstAnnotatedString.plus(secondAnnotatedString)
@@ -482,19 +506,24 @@ enum class FeedEventType (
             }
         }
         
-        fun resolveEvent(event: FeedEvent?): FeedEventType =
-            when (event?.type) {
-                RECORDING_RECOMMENDATION.type -> RECORDING_RECOMMENDATION
-                PERSONAL_RECORDING_RECOMMENDATION.type -> PERSONAL_RECORDING_RECOMMENDATION
-                RECORDING_PIN.type -> RECORDING_PIN
-                LISTEN.type -> LISTEN
-                LIKE.type -> LIKE
-                FOLLOW.type -> FOLLOW
-                NOTIFICATION.type -> NOTIFICATION
-                REVIEW.type -> REVIEW
-                THANKS.type -> THANKS
-                else -> UNKNOWN
-            }
+        fun resolveEvent(event: FeedEvent?): FeedEventType {
+
+    android.util.Log.d("THANKS_DEBUG", "Incoming event type -> ${event?.type}")
+
+    return when (event?.type) {
+        RECORDING_RECOMMENDATION.type -> RECORDING_RECOMMENDATION
+        PERSONAL_RECORDING_RECOMMENDATION.type -> PERSONAL_RECORDING_RECOMMENDATION
+        RECORDING_PIN.type -> RECORDING_PIN
+        LISTEN.type -> LISTEN
+        LIKE.type -> LIKE
+        FOLLOW.type -> FOLLOW
+        NOTIFICATION.type -> NOTIFICATION
+        REVIEW.type -> REVIEW
+        THANKS.type -> THANKS
+        else -> UNKNOWN
+    }
+}
+
         
         /** This function can be used to determine if an action is delete or hide.*/
         fun isActionDelete(event: FeedEvent, eventType: FeedEventType, parentUser: String): Boolean =

--- a/app/src/main/java/org/listenbrainz/android/model/feed/FeedEventType.kt
+++ b/app/src/main/java/org/listenbrainz/android/model/feed/FeedEventType.kt
@@ -87,6 +87,12 @@ enum class FeedEventType (
         type = "critiquebrainz_review",
         icon = R.drawable.feed_review,
     ),
+    THANKS(
+    type = "thanks",
+    icon = R.drawable.feed_love, // reusing existing icon for now
+    isPlayable = false
+),
+
     
     /** In case a new event is added in future that had not been published to the app. */
     UNKNOWN(
@@ -217,6 +223,7 @@ enum class FeedEventType (
                 goToUserPage = goToUserPage,
                 goToArtistPage = goToArtistPage
             )
+            THANKS -> UnknownFeedLayout(event = event)
             UNKNOWN -> UnknownFeedLayout(event = event)
         }
     }
@@ -306,6 +313,8 @@ enum class FeedEventType (
                     }
                 }
             }
+            
+
         
             UNKNOWN -> {
                 Pair(
@@ -483,6 +492,7 @@ enum class FeedEventType (
                 FOLLOW.type -> FOLLOW
                 NOTIFICATION.type -> NOTIFICATION
                 REVIEW.type -> REVIEW
+                THANKS.type -> THANKS
                 else -> UNKNOWN
             }
         

--- a/app/src/main/java/org/listenbrainz/android/model/feed/FeedEventType.kt
+++ b/app/src/main/java/org/listenbrainz/android/model/feed/FeedEventType.kt
@@ -109,6 +109,7 @@ enum class FeedEventType (
     @Composable
     fun Content(
         event: FeedEvent,
+        referencedEvent: FeedEvent? = null,
         parentUser: String,
         isHidden: Boolean,
         onDeleteOrHide: () -> Unit,
@@ -228,7 +229,8 @@ enum class FeedEventType (
    THANKS -> ThanksFeedLayout(
     event = event,
     parentUser = parentUser,
-    goToUserPage = goToUserPage
+    goToUserPage = goToUserPage,
+    referencedEvent=referencedEvent
 )
 
 
@@ -455,17 +457,20 @@ enum class FeedEventType (
                     }
                 }
             }
-                
-THANKS -> {
+ THANKS -> {
     buildAnnotatedString {
 
-        val thanker = feedEvent.metadata.thankerUsername ?: "Someone"
-        val thankee = feedEvent.metadata.thankeeUsername ?: "someone"
+        val thanker = feedEvent.metadata.thankerUsername ?: feedEvent.username ?: "Someone"
+        val isSelf = thanker == parentUser
+        val displayName = if (isSelf) "You" else thanker
 
-        withStyle(linkStyle) { append(thanker) }
-        withStyle(normalStyle) { append(" thanked ") }
-        withStyle(linkStyle) { append(thankee) }
-        withStyle(normalStyle) { append(".") }
+        withStyle(linkStyle) {
+            append(displayName)
+        }
+
+        withStyle(normalStyle) {
+            append(" thanked you for recommending a track.")
+        }
     }
 }
 
@@ -507,8 +512,6 @@ THANKS -> {
         }
         
         fun resolveEvent(event: FeedEvent?): FeedEventType {
-
-    android.util.Log.d("THANKS_DEBUG", "Incoming event type -> ${event?.type}")
 
     return when (event?.type) {
         RECORDING_RECOMMENDATION.type -> RECORDING_RECOMMENDATION

--- a/app/src/main/java/org/listenbrainz/android/repository/feed/FeedRepository.kt
+++ b/app/src/main/java/org/listenbrainz/android/repository/feed/FeedRepository.kt
@@ -5,6 +5,7 @@ import org.listenbrainz.android.model.feed.FeedData
 import org.listenbrainz.android.model.feed.FeedEventDeletionData
 import org.listenbrainz.android.model.feed.FeedEventVisibilityData
 import org.listenbrainz.android.util.Resource
+import org.listenbrainz.android.model.feed.FeedEvent
 
 interface FeedRepository {
 
@@ -43,7 +44,10 @@ interface FeedRepository {
         username: String?,
         data: FeedEventVisibilityData
     ): Resource<SocialResponse>
-    
+   suspend fun getFeedEventById(id: Long): Resource<FeedEvent>
+
+    suspend fun getPinById(id: Long): Resource<FeedEvent>
+
     companion object {
         const val FeedEventCount = 25
         const val FeedListensCount = 40

--- a/app/src/main/java/org/listenbrainz/android/repository/feed/FeedRepositoryImpl.kt
+++ b/app/src/main/java/org/listenbrainz/android/repository/feed/FeedRepositoryImpl.kt
@@ -8,6 +8,9 @@ import org.listenbrainz.android.model.feed.FeedEventVisibilityData
 import org.listenbrainz.android.service.FeedServiceKtor
 import org.listenbrainz.android.util.Resource
 import org.listenbrainz.android.util.Utils.parseResponse
+import org.listenbrainz.android.model.feed.FeedEvent
+
+
 
 
 class FeedRepositoryImpl(
@@ -111,4 +114,12 @@ class FeedRepositoryImpl(
             body = data
         )
     }
+override suspend fun getFeedEventById(id: Long): Resource<FeedEvent> =
+    parseResponse {
+        service.getFeedEventById(id)
+    }
+    override suspend fun getPinById(id: Long): Resource<FeedEvent> = parseResponse {
+    service.getPinById(id)
+}
+
 }

--- a/app/src/main/java/org/listenbrainz/android/service/FeedServiceKtor.kt
+++ b/app/src/main/java/org/listenbrainz/android/service/FeedServiceKtor.kt
@@ -42,4 +42,8 @@ interface FeedServiceKtor {
         username: String,
         body: FeedEventVisibilityData
     ): SocialResponse
+    suspend fun getFeedEventById(
+    id: Long
+): org.listenbrainz.android.model.feed.FeedEvent
+suspend fun getPinById(id: Long): org.listenbrainz.android.model.feed.FeedEvent
 }

--- a/app/src/main/java/org/listenbrainz/android/service/FeedServiceKtorImpl.kt
+++ b/app/src/main/java/org/listenbrainz/android/service/FeedServiceKtorImpl.kt
@@ -11,6 +11,9 @@ import org.listenbrainz.android.model.SocialResponse
 import org.listenbrainz.android.model.feed.FeedData
 import org.listenbrainz.android.model.feed.FeedEventDeletionData
 import org.listenbrainz.android.model.feed.FeedEventVisibilityData
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import org.listenbrainz.android.model.feed.FeedEvent
 
 
 class FeedServiceKtorImpl(
@@ -91,4 +94,11 @@ class FeedServiceKtorImpl(
             setBody(body)
         }.body()
     }
+override suspend fun getFeedEventById(id: Long): FeedEvent {
+    return httpClient.get("1/feed/event/$id").body()
+}
+override suspend fun getPinById(id: Long): FeedEvent {
+    return httpClient.get("1/pin/$id").body()
+}
+
 }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/feed/FeedScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/feed/FeedScreen.kt
@@ -503,6 +503,7 @@ private fun MyFeed(
                     ) {
                         eventType.Content(
                             event = event,
+                            referencedEvent = referencedEvent,
                             parentUser = parentUser,
                             isHidden = uiState.isHiddenMap[event.id] == true,
                             onDeleteOrHide = {

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/feed/FeedUiState.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/feed/FeedUiState.kt
@@ -31,5 +31,6 @@ data class FeedUiEventData(
 data class FeedUiEventItem(
     val eventType: FeedEventType,
     val event: FeedEvent,
-    val parentUser: String = ""
+    val parentUser: String = "",
+    val referencedEvent: FeedEvent? = null
 )

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/ThanksFeedLayout.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/ThanksFeedLayout.kt
@@ -1,0 +1,44 @@
+package org.listenbrainz.android.ui.screens.feed.events
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import org.listenbrainz.android.model.feed.FeedEvent
+import org.listenbrainz.android.model.feed.FeedEventType
+import org.listenbrainz.android.ui.screens.feed.BaseFeedLayout
+import org.listenbrainz.android.ui.theme.ListenBrainzTheme
+@Composable
+fun ThanksFeedLayout(
+    event: FeedEvent,
+    parentUser: String,
+    goToUserPage: (String) -> Unit
+) {
+
+    val thanker = event.metadata.thankerUsername ?: event.username ?: "Someone"
+    val thankee = event.metadata.thankeeUsername ?: "a user"
+    val message = event.metadata.blurbContent
+
+    BaseFeedLayout(
+        eventType = FeedEventType.THANKS,
+        event = event,
+        parentUser = parentUser,
+        onDeleteOrHide = {},
+        goToUserPage = goToUserPage,
+    ) {
+        Column {
+
+            Text(
+                text = "$thanker thanked $thankee",
+                color = ListenBrainzTheme.colorScheme.text
+            )
+
+            if (!message.isNullOrBlank()) {
+                Text(
+                    text = message,
+                    style = ListenBrainzTheme.textStyles.feedBlurbContent,
+                    color = ListenBrainzTheme.colorScheme.text
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/ThanksFeedLayout.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/ThanksFeedLayout.kt
@@ -7,15 +7,20 @@ import org.listenbrainz.android.model.feed.FeedEvent
 import org.listenbrainz.android.model.feed.FeedEventType
 import org.listenbrainz.android.ui.screens.feed.BaseFeedLayout
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 @Composable
 fun ThanksFeedLayout(
     event: FeedEvent,
     parentUser: String,
-    goToUserPage: (String) -> Unit
+    goToUserPage: (String) -> Unit,
+    referencedEvent:FeedEvent? = null
 ) {
 
     val thanker = event.metadata.thankerUsername ?: event.username ?: "Someone"
-    val thankee = event.metadata.thankeeUsername ?: "a user"
+    val thankee = event.metadata.thankeeUsername ?: "you"
     val message = event.metadata.blurbContent
 
     BaseFeedLayout(
@@ -28,7 +33,7 @@ fun ThanksFeedLayout(
         Column {
 
             Text(
-                text = "$thanker thanked $thankee",
+                text = "$thanker thanked $thankee for recommending a track",
                 color = ListenBrainzTheme.colorScheme.text
             )
 
@@ -39,6 +44,38 @@ fun ThanksFeedLayout(
                     color = ListenBrainzTheme.colorScheme.text
                 )
             }
+   Spacer(modifier = Modifier.height(8.dp))
+
+            // Render original event card
+            referencedEvent?.let { originalEvent ->
+
+    val originalType = FeedEventType.resolveEvent(originalEvent)
+
+    // Prevent recursive THANKS rendering
+    if (originalType != FeedEventType.THANKS) {
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        originalType.Content(
+            event = originalEvent,
+            referencedEvent = null, // avoid deep nesting
+            parentUser = parentUser,
+            isHidden = false,
+            onDeleteOrHide = {},
+            onDropdownClick = {},
+            dropDownState = null,
+            index = 0,
+            onOpenInMusicBrainz = {},
+            onRecommend = {},
+            onPersonallyRecommend = {},
+            onReview = {},
+            onPin = {},
+            onClick = {},
+            goToUserPage = goToUserPage,
+            goToArtistPage = {}
+     )
+            }
         }
     }
+}
 }

--- a/app/src/main/java/org/listenbrainz/android/viewmodel/FeedViewModel.kt
+++ b/app/src/main/java/org/listenbrainz/android/viewmodel/FeedViewModel.kt
@@ -163,6 +163,7 @@ class FeedViewModel(
         }
     }
     
+    
     private fun playFromYoutubeMusic(event: FeedEvent) {
         viewModelScope.launch {
             if (event.metadata.trackMetadata != null


### PR DESCRIPTION
Hi @07jasjeet 👋
I’ve raised a PR that adds support for resolving the new thanks feed event type so the Android feed no longer falls back to the “update app” error when such events appear.

Please let me know if this approach looks correct happy to follow up with a dedicated Thanks UI and original event rendering next.