### PR TITLE
Migrated Song Viewmodel to shared module

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
+++ b/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
@@ -38,8 +38,8 @@ import org.listenbrainz.android.repository.brainzplayer.BPArtistRepository
 import org.listenbrainz.android.repository.brainzplayer.BPArtistRepositoryImpl
 import org.listenbrainz.android.repository.brainzplayer.PlaylistRepository
 import org.listenbrainz.android.repository.brainzplayer.PlaylistRepositoryImpl
-import org.listenbrainz.android.repository.brainzplayer.SongRepository
-import org.listenbrainz.android.repository.brainzplayer.SongRepositoryImpl
+import org.listenbrainz.shared.repository.brainzplayer.SongRepository
+import org.listenbrainz.shared.repository.brainzplayer.SongRepositoryImpl
 import org.listenbrainz.android.repository.feed.FeedRepository
 import org.listenbrainz.android.repository.feed.FeedRepositoryImpl
 import org.listenbrainz.android.repository.listenservicemanager.ListenServiceManager
@@ -85,7 +85,7 @@ import org.listenbrainz.android.viewmodel.PlaylistDataViewModel
 import org.listenbrainz.android.viewmodel.PlaylistViewModel
 import org.listenbrainz.android.viewmodel.SearchViewModel
 import org.listenbrainz.android.viewmodel.SocialViewModel
-import org.listenbrainz.android.viewmodel.SongViewModel
+import org.listenbrainz.shared.viewmodel.SongViewModel
 import org.listenbrainz.android.viewmodel.UserViewModel
 import org.listenbrainz.android.viewmodel.Yim23ViewModel
 import org.listenbrainz.android.viewmodel.YimViewModel
