### PR TITLE
Fixes feed overlap when ErrorBar appears #734

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/ui/screens/feed/FeedScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/feed/FeedScreen.kt
@@ -238,6 +238,7 @@ fun FeedScreen(
                         listState = myFeedListState,
                         pagingData = myFeedPagingData,
                         uiState = uiState.myFeedState,
+                        errorDialogVisible = uiState.error != null,
                         onDeleteOrHide = callbacks.onDeleteOrHide,
                         recommendTrack = callbacks.onRecommend,
                         personallyRecommendTrack = { index ->
@@ -266,6 +267,7 @@ fun FeedScreen(
 
                     1 -> FollowListens(
                         listState = followListensListState,
+                        errorDialogVisible = uiState.error != null,
                         pagingData = followListensPagingData,
                         recommendTrack = callbacks.onRecommend,
                         personallyRecommendTrack = { index ->
@@ -293,6 +295,7 @@ fun FeedScreen(
 
                     2 -> SimilarListens(
                         listState = similarListensListState,
+                        errorDialogVisible = uiState.error != null,
                         pagingData = similarListensPagingData,
                         recommendTrack = callbacks.onRecommend,
                         personallyRecommendTrack = { index ->
@@ -448,6 +451,7 @@ private fun MyFeed(
     listState: LazyListState,
     pagingData: LazyPagingItems<FeedUiEventItem>,
     uiState: FeedUiEventData,
+    errorDialogVisible: Boolean,
     onDeleteOrHide: (event: FeedEvent, eventType: FeedEventType, parentUser: String) -> Unit,
     recommendTrack: (event: FeedEvent) -> Unit,
     personallyRecommendTrack: (index: Int) -> Unit,
@@ -478,7 +482,7 @@ private fun MyFeed(
             .widthIn(max = LocalConfiguration.current.screenWidthDp.dp),
         state = listState
     ) {
-        item { StartingSpacer() }
+        item { StartingSpacer(errorDialogVisible) }
 
         if (inRefreshingState) {
             item(contentType = "shimmer") {
@@ -560,6 +564,7 @@ private fun MyFeed(
 @Composable
 fun FollowListens(
     listState: LazyListState,
+    errorDialogVisible: Boolean,
     pagingData: LazyPagingItems<FeedUiEventItem>,
     recommendTrack: (event: FeedEvent) -> Unit,
     personallyRecommendTrack: (index: Int) -> Unit,
@@ -590,7 +595,7 @@ fun FollowListens(
         state = listState,
     ) {
 
-        item { StartingSpacer() }
+        item { StartingSpacer(errorDialogVisible) }
 
         if (inRefreshingState) {
             item(contentType = "shimmer") {
@@ -695,6 +700,7 @@ fun FollowListens(
 @Composable
 fun SimilarListens(
     listState: LazyListState,
+    errorDialogVisible: Boolean,
     pagingData: LazyPagingItems<FeedUiEventItem>,
     recommendTrack: (event: FeedEvent) -> Unit,
     personallyRecommendTrack: (index: Int) -> Unit,
@@ -725,7 +731,7 @@ fun SimilarListens(
         modifier = Modifier.fillMaxSize(),
         state = listState
     ) {
-        item { StartingSpacer() }
+        item { StartingSpacer(errorDialogVisible) }
 
         if (inRefreshingState) {
             item(contentType = "shimmer") {
@@ -1035,8 +1041,12 @@ fun ShimmerListensItem(
 }
 
 @Composable
-fun StartingSpacer() {
-    Spacer(modifier = Modifier.height(60.dp))   // 6 + 6 + 48
+fun StartingSpacer(errorDialogVisible: Boolean) {
+    Spacer(
+        modifier = Modifier.height(
+            if (errorDialogVisible) 85.dp else 60.dp
+        )
+    )
 }
 
 @Composable

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/feed/FeedScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/feed/FeedScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -57,10 +58,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.UriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.paging.LoadState
 import androidx.paging.PagingData
@@ -196,6 +199,9 @@ fun FeedScreen(
         }
     )
 
+    var headerBarHeightPx by remember { mutableIntStateOf(0) }
+    val headerBarHeightDp = with(LocalDensity.current) { headerBarHeightPx.toDp() }
+
     LaunchedEffect(scrollToTopState) {
         callbacks.onScrollToTop {
             when (pagerState.currentPage) {
@@ -238,7 +244,7 @@ fun FeedScreen(
                         listState = myFeedListState,
                         pagingData = myFeedPagingData,
                         uiState = uiState.myFeedState,
-                        errorDialogVisible = uiState.error != null,
+                        headerBarHeight = headerBarHeightDp,
                         onDeleteOrHide = callbacks.onDeleteOrHide,
                         recommendTrack = callbacks.onRecommend,
                         personallyRecommendTrack = { index ->
@@ -267,7 +273,7 @@ fun FeedScreen(
 
                     1 -> FollowListens(
                         listState = followListensListState,
-                        errorDialogVisible = uiState.error != null,
+                        headerBarHeight = headerBarHeightDp,
                         pagingData = followListensPagingData,
                         recommendTrack = callbacks.onRecommend,
                         personallyRecommendTrack = { index ->
@@ -295,7 +301,7 @@ fun FeedScreen(
 
                     2 -> SimilarListens(
                         listState = similarListensListState,
-                        errorDialogVisible = uiState.error != null,
+                        headerBarHeight = headerBarHeightDp,
                         pagingData = similarListensPagingData,
                         recommendTrack = callbacks.onRecommend,
                         personallyRecommendTrack = { index ->
@@ -333,19 +339,28 @@ fun FeedScreen(
                 }
             }
 
-            Column(Modifier.fillMaxWidth()) {
-                ErrorBar(error = uiState.error, onErrorShown = callbacks.onErrorShown)
-                NavigationChips(
-                    chips = remember {
-                        listOf(
-                            "My Feed",
-                            "Follow Listens",
-                            "Similar Listens"
-                        )
-                    },
-                    currentPageStateProvider = { pagerState.currentPage }
-                ) { position ->
-                    pagerState.animateScrollToPage(position)
+            Column(Modifier
+                .fillMaxWidth()) {
+                Column(Modifier
+                    .onSizeChanged {
+                        headerBarHeightPx = it.height
+                    }) {
+                    ErrorBar(
+                        error = uiState.error,
+                        onErrorShown = callbacks.onErrorShown
+                    )
+                    NavigationChips(
+                        chips = remember {
+                            listOf(
+                                "My Feed",
+                                "Follow Listens",
+                                "Similar Listens"
+                            )
+                        },
+                        currentPageStateProvider = { pagerState.currentPage }
+                    ) { position ->
+                        pagerState.animateScrollToPage(position)
+                    }
                 }
                 PullRefreshIndicator(
                     modifier = Modifier.align(Alignment.CenterHorizontally),
@@ -451,7 +466,7 @@ private fun MyFeed(
     listState: LazyListState,
     pagingData: LazyPagingItems<FeedUiEventItem>,
     uiState: FeedUiEventData,
-    errorDialogVisible: Boolean,
+    headerBarHeight: Dp,
     onDeleteOrHide: (event: FeedEvent, eventType: FeedEventType, parentUser: String) -> Unit,
     recommendTrack: (event: FeedEvent) -> Unit,
     personallyRecommendTrack: (index: Int) -> Unit,
@@ -480,9 +495,9 @@ private fun MyFeed(
         modifier = Modifier
             .fillMaxSize()
             .widthIn(max = LocalConfiguration.current.screenWidthDp.dp),
-        state = listState
+        state = listState,
+        contentPadding = PaddingValues(top = headerBarHeight)
     ) {
-        item { StartingSpacer(errorDialogVisible) }
 
         if (inRefreshingState) {
             item(contentType = "shimmer") {
@@ -564,7 +579,7 @@ private fun MyFeed(
 @Composable
 fun FollowListens(
     listState: LazyListState,
-    errorDialogVisible: Boolean,
+    headerBarHeight: Dp,
     pagingData: LazyPagingItems<FeedUiEventItem>,
     recommendTrack: (event: FeedEvent) -> Unit,
     personallyRecommendTrack: (index: Int) -> Unit,
@@ -593,9 +608,8 @@ fun FollowListens(
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         state = listState,
+        contentPadding = PaddingValues(top = headerBarHeight)
     ) {
-
-        item { StartingSpacer(errorDialogVisible) }
 
         if (inRefreshingState) {
             item(contentType = "shimmer") {
@@ -700,7 +714,7 @@ fun FollowListens(
 @Composable
 fun SimilarListens(
     listState: LazyListState,
-    errorDialogVisible: Boolean,
+    headerBarHeight: Dp,
     pagingData: LazyPagingItems<FeedUiEventItem>,
     recommendTrack: (event: FeedEvent) -> Unit,
     personallyRecommendTrack: (index: Int) -> Unit,
@@ -729,9 +743,9 @@ fun SimilarListens(
 
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
-        state = listState
+        state = listState,
+        contentPadding = PaddingValues(top = headerBarHeight)
     ) {
-        item { StartingSpacer(errorDialogVisible) }
 
         if (inRefreshingState) {
             item(contentType = "shimmer") {
@@ -1038,15 +1052,6 @@ fun ShimmerListensItem(
         }
     }
 
-}
-
-@Composable
-fun StartingSpacer(errorDialogVisible: Boolean) {
-    Spacer(
-        modifier = Modifier.height(
-            if (errorDialogVisible) 85.dp else 60.dp
-        )
-    )
 }
 
 @Composable


### PR DESCRIPTION
Fixes #734 

https://github.com/user-attachments/assets/179db080-0095-47ab-a4a9-12e0898106c2

Fixes the layout overlap on the Feed screen when the ErrorBar appears. Previously, when a network error occurred, the ErrorBar increased the height of the header section (TopBar + ErrorBar + NavigationChips), but the feed list below did not adjust its starting offset. This caused feed tiles to overlap with the header area.

The fix makes the spacer at the top of the feed list dynamic instead of fixed. Its height now depends on whether the ErrorBar is visible. When the error banner appears, the spacer becomes larger so the feed content starts lower and remains correctly positioned below the header. When there is no error, the spacer keeps the normal height.

This keeps the layout consistent and prevents the overlap issue across all feed tabs (My Feed, Follow Listens, and Similar Listens).