### PR TITLE
Migrated Album Viewmodel to shared module

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
+++ b/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
@@ -41,8 +41,6 @@ import org.listenbrainz.android.model.dao.ArtistDao
 import org.listenbrainz.android.model.dao.PendingListensDao
 import org.listenbrainz.android.model.dao.PlaylistDao
 import org.listenbrainz.android.model.dao.SongDao
-import org.listenbrainz.android.repository.album.AlbumRepository
-import org.listenbrainz.android.repository.album.AlbumRepositoryImpl
 import org.listenbrainz.android.repository.appupdates.AppUpdatesRepository
 import org.listenbrainz.android.repository.appupdates.AppUpdatesRepositoryImpl
 import org.listenbrainz.shared.repository.artist.ArtistRepository
@@ -79,7 +77,6 @@ import org.listenbrainz.android.repository.yim.YimRepository
 import org.listenbrainz.android.repository.yim.YimRepositoryImpl
 import org.listenbrainz.android.repository.yim23.Yim23Repository
 import org.listenbrainz.android.repository.yim23.Yim23RepositoryImpl
-import org.listenbrainz.android.service.AlbumService
 import org.listenbrainz.shared.service.ArtistService
 import org.listenbrainz.shared.service.BlogService
 import org.listenbrainz.android.service.BrainzPlayerServiceConnection
@@ -96,7 +93,6 @@ import org.listenbrainz.android.service.UserService
 import org.listenbrainz.android.service.Yim23Service
 import org.listenbrainz.android.service.YimService
 import org.listenbrainz.android.service.YouTubeApiService
-import org.listenbrainz.android.service.createAlbumService
 import org.listenbrainz.android.service.createGithubAppUpdatesService
 import org.listenbrainz.android.service.createListensService
 import org.listenbrainz.android.service.createPlaylistService
@@ -116,7 +112,6 @@ import org.listenbrainz.shared.util.Log
 import org.listenbrainz.android.util.MusicSource
 import org.listenbrainz.android.util.Utils
 import org.listenbrainz.android.viewmodel.AboutViewModel
-import org.listenbrainz.android.viewmodel.AlbumViewModel
 import org.listenbrainz.android.viewmodel.AppUpdatesViewModel
 import org.listenbrainz.shared.viewmodel.ArtistViewModel
 import org.listenbrainz.android.viewmodel.BPAlbumViewModel

--- a/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
+++ b/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
@@ -138,15 +138,14 @@ import org.listenbrainz.android.viewmodel.SongViewModel
 import org.listenbrainz.android.viewmodel.UserViewModel
 import org.listenbrainz.android.viewmodel.Yim23ViewModel
 import org.listenbrainz.android.viewmodel.YimViewModel
+import org.listenbrainz.shared.di.DEFAULT_DISPATCHER
+import org.listenbrainz.shared.di.IO_DISPATCHER
 import org.listenbrainz.shared.di.platformModule
 import org.listenbrainz.shared.util.BuildInfo
 import org.listenbrainz.shared.util.LogSubmitter
 import org.listenbrainz.shared.di.sharedDispatcherModule
 import org.listenbrainz.shared.di.sharedNetworkServiceModule
 import org.listenbrainz.shared.di.sharedRepositoryModule
-import org.listenbrainz.shared.di.DEFAULT_DISPATCHER
-import org.listenbrainz.shared.di.IO_DISPATCHER
-import org.listenbrainz.shared.di.sharedViewModelModule
 import org.listenbrainz.shared.di.sharedViewModelModule
 
 
@@ -299,15 +298,6 @@ val networkModule = module {
             .createPlaylistService()
     }
 