@@ -298,9 +298,8 @@ val appModule = module {
 
 val repositoryModule = module {
     // BrainzPlayer Repositories
-    single<SongRepository> { SongRepositoryImpl(get()) }
-    single<BPAlbumRepository> { BPAlbumRepositoryImpl(get()) }
-    single<BPArtistRepository> { BPArtistRepositoryImpl(get()) }
+    single<BPAlbumRepository> { BPAlbumRepositoryImpl(get(),get()) }
+    single<BPArtistRepository> { BPArtistRepositoryImpl(get(),get()) }
     single<PlaylistRepository> { PlaylistRepositoryImpl(get()) }
 
     // API Repositories
@@ -355,7 +354,6 @@ val viewModelModule = module {
     viewModel { PlaylistViewModel(get(), get(named(IO_DISPATCHER)), get(named(DEFAULT_DISPATCHER))) }
     viewModel { BPAlbumViewModel(get(), get(named(IO_DISPATCHER))) }
     viewModel { BPArtistViewModel(get(), get(named(IO_DISPATCHER))) }
-    viewModel { SongViewModel(get(), get(named(IO_DISPATCHER))) }
     viewModel { AboutViewModel() }
     viewModel { LoginViewModel(get()) }
 }

--- a/app/src/main/java/org/listenbrainz/android/repository/brainzplayer/BPAlbumRepositoryImpl.kt
+++ b/app/src/main/java/org/listenbrainz/android/repository/brainzplayer/BPAlbumRepositoryImpl.kt
@@ -13,14 +13,15 @@ import org.listenbrainz.shared.model.Album
 import org.listenbrainz.shared.model.Song
 import org.listenbrainz.shared.model.dao.AlbumDao
 import org.listenbrainz.android.util.AlbumsData
-import org.listenbrainz.android.util.SongsData
+import org.listenbrainz.shared.util.SongsData
 import org.listenbrainz.shared.util.Transformer.toAlbum
 import org.listenbrainz.shared.util.Transformer.toAlbumEntity
 
 
 
 class BPAlbumRepositoryImpl(
-    private val albumDao: AlbumDao
+    private val albumDao: AlbumDao,
+    private val songsData: SongsData
 ): BPAlbumRepository {
     override fun getAlbums(): Flow<List<Album>> =
         albumDao.getAlbumEntities()
@@ -55,14 +56,14 @@ class BPAlbumRepositoryImpl(
                 no immediate result is required from it.    */
             withContext(Dispatchers.IO){
                 // Update cache (companion object) of SongsData
-                SongsData.updateCache()
+                songsData.updateCache()
             }
         }
         return albums.isNotEmpty()
     }
 
     override fun getAllSongsOfAlbum(albumId: Long): Flow<List<Song>> {
-        val songs = SongsData.fetchSongs().filter { song ->
+        val songs = songsData.fetchSongs().filter { song ->
             song.albumID == albumId
         }
         return flowOf(songs)

--- a/app/src/main/java/org/listenbrainz/android/repository/brainzplayer/BPArtistRepositoryImpl.kt
+++ b/app/src/main/java/org/listenbrainz/android/repository/brainzplayer/BPArtistRepositoryImpl.kt
@@ -11,14 +11,15 @@ import org.listenbrainz.shared.model.Artist
 import org.listenbrainz.shared.model.Song
 import org.listenbrainz.shared.model.dao.ArtistDao
 import org.listenbrainz.android.util.AlbumsData
-import org.listenbrainz.android.util.SongsData
+import org.listenbrainz.shared.util.SongsData
 import org.listenbrainz.shared.util.Transformer.toAlbumEntity
 import org.listenbrainz.shared.util.Transformer.toArtist
 import org.listenbrainz.shared.util.Transformer.toArtistEntity
 import org.listenbrainz.shared.util.Transformer.toSongEntity
 
 class BPArtistRepositoryImpl(
-    private val artistDao: ArtistDao
+    private val artistDao: ArtistDao,
+    private val songsData: SongsData
 ) : BPArtistRepository {
     override fun getArtist(artistID: String): Flow<Artist> {
         val artist = artistDao.getArtistEntity(artistID)
@@ -81,7 +82,7 @@ class BPArtistRepositoryImpl(
     }
     
     override suspend fun addAllSongsOfArtist(artist: Artist, userRequestedRefresh: Boolean): List<Song> {
-        return SongsData.fetchSongs(userRequestedRefresh).filter {
+        return songsData.fetchSongs(userRequestedRefresh).filter {
             it.artist == artist.name
         }
             .map {

--- a/app/src/main/java/org/listenbrainz/android/service/BrainzPlayerService.kt
+++ b/app/src/main/java/org/listenbrainz/android/service/BrainzPlayerService.kt
@@ -21,7 +21,7 @@ import org.listenbrainz.shared.model.PlayableType
 import org.listenbrainz.android.repository.brainzplayer.BPAlbumRepository
 import org.listenbrainz.shared.repository.AppPreferences
 import org.listenbrainz.android.repository.brainzplayer.PlaylistRepository
-import org.listenbrainz.android.repository.brainzplayer.SongRepository
+import org.listenbrainz.shared.repository.brainzplayer.SongRepository
 import org.listenbrainz.android.util.BrainzPlayerExtensions.toMediaMetadataCompat
 import org.listenbrainz.android.util.BrainzPlayerNotificationManager
 import org.listenbrainz.android.util.BrainzPlayerUtils.MEDIA_ROOT_ID

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerScreen.kt
@@ -46,7 +46,7 @@ import org.listenbrainz.android.viewmodel.BPAlbumViewModel
 import org.listenbrainz.android.viewmodel.BPArtistViewModel
 import org.listenbrainz.android.viewmodel.BrainzPlayerViewModel
 import org.listenbrainz.android.viewmodel.PlaylistViewModel
-import org.listenbrainz.android.viewmodel.SongViewModel
+import org.listenbrainz.shared.viewmodel.SongViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/SongScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/SongScreen.kt
@@ -41,7 +41,7 @@ import org.listenbrainz.android.ui.components.BPLibraryEmptyMessage
 import org.listenbrainz.android.ui.components.forwardingPainter
 import org.listenbrainz.android.viewmodel.BrainzPlayerViewModel
 import org.listenbrainz.android.viewmodel.PlaylistViewModel
-import org.listenbrainz.android.viewmodel.SongViewModel
+import org.listenbrainz.shared.viewmodel.SongViewModel
 
 @OptIn(ExperimentalMaterialApi::class)
 @ExperimentalMaterial3Api

--- a/app/src/main/java/org/listenbrainz/android/util/LocalMusicSource.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/LocalMusicSource.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.withContext
 import org.listenbrainz.android.model.State
 import org.listenbrainz.android.repository.brainzplayer.BPAlbumRepository
 import org.listenbrainz.android.repository.brainzplayer.PlaylistRepository
-import org.listenbrainz.android.repository.brainzplayer.SongRepository
+import org.listenbrainz.shared.repository.brainzplayer.SongRepository
 
 class LocalMusicSource(
     private val songRepository: SongRepository,

--- a/app/src/main/java/org/listenbrainz/android/viewmodel/BrainzPlayerViewModel.kt
+++ b/app/src/main/java/org/listenbrainz/android/viewmodel/BrainzPlayerViewModel.kt
@@ -42,7 +42,7 @@ import org.listenbrainz.android.model.RepeatMode
 import org.listenbrainz.shared.model.Song
 import org.listenbrainz.android.repository.brainzplayer.BPAlbumRepository
 import org.listenbrainz.android.repository.brainzplayer.PlaylistRepository
-import org.listenbrainz.android.repository.brainzplayer.SongRepository
+import org.listenbrainz.shared.repository.brainzplayer.SongRepository
 import org.listenbrainz.shared.repository.AppPreferences
 import org.listenbrainz.android.service.BrainzPlayerService
 import org.listenbrainz.android.service.BrainzPlayerServiceConnection

--- a/shared/src/androidMain/kotlin/org/listenbrainz/shared/Platform.android.kt
+++ b/shared/src/androidMain/kotlin/org/listenbrainz/shared/Platform.android.kt
@@ -25,6 +25,8 @@ import org.listenbrainz.shared.service.ListensService
 import org.listenbrainz.shared.service.UserService
 import org.listenbrainz.shared.service.YouTubeApiService
 import org.listenbrainz.shared.di.database.BrainzPlayerDatabase
+import org.listenbrainz.shared.util.AndroidSongsData
+import org.listenbrainz.shared.util.SongsData
 
 actual fun platform() = "Android"
 
@@ -92,4 +94,8 @@ actual fun getListensSubmissionDatabase(appContext: PlatformContext): RoomDataba
         context = appContext,
         name = listensDb.absolutePath
     )
+}
+
+actual fun provideSongData(context: PlatformContext): SongsData {
+    return AndroidSongsData(context)
 }

--- a/shared/src/androidMain/kotlin/org/listenbrainz/shared/util/AndroidSongsData.kt
+++ b/shared/src/androidMain/kotlin/org/listenbrainz/shared/util/AndroidSongsData.kt
@@ -1,24 +1,15 @@
-package org.listenbrainz.android.util
+package org.listenbrainz.shared.util
 
 import android.content.ContentUris
 import android.os.Build
 import android.provider.MediaStore
-import org.listenbrainz.android.application.App.Companion.context
 import org.listenbrainz.shared.model.Song
-object SongsData {
-    // Temporary cache
-    private var songsListCache = listOf<Song>()
-    
-    /** Update cached songs list on demand. */
-    fun updateCache(){
-        fetchSongs(userRequestedRefresh = true)
-    }
-    
-    /** Fetch songs from device. Heavy task, so perform in `Dispacthers.IO`.*/
-    fun fetchSongs(userRequestedRefresh: Boolean = false): List<Song> {
-        if (songsListCache.isNotEmpty() && !userRequestedRefresh){
-            return songsListCache
-        }
+import org.listenbrainz.shared.repository.PlatformContext
+
+class AndroidSongsData(
+    private val context: PlatformContext
+): SongsData() {
+    override fun songs(): List<Song> {
         val songs = mutableListOf<Song>()
         val collection =
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
@@ -39,13 +30,14 @@ object SongsData {
             MediaStore.Audio.AudioColumns.TRACK,
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                 MediaStore.Audio.AudioColumns.DISC_NUMBER
-            }else{
-                MediaStore.Audio.AudioColumns.COMPOSER},
+            } else {
+                MediaStore.Audio.AudioColumns.COMPOSER
+            },
             MediaStore.Audio.AudioColumns.ARTIST_ID,
             MediaStore.Audio.AudioColumns.DATE_MODIFIED
         )
-        
-        
+
+
         val sortOrder = "${MediaStore.Audio.Media.TITLE} COLLATE NOCASE ASC"
         val isMusic = MediaStore.Audio.Media.IS_MUSIC + " != 0"
         val songQuery = context.contentResolver?.query(
@@ -106,7 +98,6 @@ object SongsData {
                 )
             }
         }
-        songsListCache = songs
-        return songsListCache
+        return songs
     }
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/Platform.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/Platform.kt
@@ -15,6 +15,7 @@ import org.listenbrainz.shared.service.ListensService
 import org.listenbrainz.shared.service.UserService
 import org.listenbrainz.shared.service.YouTubeApiService
 import org.listenbrainz.shared.di.database.BrainzPlayerDatabase
+import org.listenbrainz.shared.util.SongsData
 
 expect fun platform(): String
 
@@ -48,3 +49,7 @@ expect fun provideListensRepositoryImpl(
 expect fun getListensSubmissionDatabase(
     appContext: PlatformContext
 ): RoomDatabase.Builder<ListensSubmissionDatabase>
+
+expect fun provideSongData(
+    context: PlatformContext
+): SongsData

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedAppModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedAppModule.kt
@@ -4,6 +4,8 @@ import org.koin.dsl.module
 import org.listenbrainz.shared.provideRemotePlaybackHandler
 import org.listenbrainz.shared.repository.remoteplayer.RemotePlaybackHandler
 import org.listenbrainz.shared.service.YouTubeApiService
+import org.listenbrainz.shared.provideSongData
+import org.listenbrainz.shared.util.SongsData
 import org.listenbrainz.shared.provideLogSubmitter
 import org.listenbrainz.shared.provideLogger
 import org.listenbrainz.shared.util.BuildInfo
@@ -20,5 +22,8 @@ val platformModule = module {
 
     single<RemotePlaybackHandler> {
         provideRemotePlaybackHandler(get(), youTubeApiService = get<YouTubeApiService>())
+    }
+    single<SongsData>{
+        provideSongData(get())
     }
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedRepositoryModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedRepositoryModule.kt
@@ -17,6 +17,8 @@ import org.listenbrainz.shared.repository.socket.SocketRepository
 import org.listenbrainz.shared.repository.socket.SocketRepositoryImpl
 import org.listenbrainz.shared.service.ListensService
 import org.listenbrainz.shared.service.UserService
+import org.listenbrainz.shared.repository.brainzplayer.SongRepository
+import org.listenbrainz.shared.repository.brainzplayer.SongRepositoryImpl
 
 val sharedRepositoryModule = module {
     single<SocketRepository> { SocketRepositoryImpl(get<HttpClient>(named(SHARED_HTTP_CLIENT)),get()) }
@@ -35,4 +37,5 @@ val sharedRepositoryModule = module {
             get()
         )
     }
+    single<SongRepository> { SongRepositoryImpl(get(),get()) }
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
@@ -11,6 +11,7 @@ import org.listenbrainz.shared.viewmodel.ArtistViewModel
 import org.listenbrainz.shared.viewmodel.LoginViewModel
 import org.listenbrainz.shared.viewmodel.ListensViewModel
 import org.listenbrainz.shared.viewmodel.SettingsViewModel
+import org.listenbrainz.shared.viewmodel.SongViewModel
 
 val sharedViewModelModule = module {
     viewModel { SettingsViewModel(get(),get()) }
@@ -21,4 +22,5 @@ val sharedViewModelModule = module {
     viewModel { LoginViewModel(get()) }
     viewModel { AlbumViewModel(get(),get(named(IO_DISPATCHER))) }
     viewModel { ListensViewModel(get(),get(),get(),get(),get(named(DEFAULT_DISPATCHER))) }
+    viewModel { SongViewModel(get(),get(named(IO_DISPATCHER))) }
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/model/Artist.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/model/Artist.kt
@@ -1,7 +1,6 @@
 package org.listenbrainz.shared.model
 
 import kotlinx.serialization.Serializable
-import org.listenbrainz.shared.model.Song
 
 @Serializable
 data class Artist(

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/brainzplayer/SongRepository.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/brainzplayer/SongRepository.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android.repository.brainzplayer
+package org.listenbrainz.shared.repository.brainzplayer
 
 import kotlinx.coroutines.flow.Flow
 import org.listenbrainz.shared.model.Song

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/brainzplayer/SongRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/brainzplayer/SongRepositoryImpl.kt
@@ -1,16 +1,17 @@
-package org.listenbrainz.android.repository.brainzplayer
+package org.listenbrainz.shared.repository.brainzplayer
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import org.listenbrainz.shared.model.Song
 import org.listenbrainz.shared.model.dao.SongDao
-import org.listenbrainz.android.util.SongsData
+import org.listenbrainz.shared.util.SongsData
 import org.listenbrainz.shared.util.Transformer.toSong
 import org.listenbrainz.shared.util.Transformer.toSongEntity
 import kotlin.time.Clock
 
 class SongRepositoryImpl(
-    private val songDao: SongDao
+    private val songDao: SongDao,
+    private val songsData: SongsData
 ) : SongRepository {
     override fun getSongsStream(): Flow<List<Song>> =
         songDao.getSongEntities()
@@ -21,7 +22,7 @@ class SongRepositoryImpl(
             }
     
     override suspend fun addSongs(userRequestedRefresh: Boolean): Boolean {
-        val songs = SongsData.fetchSongs(userRequestedRefresh).map {
+        val songs = songsData.fetchSongs(userRequestedRefresh).map {
             it.toSongEntity()
         }
         

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/util/SongsData.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/util/SongsData.kt
@@ -1,0 +1,24 @@
+package org.listenbrainz.shared.util
+
+import org.listenbrainz.shared.model.Song
+
+abstract class SongsData {
+    // Temporary cache
+    private var songsListCache = listOf<Song>()
+
+    protected abstract fun songs(): List<Song>
+
+    /** Update cached songs list on demand. */
+    fun updateCache(){
+        fetchSongs(userRequestedRefresh = true)
+    }
+
+    /** Fetch songs from device. Heavy task, so perform in `Dispacthers.IO`.*/
+    fun fetchSongs(userRequestedRefresh: Boolean = false): List<Song> {
+        if (songsListCache.isNotEmpty() && !userRequestedRefresh){
+            return songsListCache
+        }
+        songsListCache = songs()
+        return songsListCache
+    }
+}

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/viewmodel/SongViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/viewmodel/SongViewModel.kt
@@ -1,30 +1,29 @@
-package org.listenbrainz.android.viewmodel
+package org.listenbrainz.shared.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import org.listenbrainz.android.repository.brainzplayer.SongRepository
+import org.listenbrainz.shared.repository.brainzplayer.SongRepository
 
 class SongViewModel(
     private val songRepository: SongRepository,
     private val ioDispatcher: CoroutineDispatcher
 ) : ViewModel() {
     val songs = songRepository.getSongsStream()
-    
+
     // Refreshing variables.
     private val _isRefreshing = MutableStateFlow(false)
     val isRefreshing = _isRefreshing.asStateFlow()
-    
+
     init {
         fetchSongsFromDevice()
     }
-    
+
     fun fetchSongsFromDevice(userRequestedRefresh: Boolean = false){
         viewModelScope.launch(ioDispatcher) {
             if (userRequestedRefresh){

--- a/shared/src/iosMain/kotlin/org/listenbrainz/shared/Platform.ios.kt
+++ b/shared/src/iosMain/kotlin/org/listenbrainz/shared/Platform.ios.kt
@@ -28,6 +28,8 @@ import org.listenbrainz.shared.service.UserService
 import org.listenbrainz.shared.service.YouTubeApiService
 import platform.posix.err
 import org.listenbrainz.shared.di.database.BrainzPlayerDatabase
+import org.listenbrainz.shared.util.IosSongsData
+import org.listenbrainz.shared.util.SongsData
 import platform.Foundation.NSFileManager
 
 actual fun platform() = "iOS"
@@ -106,4 +108,8 @@ actual fun getListensSubmissionDatabase(appContext: PlatformContext): RoomDataba
     return Room.databaseBuilder<ListensSubmissionDatabase>(
         name = listensDB
     )
+}
+
+actual fun provideSongData(context: PlatformContext): SongsData {
+    return IosSongsData()
 }

--- a/shared/src/iosMain/kotlin/org/listenbrainz/shared/util/IosSongsData.kt
+++ b/shared/src/iosMain/kotlin/org/listenbrainz/shared/util/IosSongsData.kt
@@ -1,0 +1,70 @@
+package org.listenbrainz.shared.util
+
+import org.listenbrainz.shared.model.Song
+import platform.Foundation.NSCalendar
+import platform.Foundation.NSCalendarUnitYear
+import platform.Foundation.NSDate
+import platform.Foundation.timeIntervalSince1970
+import platform.MediaPlayer.MPMediaItem
+import platform.MediaPlayer.MPMediaItemPropertyAlbumPersistentID
+import platform.MediaPlayer.MPMediaItemPropertyAlbumTitle
+import platform.MediaPlayer.MPMediaItemPropertyAlbumTrackNumber
+import platform.MediaPlayer.MPMediaItemPropertyArtist
+import platform.MediaPlayer.MPMediaItemPropertyArtistPersistentID
+import platform.MediaPlayer.MPMediaItemPropertyDateAdded
+import platform.MediaPlayer.MPMediaItemPropertyDiscNumber
+import platform.MediaPlayer.MPMediaItemPropertyPersistentID
+import platform.MediaPlayer.MPMediaItemPropertyPlaybackDuration
+import platform.MediaPlayer.MPMediaItemPropertyReleaseDate
+import platform.MediaPlayer.MPMediaItemPropertyTitle
+import platform.MediaPlayer.MPMediaLibrary
+import platform.MediaPlayer.MPMediaLibraryAuthorizationStatus
+import platform.MediaPlayer.MPMediaLibraryAuthorizationStatusAuthorized
+import platform.MediaPlayer.MPMediaQuery
+
+class IosSongsData(): SongsData() {
+    override fun songs(): List<Song> {
+        if(MPMediaLibrary.authorizationStatus()!= MPMediaLibraryAuthorizationStatusAuthorized){
+            return emptyList()
+        }
+
+        val songs = mutableListOf<Song>()
+        val mediaItems = MPMediaQuery.songsQuery().items ?: return emptyList()
+
+        for(item in mediaItems){
+            val mediaItem = item as? MPMediaItem
+            if(mediaItem == null){
+                continue
+            }
+            val id = mediaItem.valueForProperty(MPMediaItemPropertyPersistentID) as? Long ?: 0L
+            val albumID = mediaItem.valueForProperty(MPMediaItemPropertyAlbumPersistentID) as? Long ?: 0L
+            val year = (mediaItem.valueForProperty(MPMediaItemPropertyReleaseDate) as? NSDate)?.let {
+                NSCalendar.currentCalendar.component(NSCalendarUnitYear,it).toInt()
+            }
+            val durationLong = (mediaItem.valueForProperty(MPMediaItemPropertyPlaybackDuration) as? Double)?.let {
+                (it*1000).toLong()
+            }
+            val dateModified = (mediaItem.valueForProperty(MPMediaItemPropertyDateAdded) as? NSDate)?.let {
+                (it.timeIntervalSince1970 * 1000).toLong()
+            }
+            val contentUri = "mediaitem://$id"
+            val albumArt = "mediaitem-art://$albumID"
+            songs += Song(
+                mediaID = id,
+                title = mediaItem.valueForProperty(MPMediaItemPropertyTitle) as? String ?: "Title",
+                artist = mediaItem.valueForProperty(MPMediaItemPropertyArtist) as? String  ?: "Artist",
+                albumID = albumID,
+                album =  mediaItem.valueForProperty(MPMediaItemPropertyAlbumTitle) as? String ?: "Album",
+                year = year ?: 0,
+                duration = durationLong ?: 0L,
+                trackNumber = (mediaItem.valueForProperty(MPMediaItemPropertyAlbumTrackNumber) as? Long)?.toInt() ?: 0,
+                discNumber = mediaItem.valueForProperty(MPMediaItemPropertyDiscNumber) as? Long ?: 1L,
+                artistId = mediaItem.valueForProperty(MPMediaItemPropertyArtistPersistentID) as? Long ?: 0L,
+                dateModified = dateModified ?: 0L,
+                uri = contentUri,
+                albumArt = albumArt
+            )
+        }
+        return songs
+    }
+}


### PR DESCRIPTION
## Base PR:- #752 
#### Rebased with the latest upstream/cmp branch, and this branch includes all commits from the base branch

---

This PR fixes #712 migrates `SongViewModel` from `androidApp` module to shared module

## Key Changes:- 
1. Moved `SongViewModel` to shared/commonMain/viewmodel/ using kmp lifecycle dependencies.
2. Moved `SongsData` to shared module while having platform specific impl in `androidMain` and `iosMain` resp.
4. Moved `SongRepository` to shared module with its impl as well.
5. Registered the viewmodel inside `sharedViewModelModule`, repository inside `sharedRepositoryModule` and the `SongsData` inside `platformModule` via platform specific providers.
6. Wired all the shared modules inside of `KoinModules.kt`