### PR TITLE
Migrated SettingsViewModel to shared module

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -152,8 +152,8 @@ dependencies {
 
     // AndroidX libraries
     implementation(libs.androidx.appcompat)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
-    implementation(libs.androidx.lifecycle.viewmodel.ktx)
+    implementation(libs.androidx.lifecycle.runtime)
+    implementation(libs.androidx.lifecycle.viewmodel)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.livedata.ktx)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,7 +23,7 @@ android {
     val versionMap = mapOf(
         major to 2,
         minor to 15,
-        patch to 0,
+        patch to 1,
         build to 0
     )
     fun versionCode() = versionMap[major]!! * 10000 + versionMap[minor]!! * 100 + versionMap[patch]!! * 10 + versionMap[build]!! * 1

--- a/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
+++ b/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
@@ -136,12 +136,13 @@ import org.listenbrainz.android.viewmodel.NewsListViewModel
 import org.listenbrainz.android.viewmodel.PlaylistDataViewModel
 import org.listenbrainz.android.viewmodel.PlaylistViewModel
 import org.listenbrainz.android.viewmodel.SearchViewModel
-import org.listenbrainz.android.viewmodel.SettingsViewModel
+import org.listenbrainz.shared.viewmodel.SettingsViewModel
 import org.listenbrainz.android.viewmodel.SocialViewModel
 import org.listenbrainz.android.viewmodel.SongViewModel
 import org.listenbrainz.android.viewmodel.UserViewModel
 import org.listenbrainz.android.viewmodel.Yim23ViewModel
 import org.listenbrainz.android.viewmodel.YimViewModel
+import org.listenbrainz.shared.di.sharedViewModelModule
 
 // Qualifier names for dispatchers
 const val DEFAULT_DISPATCHER = "DefaultDispatcher"
@@ -562,7 +563,6 @@ val viewModelModule = module {
     viewModel { SongViewModel(get(), get(named(IO_DISPATCHER))) }
     viewModel { ArtistViewModel(get(), get(named(IO_DISPATCHER))) }
     viewModel { AlbumViewModel(get(), get(named(IO_DISPATCHER))) }
-    viewModel { SettingsViewModel(get()) }
     viewModel { FeaturesViewModel(get()) }
     viewModel { AboutViewModel() }
     viewModel { LoginViewModel() }
@@ -577,5 +577,6 @@ val appModules = listOf(
     appModule,
     repositoryModule,
     playerModule,
-    viewModelModule
+    viewModelModule,
+    sharedViewModelModule
 )

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
@@ -112,6 +112,10 @@ import kotlin.math.absoluteValue
 import kotlin.math.max
 
 @ExperimentalMaterialApi
+private fun BackdropScaffoldState.offsetOrZero(): Float =
+    try { requireOffset() } catch (_: IllegalStateException) { 0f }
+
+@ExperimentalMaterialApi
 @Composable
 fun BrainzPlayerBackDropScreen(
     modifier: Modifier = Modifier,
@@ -177,7 +181,7 @@ fun BrainzPlayerBackDropScreen(
         persistentAppBar = false,
         frontLayerContent = {
             LaunchedEffect(Unit) {
-                val delta = backdropScaffoldState.requireOffset()
+                val delta = backdropScaffoldState.offsetOrZero()
                 maxDelta = max(delta, maxDelta)
             }
 
@@ -209,7 +213,7 @@ fun BrainzPlayerBackDropScreen(
                             .height(ListenBrainzTheme.sizes.brainzPlayerPeekHeight)
                             .graphicsLayer {
                                 alpha =
-                                    (backdropScaffoldState.requireOffset() / (maxDelta - headerHeight.toPx()))
+                                    (backdropScaffoldState.offsetOrZero() / (maxDelta - headerHeight.toPx()))
                             },
                         songList = currentPlayableState.value.songs,
                         backdropScaffoldState = backdropScaffoldState,
@@ -235,7 +239,7 @@ fun BrainzPlayerBackDropScreen(
                                 .fillMaxSize()
                                 .graphicsLayer {
                                     val value =
-                                        (backdropScaffoldState.requireOffset() / (maxDelta - headerHeight.toPx()))
+                                        (backdropScaffoldState.offsetOrZero() / (maxDelta - headerHeight.toPx()))
                                     alpha =
                                         if (value < 0.8f)
                                             (1f - value) * 0.25f else 0f
@@ -267,7 +271,7 @@ fun BrainzPlayerBackDropScreen(
                             .height(ListenBrainzTheme.sizes.brainzPlayerPeekHeight)
                             .graphicsLayer {
                                 alpha =
-                                    (backdropScaffoldState.requireOffset() / (maxDelta - headerHeight.toPx()))
+                                    (backdropScaffoldState.offsetOrZero() / (maxDelta - headerHeight.toPx()))
                             }
                     )
                 }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/settings/SettingsScreen.kt
@@ -68,7 +68,7 @@ import org.listenbrainz.android.util.Constants
 import org.listenbrainz.android.util.Utils.submitLogs
 import org.listenbrainz.android.viewmodel.DashBoardViewModel
 import org.listenbrainz.android.viewmodel.ListensViewModel
-import org.listenbrainz.android.viewmodel.SettingsViewModel
+import org.listenbrainz.shared.viewmodel.SettingsViewModel
 
 @Composable
 fun SettingsScreen(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,6 +74,8 @@ koin-androidx-compose = { module = "io.insert-koin:koin-androidx-compose", versi
 koin-androidx-workmanager = { module = "io.insert-koin:koin-androidx-workmanager" }
 koin-test = { module = "io.insert-koin:koin-test" }
 koin-test-junit4 = { module = "io.insert-koin:koin-test-junit4" }
+koin-compose = { module = "io.insert-koin:koin-compose", version.ref = "koin" }
+koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel", version.ref = "koin" }
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime", version.ref = "lifecycle" }
 androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel", version.ref = "lifecycle" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -68,14 +68,14 @@ core = "1.7.0"
 [libraries]
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 koin-bom = { module = "io.insert-koin:koin-bom", version.ref = "koin" }
-koin-core = { module = "io.insert-koin:koin-core" }
+koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 koin-android = { module = "io.insert-koin:koin-android" }
 koin-androidx-compose = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koinAndroidxCompose" }
 koin-androidx-workmanager = { module = "io.insert-koin:koin-androidx-workmanager" }
 koin-test = { module = "io.insert-koin:koin-test" }
 koin-test-junit4 = { module = "io.insert-koin:koin-test-junit4" }
-androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }
-androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
+androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime", version.ref = "lifecycle" }
+androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel", version.ref = "lifecycle" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle" }
 androidx-lifecycle-livedata-ktx = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "lifecycle" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -81,6 +81,8 @@ kotlin {
                 implementation(libs.androidx.lifecycle.runtime)
                 // koin
                 implementation(libs.koin.core)
+                implementation(libs.koin.compose)
+                implementation(libs.koin.compose.viewmodel)
                 // Room Multiplatform
                 implementation(libs.androidx.room.runtime)
                 implementation(libs.androidx.sqlite.bundled)

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -76,6 +76,11 @@ kotlin {
                 implementation(libs.datastore.preferences.core)
                 implementation(libs.kotlinx.serialization.json)
                 api(libs.kotlinx.coroutines.core)
+                // lifecycle
+                api(libs.androidx.lifecycle.viewmodel)
+                implementation(libs.androidx.lifecycle.runtime)
+                // koin
+                implementation(libs.koin.core)
                 // Room Multiplatform
                 implementation(libs.androidx.room.runtime)
                 implementation(libs.androidx.sqlite.bundled)

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
@@ -1,0 +1,9 @@
+package org.listenbrainz.shared.di
+
+import org.koin.core.module.dsl.viewModel
+import org.koin.dsl.module
+import org.listenbrainz.shared.viewmodel.SettingsViewModel
+
+val sharedViewModelModule = module {
+    viewModel { SettingsViewModel(get()) }
+}

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/viewmodel/SettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/viewmodel/SettingsViewModel.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android.viewmodel
+package org.listenbrainz.shared.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -23,7 +23,7 @@ class SettingsViewModel(
             _logoutStatus.emit(result)
         }
     }
-    
+
     fun version(): String {
         return appPreferences.version
     }

--- a/sharedTest/src/main/java/org/listenbrainz/sharedtest/mocks/MockListensRepository.kt
+++ b/sharedTest/src/main/java/org/listenbrainz/sharedtest/mocks/MockListensRepository.kt
@@ -59,4 +59,11 @@ class MockListensRepository : ListensRepository {
     override suspend fun getNowPlaying(username: String?): Resource<Listens> {
         TODO("Not yet implemented")
     }
+
+    override suspend fun deleteListen(
+        listenedAt: Long,
+        recordingMsid: String
+    ): Resource<PostResponse> {
+        TODO("Not yet implemented")
+    }
 }


### PR DESCRIPTION
This PR fixes #716 migrates the `SettingsViewModel` from native `androidApp` module to shared module.

### Key Changes

1. Moved `SettingsViewModel` to `shared/commonMain/viewmodel/` using kmp lifecycle dependencies.
2. Created `SharedViewModelModule` inside the shared module for a single source for registering all shared viewmodels.
3. Wired the new `sharedViewModelModule` to the core `KoinModules` under `androidApp` module.
