### PR TITLE
Migrated CreateAccountViewModel to shared module

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
+++ b/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
@@ -123,7 +123,6 @@ import org.listenbrainz.shared.viewmodel.ArtistViewModel
 import org.listenbrainz.android.viewmodel.BPAlbumViewModel
 import org.listenbrainz.android.viewmodel.BPArtistViewModel
 import org.listenbrainz.android.viewmodel.BrainzPlayerViewModel
-import org.listenbrainz.android.viewmodel.CreateAccountViewModel
 import org.listenbrainz.android.viewmodel.DashBoardViewModel
 import org.listenbrainz.android.viewmodel.FeaturesViewModel
 import org.listenbrainz.android.viewmodel.FeedViewModel
@@ -521,7 +520,6 @@ val viewModelModule = module {
     viewModel { FeaturesViewModel(get()) }
     viewModel { AboutViewModel() }
     viewModel { LoginViewModel(get()) }
-    viewModel { CreateAccountViewModel(get()) }
 }
 
 val appModules = listOf(
@@ -536,6 +534,5 @@ val appModules = listOf(
     sharedNetworkServiceModule,
     sharedDispatcherModule,
     sharedRepositoryModule,
-    sharedViewModelModule,
     platformModule
 )

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/onboarding/auth/CreateAccountWebView.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/onboarding/auth/CreateAccountWebView.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import org.listenbrainz.android.ui.screens.onboarding.auth.createaccount.CreateAccountClientCallbacks
 import org.listenbrainz.android.ui.screens.onboarding.auth.createaccount.CreateAccountWebAppInterface
 import org.listenbrainz.android.ui.screens.profile.CreateAccountWebClient
-import org.listenbrainz.android.viewmodel.CreateAccountViewModel
+import org.listenbrainz.shared.viewmodel.CreateAccountViewModel
 
 @SuppressLint("SetJavaScriptEnabled")
 @Composable

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/onboarding/auth/createaccount/CreateAccountScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/onboarding/auth/createaccount/CreateAccountScreen.kt
@@ -23,9 +23,9 @@ import org.koin.androidx.compose.koinViewModel
 import org.listenbrainz.android.ui.components.LoadingAnimation
 import org.listenbrainz.android.ui.screens.onboarding.auth.CreateAccountWebViewClient
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
-import org.listenbrainz.android.viewmodel.CreateAccountState
-import org.listenbrainz.android.viewmodel.CreateAccountScreenState
-import org.listenbrainz.android.viewmodel.CreateAccountViewModel
+import org.listenbrainz.shared.viewmodel.CreateAccountState
+import org.listenbrainz.shared.viewmodel.CreateAccountScreenState
+import org.listenbrainz.shared.viewmodel.CreateAccountViewModel
 
 private const val TAG = "CreateAccountScreen"
 

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/onboarding/auth/createaccount/CreateAccountScreenLayout.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/onboarding/auth/createaccount/CreateAccountScreenLayout.kt
@@ -67,8 +67,8 @@ import org.listenbrainz.android.ui.screens.onboarding.introduction.OnboardingSup
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.ui.theme.lb_purple
 import org.listenbrainz.android.ui.theme.lb_purple_night
-import org.listenbrainz.android.viewmodel.CreateAccountUIState
-import org.listenbrainz.android.viewmodel.CreateAccountScreenState
+import org.listenbrainz.shared.viewmodel.CreateAccountUIState
+import org.listenbrainz.shared.viewmodel.CreateAccountScreenState
 import org.listenbrainz.shared.repository.PlatformContext
 
 @Composable

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/CreateAccountWebClient.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/CreateAccountWebClient.kt
@@ -12,7 +12,7 @@ import org.json.JSONObject
 import org.listenbrainz.shared.model.ResponseError
 import org.listenbrainz.android.ui.screens.onboarding.auth.createaccount.CreateAccountClientCallbacks
 import org.listenbrainz.shared.util.Resource
-import org.listenbrainz.android.viewmodel.CreateAccountCredentials
+import org.listenbrainz.shared.viewmodel.CreateAccountCredentials
 
 private const val TAG = "CreateAccountWebClient"
 

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
@@ -3,10 +3,12 @@ package org.listenbrainz.shared.di
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
+import org.listenbrainz.shared.viewmodel.CreateAccountViewModel
 import org.listenbrainz.shared.viewmodel.ArtistViewModel
 import org.listenbrainz.shared.viewmodel.SettingsViewModel
 
 val sharedViewModelModule = module {
     viewModel { SettingsViewModel(get(),get()) }
+    viewModel { CreateAccountViewModel(get()) }
     viewModel { ArtistViewModel(get(),get(named(IO_DISPATCHER))) }
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/viewmodel/CreateAccountViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/viewmodel/CreateAccountViewModel.kt
@@ -1,6 +1,5 @@
-package org.listenbrainz.android.viewmodel
+package org.listenbrainz.shared.viewmodel
 
-import android.util.Patterns
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Job
@@ -55,6 +54,8 @@ class CreateAccountViewModel(
 ) : ViewModel() {
     private companion object {
         const val TIMEOUT_SECONDS = 60
+
+        val EMAIL_REGEX = """^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$""".toRegex()
     }
 
     private val _uiState = MutableStateFlow(CreateAccountUIState())
@@ -154,7 +155,7 @@ class CreateAccountViewModel(
                 _uiState.update { it.copy(errorMessage = "Email cannot be empty") }
                 return
             }
-            !Patterns.EMAIL_ADDRESS.matcher(credentials.email).matches() -> {
+            !EMAIL_REGEX.matches(credentials.email) -> {
                 _uiState.update { it.copy(errorMessage = "Please enter a valid email address") }
                 return
             }


### PR DESCRIPTION
## Base PR:- None
#### Rebased with the latest upstream/cmp branch, and there is no base PR for this specific one.

---

This PR fixes https://github.com/metabrainz/listenbrainz-android/issues/718 migrates the `CreateAccountViewModel` from native `androidApp` module to `shared` module.
## Key Changes:- 

1. Moved `CreateAccountViewModel` to shared/commonMain/viewmodel/ using kmp lifecycle dependencies.
2. Registered the viewmodel under `sharedViewModelModule`.
3. Wired the `sharedViewModelModule` to the core `KoinModules` under `androidApp` module.