-    single<AlbumService> {
-        val httpClient = createBaseHttpClient(androidContext(), baseUrl = LB_BASE_URL)
-        Ktorfit.Builder()
-            .baseUrl(LB_BASE_URL)
-            .httpClient(httpClient)
-            .build()
-            .createAlbumService()
-    }
-
     single<YouTubeApiService> {
         val context = androidContext()
         val httpClient = HttpClient(OkHttp) {
@@ -448,7 +438,6 @@ val repositoryModule = module {
     single<UserRepository> { UserRepositoryImpl(get(), get()) }
     single<ListensRepository> { ListensRepositoryImpl(get(), get(), get(), get(), get(named(IO_DISPATCHER))) }
     single<PlaylistDataRepository> { PlaylistDataRepositoryImpl(get(), get(), get(), get(named(IO_DISPATCHER))) }
-    single<AlbumRepository> { AlbumRepositoryImpl(get(), get(), get()) }
     single<YimRepository> { YimRepositoryImpl(get()) }
     single<Yim23Repository> { Yim23RepositoryImpl(get()) }
     single<AppUpdatesRepository> { AppUpdatesRepositoryImpl(get(), get(), get(named(IO_DISPATCHER))) }
@@ -500,7 +489,6 @@ val viewModelModule = module {
     viewModel { BPAlbumViewModel(get(), get(named(IO_DISPATCHER))) }
     viewModel { BPArtistViewModel(get(), get(named(IO_DISPATCHER))) }
     viewModel { SongViewModel(get(), get(named(IO_DISPATCHER))) }
-    viewModel { AlbumViewModel(get(), get(named(IO_DISPATCHER))) }
     viewModel { FeaturesViewModel(get()) }
     viewModel { AboutViewModel() }
     viewModel { LoginViewModel(get()) }
@@ -517,9 +505,6 @@ val appModules = listOf(
     viewModelModule,
     sharedViewModelModule,
     sharedNetworkServiceModule,
-    sharedRepositoryModule,
-    sharedNetworkServiceModule,
-    sharedDispatcherModule,
     sharedRepositoryModule,
     platformModule
 )

--- a/app/src/main/java/org/listenbrainz/android/repository/listens/ListensRepositoryImpl.kt
+++ b/app/src/main/java/org/listenbrainz/android/repository/listens/ListensRepositoryImpl.kt
@@ -18,6 +18,7 @@ import org.listenbrainz.android.service.UserService
 import org.listenbrainz.shared.util.Resource
 import org.listenbrainz.shared.util.Utils.parseResponse
 import org.listenbrainz.shared.model.CoverArt
+import org.listenbrainz.shared.util.Utils.parseResponse
 
 class ListensRepositoryImpl(
     private val service: ListensService,

--- a/app/src/main/java/org/listenbrainz/android/repository/listens/ListensRepositoryImpl.kt
+++ b/app/src/main/java/org/listenbrainz/android/repository/listens/ListensRepositoryImpl.kt
@@ -18,7 +18,6 @@ import org.listenbrainz.android.service.UserService
 import org.listenbrainz.shared.util.Resource
 import org.listenbrainz.shared.util.Utils.parseResponse
 import org.listenbrainz.shared.model.CoverArt
-import org.listenbrainz.shared.util.Utils.parseResponse
 
 class ListensRepositoryImpl(
     private val service: ListensService,

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/album/AlbumScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/album/AlbumScreen.kt
@@ -55,8 +55,9 @@ import org.listenbrainz.android.ui.screens.profile.stats.ArtistCard
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.ui.theme.new_app_bg_light
 import org.listenbrainz.shared.util.LinkUtils.parseLinks
-import org.listenbrainz.android.viewmodel.AlbumViewModel
+import org.listenbrainz.shared.viewmodel.AlbumViewModel
 import org.listenbrainz.android.viewmodel.SocialViewModel
+import org.listenbrainz.shared.ui.screens.album.AlbumUiState
 
 @Composable
 fun AlbumScreen(

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/artist/ArtistScreen.kt
@@ -650,7 +650,7 @@ private fun PopularTracks(
 
                 ListenCardSmallDefault(
                     metadata = metadata,
-                    coverArtUrl = Utils.getCoverArtUrl(track?.caaReleaseMbid, track?.caaId),
+                    coverArtUrl = org.listenbrainz.shared.util.Utils.getCoverArtUrl(track?.caaReleaseMbid, track?.caaId),
                     onDropdownError = { error ->
                         snackbarState.showSnackbar(error.toast)
                     },
@@ -715,7 +715,7 @@ private fun AlbumsCard(
                         }) {
                         Column {
                             val coverArt =
-                                Utils.getCoverArtUrl(album?.caaReleaseMbid, album?.caaId, 500)
+                                org.listenbrainz.shared.util.Utils.getCoverArtUrl(album?.caaReleaseMbid, album?.caaId, 500)
                             AsyncImage(
                                 model = ImageRequest.Builder(LocalContext.current)
                                     .data(coverArt)

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/feed/FeedScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/feed/FeedScreen.kt
@@ -625,7 +625,7 @@ fun FollowListens(
                             )
                         ),
                         coverArtUrl =
-                            Utils.getCoverArtUrl(
+                            org.listenbrainz.shared.util.Utils.getCoverArtUrl(
                                 caaReleaseMbid = event.metadata.trackMetadata?.mbidMapping?.caaReleaseMbid,
                                 caaId = event.metadata.trackMetadata?.mbidMapping?.caaId
                             ),
@@ -760,7 +760,7 @@ fun SimilarListens(
                             )
                         ),
                         coverArtUrl =
-                            Utils.getCoverArtUrl(
+                            org.listenbrainz.shared.util.Utils.getCoverArtUrl(
                                 caaReleaseMbid = event.metadata.trackMetadata?.mbidMapping?.caaReleaseMbid,
                                 caaId = event.metadata.trackMetadata?.mbidMapping?.caaId
                             ),

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/ListenFeedLayout.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/ListenFeedLayout.kt
@@ -43,7 +43,7 @@ fun ListenFeedLayout (
             trackName = event.metadata.trackMetadata?.trackName ?: "Unknown",
             artists = event.metadata.trackMetadata?.mbidMapping?.artists ?: listOf(FeedListenArtist(event.metadata.trackMetadata?.artistName ?: "" , null, "")),
             coverArtUrl = remember {
-                Utils.getCoverArtUrl(
+                org.listenbrainz.shared.util.Utils.getCoverArtUrl(
                     caaReleaseMbid = event.metadata.trackMetadata?.mbidMapping?.caaReleaseMbid,
                     caaId = event.metadata.trackMetadata?.mbidMapping?.caaId
                 )

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/ListenLikeFeedLayout.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/ListenLikeFeedLayout.kt
@@ -12,7 +12,7 @@ import org.listenbrainz.android.ui.components.ListenCardSmall
 import org.listenbrainz.android.ui.screens.feed.BaseFeedLayout
 import org.listenbrainz.android.ui.screens.feed.SocialDropdown
 import org.listenbrainz.android.util.PreviewSurface
-import org.listenbrainz.android.util.Utils.getCoverArtUrl
+import org.listenbrainz.shared.util.Utils
 
 @Composable
 fun ListenLikeFeedLayout(
@@ -42,7 +42,7 @@ fun ListenLikeFeedLayout(
             trackName = event.metadata.trackMetadata?.trackName ?: "Unknown",
             artists = event.metadata.trackMetadata?.mbidMapping?.artists ?: listOf(FeedListenArtist(event.metadata.trackMetadata?.artistName ?: "" , null, "")),
             coverArtUrl = remember {
-                getCoverArtUrl(
+                Utils.getCoverArtUrl(
                     caaReleaseMbid = event.metadata.trackMetadata?.mbidMapping?.caaReleaseMbid,
                     caaId = event.metadata.trackMetadata?.mbidMapping?.caaId
                 )

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/PersonalRecommendationFeedLayout.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/PersonalRecommendationFeedLayout.kt
@@ -55,7 +55,7 @@ fun PersonalRecommendationFeedLayout(
             trackName = event.metadata.trackMetadata?.trackName ?: "Unknown",
             artists = event.metadata.trackMetadata?.mbidMapping?.artists ?: listOf(FeedListenArtist(event.metadata.trackMetadata?.artistName ?: "" , null, "")),
             coverArtUrl = remember {
-                Utils.getCoverArtUrl(
+                org.listenbrainz.shared.util.Utils.getCoverArtUrl(
                     caaReleaseMbid = event.metadata.trackMetadata?.mbidMapping?.caaReleaseMbid,
                     caaId = event.metadata.trackMetadata?.mbidMapping?.caaId
                 )

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/PinFeedLayout.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/PinFeedLayout.kt
@@ -47,7 +47,7 @@ fun PinFeedLayout(
             trackName = event.metadata.trackMetadata?.trackName ?: "Unknown",
             artists = event.metadata.trackMetadata?.mbidMapping?.artists ?: listOf(FeedListenArtist(event.metadata.trackMetadata?.artistName ?: "" , null, "")),
             coverArtUrl = remember {
-                Utils.getCoverArtUrl(
+                org.listenbrainz.shared.util.Utils.getCoverArtUrl(
                     caaReleaseMbid = event.metadata.trackMetadata?.mbidMapping?.caaReleaseMbid,
                     caaId = event.metadata.trackMetadata?.mbidMapping?.caaId
                 )

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/RecordingRecommendationFeedLayout.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/RecordingRecommendationFeedLayout.kt
@@ -42,7 +42,7 @@ fun RecordingRecommendationFeedLayout(
             trackName = event.metadata.trackMetadata?.trackName ?: "Unknown",
             artists = event.metadata.trackMetadata?.mbidMapping?.artists ?: listOf(FeedListenArtist(event.metadata.trackMetadata?.artistName ?: "" , null, "")),
             coverArtUrl = remember {
-                Utils.getCoverArtUrl(
+                org.listenbrainz.shared.util.Utils.getCoverArtUrl(
                     caaReleaseMbid = event.metadata.trackMetadata?.mbidMapping?.caaReleaseMbid,
                     caaId = event.metadata.trackMetadata?.mbidMapping?.caaId
                 )

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/ReviewFeedLayout.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/ReviewFeedLayout.kt
@@ -66,7 +66,7 @@ fun ReviewFeedLayout(
             trackName = event.metadata.entityName ?: "Unknown",
             artists = event.metadata.trackMetadata?.mbidMapping?.artists ?: listOf(FeedListenArtist(event.metadata.trackMetadata?.artistName ?: "" , null, "")),
             coverArtUrl = remember {
-                Utils.getCoverArtUrl(
+                org.listenbrainz.shared.util.Utils.getCoverArtUrl(
                     caaReleaseMbid = event.metadata.trackMetadata?.mbidMapping?.caaReleaseMbid,
                     caaId = event.metadata.trackMetadata?.mbidMapping?.caaId
                 )

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/playlist/PlaylistDetailScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/playlist/PlaylistDetailScreen.kt
@@ -91,7 +91,7 @@ import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.ui.theme.lb_purple
 import org.listenbrainz.android.util.Utils
 import org.listenbrainz.android.util.Utils.formatDurationSeconds
-import org.listenbrainz.android.util.Utils.getCoverArtUrl
+import org.listenbrainz.shared.util.Utils.getCoverArtUrl
 import org.listenbrainz.android.util.Utils.removeHtmlTags
 import org.listenbrainz.android.viewmodel.PlaylistDataViewModel
 import org.listenbrainz.android.viewmodel.SocialViewModel

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/createdforyou/CreatedForYouScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/createdforyou/CreatedForYouScreen.kt
@@ -70,7 +70,7 @@ import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.shared.util.Log
 import org.listenbrainz.android.util.Utils.VerticalSpacer
 import org.listenbrainz.android.util.Utils.formatDurationSeconds
-import org.listenbrainz.android.util.Utils.getCoverArtUrl
+import org.listenbrainz.shared.util.Utils.getCoverArtUrl
 import org.listenbrainz.android.util.Utils.shareLink
 import org.listenbrainz.android.viewmodel.SocialViewModel
 import org.listenbrainz.android.viewmodel.UserViewModel

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/listens/ListensScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/listens/ListensScreen.kt
@@ -110,7 +110,7 @@ import org.listenbrainz.android.ui.theme.lb_purple_night
 import org.listenbrainz.shared.util.Constants
 import org.listenbrainz.android.util.PreviewSurface
 import org.listenbrainz.android.util.Utils.Spacer
-import org.listenbrainz.android.util.Utils.getCoverArtUrl
+import org.listenbrainz.shared.util.Utils.getCoverArtUrl
 import org.listenbrainz.android.util.consumeHorizontalDrag
 import org.listenbrainz.android.util.optionalSharedElement
 import org.listenbrainz.android.viewmodel.ListensViewModel

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/stats/StatsScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/stats/StatsScreen.kt
@@ -89,7 +89,7 @@ import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.util.PreviewSurface
 import org.listenbrainz.android.util.Utils.LaunchedEffectUnit
 import org.listenbrainz.android.util.Utils.Spacer
-import org.listenbrainz.android.util.Utils.getCoverArtUrl
+import org.listenbrainz.shared.util.Utils.getCoverArtUrl
 import org.listenbrainz.android.util.getStringResource
 import org.listenbrainz.android.viewmodel.SocialViewModel
 import org.listenbrainz.android.viewmodel.UserViewModel

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/taste/TasteScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/taste/TasteScreen.kt
@@ -65,7 +65,7 @@ import org.listenbrainz.android.ui.screens.profile.listens.LoadMoreButton
 import org.listenbrainz.android.ui.screens.profile.listens.headerTextVerticalPadding
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.util.PreviewSurface
-import org.listenbrainz.android.util.Utils.getCoverArtUrl
+import org.listenbrainz.shared.util.Utils.getCoverArtUrl
 import org.listenbrainz.android.viewmodel.FeedViewModel
 import org.listenbrainz.android.viewmodel.SocialViewModel
 import org.listenbrainz.android.viewmodel.UserViewModel

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/search/BaseSearchScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/search/BaseSearchScreen.kt
@@ -63,7 +63,7 @@ import org.listenbrainz.android.ui.components.NavigationChips
 import org.listenbrainz.android.ui.components.TitleAndSubtitle
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.util.Utils.formatDurationSeconds
-import org.listenbrainz.android.util.Utils.getCoverArtUrl
+import org.listenbrainz.shared.util.Utils.getCoverArtUrl
 import org.listenbrainz.android.util.Utils.removeHtmlTags
 import org.listenbrainz.android.viewmodel.SearchViewModel
 import org.listenbrainz.shared.model.feed.FeedListenArtist

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/yim/YimDiscoverScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/yim/YimDiscoverScreen.kt
@@ -45,7 +45,7 @@ import org.listenbrainz.android.ui.components.YimNavigationStation
 import org.listenbrainz.android.ui.theme.LocalYimPaddings
 import org.listenbrainz.android.ui.theme.YearInMusicTheme
 import org.listenbrainz.android.ui.theme.YimPaddings
-import org.listenbrainz.android.util.Utils.getCoverArtUrl
+import org.listenbrainz.shared.util.Utils.getCoverArtUrl
 import org.listenbrainz.android.viewmodel.YimViewModel
 
 @Composable

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/yim/YimTopAlbumsScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/yim/YimTopAlbumsScreen.kt
@@ -188,7 +188,7 @@ private fun YimAlbumViewer(list: List<TopRelease>?, listState: LazyListState = r
                     AsyncImage(
                         model = ImageRequest.Builder(context)
                             .data(
-                                Utils.getCoverArtUrl(
+                                org.listenbrainz.shared.util.Utils.getCoverArtUrl(
                                     caaReleaseMbid = item.caaReleaseMbid,
                                     caaId = item.caaId,
                                     size = 500

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/yim23/Yim23DiscoveriesListScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/yim23/Yim23DiscoveriesListScreen.kt
@@ -58,7 +58,7 @@ private fun Yim23Discoveries (viewModel: Yim23ViewModel) {
                 items(topDiscoveries) {
 
                     YimListenCard(releaseName = it.title, artistName = it.creator,
-                        coverArtUrl = Utils.getCoverArtUrl(
+                        coverArtUrl = org.listenbrainz.shared.util.Utils.getCoverArtUrl(
                             caaId = it.extension.extensionData.additionalMetadata.caaId,
                             caaReleaseMbid = it.extension.extensionData.additionalMetadata.caaReleaseMbid ,
                             size = 250

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/yim23/Yim23DiscoveriesScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/yim23/Yim23DiscoveriesScreen.kt
@@ -78,7 +78,7 @@ private fun Yim23DiscoveriesArt(viewModel: Yim23ViewModel) {
                             AsyncImage(
                                 model = ImageRequest.Builder(context)
                                     .data(
-                                        Utils.getCoverArtUrl(
+                                        org.listenbrainz.shared.util.Utils.getCoverArtUrl(
                                             caaReleaseMbid = tracks[i - 1].extension.extensionData.additionalMetadata.caaReleaseMbid,
                                             caaId = tracks[i - 1].extension.extensionData.additionalMetadata.caaId.toLong(),
                                             size = 250,

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/yim23/Yim23MissedSongsListScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/yim23/Yim23MissedSongsListScreen.kt
@@ -60,7 +60,7 @@ private fun Yim23MissedSongs (viewModel: Yim23ViewModel) {
             LazyColumn (state = rememberLazyListState()) {
                 items(topMissedSongs) {
                     YimListenCard(releaseName = it.title, artistName = it.creator, coverArtUrl =
-                    Utils.getCoverArtUrl(
+                    org.listenbrainz.shared.util.Utils.getCoverArtUrl(
                         caaId = it.extension.extensionData.additionalMetadata.caaId.toLong(),
                         caaReleaseMbid = it.extension.extensionData.additionalMetadata.caaReleaseMbid,
                         size = 250),)

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/yim23/Yim23MissedSongsScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/yim23/Yim23MissedSongsScreen.kt
@@ -74,7 +74,7 @@ private fun Yim23MissedSongsArt(viewModel: Yim23ViewModel) {
                             AsyncImage(
                                 model = ImageRequest.Builder(context)
                                     .data(
-                                        Utils.getCoverArtUrl(
+                                        org.listenbrainz.shared.util.Utils.getCoverArtUrl(
                                             caaReleaseMbid = tracks[i - 1].extension.extensionData.additionalMetadata.caaReleaseMbid,
                                             caaId = tracks[i - 1].extension.extensionData.additionalMetadata.caaId.toLong(),
                                             size = 250,

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/yim23/Yim23NewAlbumsFromTopArtistsScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/yim23/Yim23NewAlbumsFromTopArtistsScreen.kt
@@ -58,7 +58,7 @@ private fun Yim23NewAlbumsFromTopArtists (viewModel: Yim23ViewModel) {
         LazyColumn (state = rememberLazyListState()) {
             items(newReleases) {
                 YimListenCard(releaseName = it.title, artistName = it.artistCreditName, coverArtUrl =
-                Utils.getCoverArtUrl(
+                org.listenbrainz.shared.util.Utils.getCoverArtUrl(
                     caaId = it.caaId,
                     caaReleaseMbid = it.caaReleaseMbid ,
                     size = 250),)

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/yim23/Yim23TopAlbumsScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/yim23/Yim23TopAlbumsScreen.kt
@@ -85,7 +85,7 @@ private fun AlbumCoverPic(list: List<TopReleaseYim23>?) {
                     AsyncImage(
                         model = ImageRequest.Builder(context)
                             .data(
-                                Utils.getCoverArtUrl(
+                                org.listenbrainz.shared.util.Utils.getCoverArtUrl(
                                     caaReleaseMbid = list!![i - 1].caaReleaseMbid,
                                     caaId = list[i - 1].caaId,
                                     size = 250,

--- a/app/src/main/java/org/listenbrainz/android/util/Utils.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/Utils.kt
@@ -80,13 +80,6 @@ import kotlin.contracts.contract
  * A set of fairly general Android utility methods.
  */
 object Utils {
-
-    /** Get *CoverArtArchive* url for cover art of a release.
-     * @param size Allowed sizes are 250, 500, 750 and 1000. Default is 250.*/
-    fun getCoverArtUrl(caaReleaseMbid: String?, caaId: Long?, size: Int = 250): String? {
-        if (caaReleaseMbid == null || caaId == null) return null
-        return "https://archive.org/download/mbid-${caaReleaseMbid}/mbid-${caaReleaseMbid}-${caaId}_thumb${size}.jpg"
-    }
     
     fun similarityToPercent(similarity: Float?): String {
         return if (similarity != null)

--- a/app/src/main/java/org/listenbrainz/android/viewmodel/ListeningNowViewModel.kt
+++ b/app/src/main/java/org/listenbrainz/android/viewmodel/ListeningNowViewModel.kt
@@ -23,7 +23,7 @@ import org.listenbrainz.android.repository.listens.ListensRepository
 import org.listenbrainz.shared.repository.AppPreferences
 import org.listenbrainz.shared.repository.socket.SocketRepository
 import org.listenbrainz.android.util.ImagePalette
-import org.listenbrainz.android.util.Utils.getCoverArtUrl
+import org.listenbrainz.shared.util.Utils.getCoverArtUrl
 import org.listenbrainz.android.util.getPaletteFromImage
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds

--- a/app/src/main/java/org/listenbrainz/android/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/org/listenbrainz/android/viewmodel/SearchViewModel.kt
@@ -37,7 +37,7 @@ import org.listenbrainz.shared.model.playlist.PlaylistTrack
 import org.listenbrainz.shared.model.playlist.toUiModel
 import org.listenbrainz.shared.model.search.albumSearch.AlbumSearchUiState
 import org.listenbrainz.shared.model.search.albumSearch.AlbumUiModel
-import org.listenbrainz.android.repository.album.AlbumRepository
+import org.listenbrainz.shared.repository.album.AlbumRepository
 import org.listenbrainz.shared.repository.artist.ArtistRepository
 import org.listenbrainz.android.repository.playlists.PlaylistDataRepository
 import org.listenbrainz.android.repository.remoteplayer.RemotePlaybackHandler

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -99,12 +99,7 @@ kotlin {
                 implementation(libs.ktor.serialization.kotlinx.json)
                 implementation(libs.ktor.client.logging)
                 implementation(libs.ktorfit.lib)
-                // Ktor
-                implementation(libs.ktor.client.core)
-                implementation(libs.kmp.socketio)
                 api(libs.kermit)
-                // Ktor
-                implementation(libs.ktor.client.core)
                 implementation(libs.kmp.socketio)
                 implementation(libs.kotlinx.datetime)
             }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedNetworkServiceModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedNetworkServiceModule.kt
@@ -17,9 +17,11 @@ import kotlinx.coroutines.IO
 import kotlinx.serialization.json.Json
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
+import org.listenbrainz.shared.service.AlbumService
 import org.listenbrainz.shared.service.ArtistService
 import org.listenbrainz.shared.service.CBService
 import org.listenbrainz.shared.service.MBService
+import org.listenbrainz.shared.service.createAlbumService
 import org.listenbrainz.shared.service.createArtistService
 import org.listenbrainz.shared.service.createMBService
 import org.listenbrainz.shared.service.createCBService
@@ -29,6 +31,7 @@ import org.listenbrainz.shared.util.Constants.MB_BASE_URL
 import org.listenbrainz.shared.service.BlogService
 import org.listenbrainz.shared.service.createBlogService
 
+// Qualifier names for dispatchers
 const val DEFAULT_DISPATCHER = "DefaultDispatcher"
 const val IO_DISPATCHER = "IoDispatcher"
 const val MAIN_DISPATCHER = "MainDispatcher"
@@ -103,6 +106,14 @@ val sharedNetworkServiceModule = module {
             .httpClient(get<HttpClient>(named(SHARED_HTTP_CLIENT)))
             .build()
             .createCBService()
+    }
+
+    single<AlbumService>{
+        Ktorfit.Builder()
+            .baseUrl(LB_BASE_URL)
+            .httpClient(get<HttpClient>(named(SHARED_HTTP_CLIENT)))
+            .build()
+            .createAlbumService()
     }
 
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedRepositoryModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedRepositoryModule.kt
@@ -3,10 +3,13 @@ package org.listenbrainz.shared.di
 import org.koin.dsl.module
 import org.listenbrainz.shared.repository.blog.BlogRepository
 import org.listenbrainz.shared.repository.blog.BlogRepositoryImpl
+import org.listenbrainz.shared.repository.album.AlbumRepository
+import org.listenbrainz.shared.repository.album.AlbumRepositoryImpl
 import org.listenbrainz.shared.repository.artist.ArtistRepository
 import org.listenbrainz.shared.repository.artist.ArtistRepositoryImpl
 
 val sharedRepositoryModule = module {
     single<BlogRepository> { BlogRepositoryImpl(get()) }
     single<ArtistRepository> { ArtistRepositoryImpl(get(),get(),get()) }
+    single<AlbumRepository> { AlbumRepositoryImpl(get(),get(),get()) }
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
@@ -5,6 +5,7 @@ import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import org.listenbrainz.shared.viewmodel.NewsListViewModel
 import org.listenbrainz.shared.viewmodel.CreateAccountViewModel
+import org.listenbrainz.shared.viewmodel.AlbumViewModel
 import org.listenbrainz.shared.viewmodel.ArtistViewModel
 import org.listenbrainz.shared.viewmodel.SettingsViewModel
 
@@ -13,4 +14,5 @@ val sharedViewModelModule = module {
     viewModel { NewsListViewModel(get(),get(named(IO_DISPATCHER))) }
     viewModel { CreateAccountViewModel(get()) }
     viewModel { ArtistViewModel(get(),get(named(IO_DISPATCHER))) }
+    viewModel { AlbumViewModel(get(),get(named(IO_DISPATCHER))) }
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/album/AlbumRepository.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/album/AlbumRepository.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android.repository.album
+package org.listenbrainz.shared.repository.album
 
 import org.listenbrainz.shared.model.album.AlbumInfo
 import org.listenbrainz.shared.model.albumSearch.AlbumSearchPayload

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/album/AlbumRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/album/AlbumRepositoryImpl.kt
@@ -1,11 +1,11 @@
-package org.listenbrainz.android.repository.album
+package org.listenbrainz.shared.repository.album
 
 import org.listenbrainz.shared.model.ResponseError
 import org.listenbrainz.shared.model.album.AlbumInfo
 import org.listenbrainz.shared.model.album.Album
 import org.listenbrainz.shared.model.albumSearch.AlbumSearchPayload
 import org.listenbrainz.shared.model.artist.CBReview
-import org.listenbrainz.android.service.AlbumService
+import org.listenbrainz.shared.service.AlbumService
 import org.listenbrainz.shared.service.CBService
 import org.listenbrainz.shared.service.MBService
 import org.listenbrainz.shared.util.Resource

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/service/AlbumService.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/service/AlbumService.kt
@@ -1,8 +1,9 @@
-package org.listenbrainz.android.service
+package org.listenbrainz.shared.service
 
 import de.jensklingenberg.ktorfit.http.POST
 import de.jensklingenberg.ktorfit.http.Path
 import org.listenbrainz.shared.model.album.Album
+
 interface AlbumService {
     @POST("album/{album_mbid}/")
     suspend fun getAlbumData(@Path("album_mbid") albumMbid: String): Album

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/ui/screens/album/AlbumUIState.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/ui/screens/album/AlbumUIState.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android.ui.screens.album
+package org.listenbrainz.shared.ui.screens.album
 
 import org.listenbrainz.shared.model.album.ReleaseGroupData
 import org.listenbrainz.shared.model.album.Track

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/util/Utils.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/util/Utils.kt
@@ -63,4 +63,12 @@ object Utils {
             else -> Resource.failure(error = ResponseError.Unknown())
         }
     }
+
+
+    /** Get *CoverArtArchive* url for cover art of a release.
+     * @param size Allowed sizes are 250, 500, 750 and 1000. Default is 250.*/
+    fun getCoverArtUrl(caaReleaseMbid: String?, caaId: Long?, size: Int = 250): String? {
+        if (caaReleaseMbid == null || caaId == null) return null
+        return "https://archive.org/download/mbid-${caaReleaseMbid}/mbid-${caaReleaseMbid}-${caaId}_thumb${size}.jpg"
+    }
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/viewmodel/AlbumViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/viewmodel/AlbumViewModel.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android.viewmodel
+package org.listenbrainz.shared.viewmodel
 
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineDispatcher
@@ -7,10 +7,9 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
-import org.listenbrainz.android.repository.album.AlbumRepository
-import org.listenbrainz.android.ui.screens.album.AlbumUiState
-import org.listenbrainz.android.util.Utils
-import org.listenbrainz.shared.viewmodel.BaseViewModel
+import org.listenbrainz.shared.repository.album.AlbumRepository
+import org.listenbrainz.shared.ui.screens.album.AlbumUiState
+import org.listenbrainz.shared.util.Utils
 
 class AlbumViewModel(
     private val repository: AlbumRepository,


### PR DESCRIPTION
## Base PR: #745 
#### Rebased with the latest upstream/cmp branch, and this branch includes all commits from the base branch.
--- 

This PR fixes #715 migrated the `AlbumViewModel` from `androidApp` to `shared` module

## Key Changes:- 

1. Moved `AlbumViewModel` to shared/commonMain/viewmodel/ using kmp lifecycle dependencies.
2. Migrated all the necessary data models, services and repositories to shared module.
3. Registered the viewmodel under `sharedViewModelModule`, service under `sharedNetworkServiceModule` and repos under `sharedRepositoryModule`.
3. Wired all the `sharedModules` to the core `KoinModules` under `androidApp` module.
4. Moved necessary Util fun from android native `Utils` object to shared module `Utils`, i.e:- `getCoverArtUrl`