### PR TITLE
Migrated NewsListViewModel to shared module

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
+++ b/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
@@ -97,7 +97,6 @@ import org.listenbrainz.android.service.Yim23Service
 import org.listenbrainz.android.service.YimService
 import org.listenbrainz.android.service.YouTubeApiService
 import org.listenbrainz.android.service.createAlbumService
-import org.listenbrainz.android.service.createBlogService
 import org.listenbrainz.android.service.createGithubAppUpdatesService
 import org.listenbrainz.android.service.createListensService
 import org.listenbrainz.android.service.createPlaylistService

--- a/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
+++ b/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
@@ -47,8 +47,8 @@ import org.listenbrainz.android.repository.appupdates.AppUpdatesRepository
 import org.listenbrainz.android.repository.appupdates.AppUpdatesRepositoryImpl
 import org.listenbrainz.shared.repository.artist.ArtistRepository
 import org.listenbrainz.shared.repository.artist.ArtistRepositoryImpl
-import org.listenbrainz.android.repository.blog.BlogRepository
-import org.listenbrainz.android.repository.blog.BlogRepositoryImpl
+import org.listenbrainz.shared.repository.blog.BlogRepository
+import org.listenbrainz.shared.repository.blog.BlogRepositoryImpl
 import org.listenbrainz.android.repository.brainzplayer.BPAlbumRepository
 import org.listenbrainz.android.repository.brainzplayer.BPAlbumRepositoryImpl
 import org.listenbrainz.android.repository.brainzplayer.BPArtistRepository
@@ -81,7 +81,7 @@ import org.listenbrainz.android.repository.yim23.Yim23Repository
 import org.listenbrainz.android.repository.yim23.Yim23RepositoryImpl
 import org.listenbrainz.android.service.AlbumService
 import org.listenbrainz.shared.service.ArtistService
-import org.listenbrainz.android.service.BlogService
+import org.listenbrainz.shared.service.BlogService
 import org.listenbrainz.android.service.BrainzPlayerServiceConnection
 import org.listenbrainz.shared.service.CBService
 import org.listenbrainz.android.service.FeedServiceKtor
@@ -130,7 +130,7 @@ import org.listenbrainz.android.viewmodel.FeedViewModel
 import org.listenbrainz.android.viewmodel.ListeningNowViewModel
 import org.listenbrainz.android.viewmodel.ListensViewModel
 import org.listenbrainz.android.viewmodel.LoginViewModel
-import org.listenbrainz.android.viewmodel.NewsListViewModel
+import org.listenbrainz.shared.viewmodel.NewsListViewModel
 import org.listenbrainz.android.viewmodel.PlaylistDataViewModel
 import org.listenbrainz.android.viewmodel.PlaylistViewModel
 import org.listenbrainz.android.viewmodel.SearchViewModel
@@ -146,13 +146,11 @@ import org.listenbrainz.shared.util.LogSubmitter
 import org.listenbrainz.shared.di.sharedDispatcherModule
 import org.listenbrainz.shared.di.sharedNetworkServiceModule
 import org.listenbrainz.shared.di.sharedRepositoryModule
+import org.listenbrainz.shared.di.DEFAULT_DISPATCHER
+import org.listenbrainz.shared.di.IO_DISPATCHER
 import org.listenbrainz.shared.di.sharedViewModelModule
 import org.listenbrainz.shared.di.sharedViewModelModule
 
-// Qualifier names for dispatchers
-const val DEFAULT_DISPATCHER = "DefaultDispatcher"
-const val IO_DISPATCHER = "IoDispatcher"
-const val MAIN_DISPATCHER = "MainDispatcher"
 
 private val jsonConfig = Json {
     ignoreUnknownKeys = true
@@ -256,18 +254,6 @@ val daoModule = module {
 val networkModule = module {
     single<HttpClient> {
         createBaseHttpClient(androidContext(), get<AppPreferences>())
-    }
-
-    single<BlogService> {
-        val httpClient = createBaseHttpClient(
-            androidContext(),
-            baseUrl = "https://public-api.wordpress.com/rest/v1.1/sites/"
-        )
-        Ktorfit.Builder()
-            .baseUrl("https://public-api.wordpress.com/rest/v1.1/sites/")
-            .httpClient(httpClient)
-            .build()
-            .createBlogService()
     }
 
     single<ListensService> {
@@ -465,7 +451,6 @@ val repositoryModule = module {
     single<ListensRepository> { ListensRepositoryImpl(get(), get(), get(), get(), get(named(IO_DISPATCHER))) }
     single<PlaylistDataRepository> { PlaylistDataRepositoryImpl(get(), get(), get(), get(named(IO_DISPATCHER))) }
     single<AlbumRepository> { AlbumRepositoryImpl(get(), get(), get()) }
-    single<BlogRepository> { BlogRepositoryImpl(get()) }
     single<YimRepository> { YimRepositoryImpl(get()) }
     single<Yim23Repository> { Yim23RepositoryImpl(get()) }
     single<AppUpdatesRepository> { AppUpdatesRepositoryImpl(get(), get(), get(named(IO_DISPATCHER))) }
@@ -525,6 +510,7 @@ val viewModelModule = module {
 }
 
 val appModules = listOf(
+    sharedDispatcherModule,
     databaseModule,
     daoModule,
     networkModule,
@@ -533,6 +519,8 @@ val appModules = listOf(
     playerModule,
     viewModelModule,
     sharedViewModelModule,
+    sharedNetworkServiceModule,
+    sharedRepositoryModule,
     sharedNetworkServiceModule,
     sharedDispatcherModule,
     sharedRepositoryModule,

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/newsbrainz/NewsBrainzActivity.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/newsbrainz/NewsBrainzActivity.kt
@@ -13,7 +13,7 @@ import com.aemerse.share.Share
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.shared.util.Log
-import org.listenbrainz.android.viewmodel.NewsListViewModel
+import org.listenbrainz.shared.viewmodel.NewsListViewModel
 
 class NewsBrainzActivity : ComponentActivity() {
 

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/newsbrainz/NewsBrainzScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/newsbrainz/NewsBrainzScreen.kt
@@ -39,12 +39,12 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.text.HtmlCompat
-import org.listenbrainz.android.model.BlogPost
+import org.listenbrainz.shared.model.BlogPost
 import org.listenbrainz.android.ui.components.LoadingAnimation
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.ui.theme.offWhite
 import org.listenbrainz.android.ui.theme.onScreenUiModeIsDark
-import org.listenbrainz.android.viewmodel.NewsListViewModel
+import org.listenbrainz.shared.viewmodel.NewsListViewModel
 import org.listenbrainz.android.R
 
 @Composable

--- a/app/src/main/java/org/listenbrainz/android/util/Utils.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/Utils.kt
@@ -66,8 +66,8 @@ import org.listenbrainz.android.R
 import org.listenbrainz.shared.util.Log
 import org.listenbrainz.shared.model.ApiError
 import org.listenbrainz.shared.model.ResponseError
-import org.listenbrainz.shared.util.Constants
 import org.listenbrainz.shared.util.Resource
+import org.listenbrainz.shared.util.Constants
 import java.io.*
 import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedNetworkServiceModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedNetworkServiceModule.kt
@@ -26,6 +26,8 @@ import org.listenbrainz.shared.service.createCBService
 import org.listenbrainz.shared.util.Constants.CB_BASE_URL
 import org.listenbrainz.shared.util.Constants.LB_BASE_URL
 import org.listenbrainz.shared.util.Constants.MB_BASE_URL
+import org.listenbrainz.shared.service.BlogService
+import org.listenbrainz.shared.service.createBlogService
 
 const val DEFAULT_DISPATCHER = "DefaultDispatcher"
 const val IO_DISPATCHER = "IoDispatcher"
@@ -64,6 +66,14 @@ val sharedNetworkServiceModule = module {
         }
     }
 
+    single<BlogService> {
+        Ktorfit.Builder()
+            .baseUrl("https://public-api.wordpress.com/rest/v1.1/sites/")
+            .httpClient(get<HttpClient>(named(SHARED_HTTP_CLIENT)))
+            .build()
+            .createBlogService()
+    }
+
     single<ArtistService> {
         Ktorfit.Builder()
             .baseUrl(LB_BASE_URL)
@@ -94,6 +104,7 @@ val sharedNetworkServiceModule = module {
             .build()
             .createCBService()
     }
+
 }
 
 val sharedDispatcherModule = module {

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedRepositoryModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedRepositoryModule.kt
@@ -1,9 +1,12 @@
 package org.listenbrainz.shared.di
 
 import org.koin.dsl.module
+import org.listenbrainz.shared.repository.blog.BlogRepository
+import org.listenbrainz.shared.repository.blog.BlogRepositoryImpl
 import org.listenbrainz.shared.repository.artist.ArtistRepository
 import org.listenbrainz.shared.repository.artist.ArtistRepositoryImpl
 
 val sharedRepositoryModule = module {
+    single<BlogRepository> { BlogRepositoryImpl(get()) }
     single<ArtistRepository> { ArtistRepositoryImpl(get(),get(),get()) }
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
@@ -3,10 +3,12 @@ package org.listenbrainz.shared.di
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
+import org.listenbrainz.shared.viewmodel.NewsListViewModel
 import org.listenbrainz.shared.viewmodel.ArtistViewModel
 import org.listenbrainz.shared.viewmodel.SettingsViewModel
 
 val sharedViewModelModule = module {
     viewModel { SettingsViewModel(get(),get()) }
+    viewModel { NewsListViewModel(get(),get(named(IO_DISPATCHER))) }
     viewModel { ArtistViewModel(get(),get(named(IO_DISPATCHER))) }
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/model/Blog.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/model/Blog.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android.model
+package org.listenbrainz.shared.model
 
 import kotlinx.serialization.Serializable
 

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/model/BlogPost.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/model/BlogPost.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android.model
+package org.listenbrainz.shared.model
 
 import kotlinx.serialization.Serializable
 

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/blog/BlogRepository.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/blog/BlogRepository.kt
@@ -1,6 +1,6 @@
-package org.listenbrainz.android.repository.blog
+package org.listenbrainz.shared.repository.blog
 
-import org.listenbrainz.android.model.Blog
+import org.listenbrainz.shared.model.Blog
 import org.listenbrainz.shared.util.Resource
 
 interface BlogRepository {

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/blog/BlogRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/blog/BlogRepositoryImpl.kt
@@ -1,14 +1,12 @@
-package org.listenbrainz.android.repository.blog
+package org.listenbrainz.shared.repository.blog
 
-import androidx.annotation.WorkerThread
-import org.listenbrainz.android.service.BlogService
-import org.listenbrainz.android.model.Blog
+import org.listenbrainz.shared.service.BlogService
+import org.listenbrainz.shared.model.Blog
 import org.listenbrainz.shared.util.Resource
 import org.listenbrainz.shared.util.Resource.Status.SUCCESS
 
 class BlogRepositoryImpl(private val service: BlogService) : BlogRepository {
 
-    @WorkerThread
     override suspend fun fetchBlogs(): Resource<Blog> {
         return try {
             val result = service.getBlogs()

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/service/BlogService.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/service/BlogService.kt
@@ -1,7 +1,7 @@
-package org.listenbrainz.android.service
+package org.listenbrainz.shared.service
 
 import de.jensklingenberg.ktorfit.http.GET
-import org.listenbrainz.android.model.Blog
+import org.listenbrainz.shared.model.Blog
 
 interface BlogService {
     @GET("blog.metabrainz.org/posts/")

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/viewmodel/NewsListViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/viewmodel/NewsListViewModel.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android.viewmodel
+package org.listenbrainz.shared.viewmodel
 
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -10,10 +10,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import org.listenbrainz.android.model.BlogPost
-import org.listenbrainz.android.repository.blog.BlogRepository
+import org.listenbrainz.shared.model.BlogPost
+import org.listenbrainz.shared.repository.blog.BlogRepository
 import org.listenbrainz.shared.util.Resource
-import org.listenbrainz.shared.util.Resource.Status.SUCCESS
 
 class NewsListViewModel(
     private val repository: BlogRepository,
@@ -27,7 +26,7 @@ class NewsListViewModel(
         viewModelScope.launch {
             val response = repository.fetchBlogs()
             when (response.status) {
-                SUCCESS -> {
+                Resource.Status.SUCCESS -> {
                     val responseBlogs = response.data!!
                     // Updating blogs
                     _blogPostsFlow.update { responseBlogs.posts }


### PR DESCRIPTION
## Base PR: #745 
#### Rebased with the latest upstream/cmp branch, and cherry-picked few commits from above mentioned base PR.

---

This PR fixes https://github.com/metabrainz/listenbrainz-android/issues/707 migrates the `NewsListViewModel` from native `androidApp` module to `shared` module.
## Key Changes:- 

1. Moved `NewsListViewModel` to shared/commonMain/viewmodel/ using kmp lifecycle dependencies.
2. Migrated all the necessary data models, services and repositories to shared module.
3. Registered the viewmodel under `sharedViewModelModule`, service under `sharedNetworkServiceModule` and repos under `sharedRepositoryModule`.
3. Wired all the `sharedModules` to the core `KoinModules` under `androidApp` module.