### PR TITLE
Migrated Playlist Viewmodel to shared module

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
+++ b/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
@@ -36,8 +36,6 @@ import org.listenbrainz.android.repository.brainzplayer.BPAlbumRepository
 import org.listenbrainz.android.repository.brainzplayer.BPAlbumRepositoryImpl
 import org.listenbrainz.android.repository.brainzplayer.BPArtistRepository
 import org.listenbrainz.android.repository.brainzplayer.BPArtistRepositoryImpl
-import org.listenbrainz.android.repository.brainzplayer.PlaylistRepository
-import org.listenbrainz.android.repository.brainzplayer.PlaylistRepositoryImpl
 import org.listenbrainz.shared.repository.brainzplayer.SongRepository
 import org.listenbrainz.shared.repository.brainzplayer.SongRepositoryImpl
 import org.listenbrainz.android.repository.feed.FeedRepository
@@ -82,7 +80,6 @@ import org.listenbrainz.android.viewmodel.DashBoardViewModel
 import org.listenbrainz.android.viewmodel.FeedViewModel
 import org.listenbrainz.android.viewmodel.ListeningNowViewModel
 import org.listenbrainz.android.viewmodel.PlaylistDataViewModel
-import org.listenbrainz.android.viewmodel.PlaylistViewModel
 import org.listenbrainz.android.viewmodel.SearchViewModel
 import org.listenbrainz.android.viewmodel.SocialViewModel
 import org.listenbrainz.shared.viewmodel.SongViewModel
@@ -300,7 +297,6 @@ val repositoryModule = module {
     // BrainzPlayer Repositories
     single<BPAlbumRepository> { BPAlbumRepositoryImpl(get(),get()) }
     single<BPArtistRepository> { BPArtistRepositoryImpl(get(),get()) }
-    single<PlaylistRepository> { PlaylistRepositoryImpl(get()) }
 
     // API Repositories
     single<FeedRepository> { FeedRepositoryImpl(get()) }
@@ -351,7 +347,6 @@ val viewModelModule = module {
     viewModel { NewsListViewModel(get(), get(named(IO_DISPATCHER))) }
     viewModel { SearchViewModel(get(),get(),get(),get(),get(), get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER))) }
     viewModel { BrainzPlayerViewModel(get(), get(), get(), get(), get(), get(named(IO_DISPATCHER))) }
-    viewModel { PlaylistViewModel(get(), get(named(IO_DISPATCHER)), get(named(DEFAULT_DISPATCHER))) }
     viewModel { BPAlbumViewModel(get(), get(named(IO_DISPATCHER))) }
     viewModel { BPArtistViewModel(get(), get(named(IO_DISPATCHER))) }
     viewModel { AboutViewModel() }

--- a/app/src/main/java/org/listenbrainz/android/service/BrainzPlayerService.kt
+++ b/app/src/main/java/org/listenbrainz/android/service/BrainzPlayerService.kt
@@ -20,7 +20,7 @@ import org.listenbrainz.shared.model.Playable.Companion.EMPTY_PLAYABLE
 import org.listenbrainz.shared.model.PlayableType
 import org.listenbrainz.android.repository.brainzplayer.BPAlbumRepository
 import org.listenbrainz.shared.repository.AppPreferences
-import org.listenbrainz.android.repository.brainzplayer.PlaylistRepository
+import org.listenbrainz.shared.repository.brainzplayer.PlaylistRepository
 import org.listenbrainz.shared.repository.brainzplayer.SongRepository
 import org.listenbrainz.android.util.BrainzPlayerExtensions.toMediaMetadataCompat
 import org.listenbrainz.android.util.BrainzPlayerNotificationManager

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerBackDropScreen.kt
@@ -106,7 +106,7 @@ import org.listenbrainz.android.util.BrainzPlayerExtensions.toSong
 import org.listenbrainz.android.util.SongViewPager
 import org.listenbrainz.android.viewmodel.BrainzPlayerViewModel
 import org.listenbrainz.android.viewmodel.ListeningNowViewModel
-import org.listenbrainz.android.viewmodel.PlaylistViewModel
+import org.listenbrainz.shared.viewmodel.PlaylistViewModel
 import java.util.Locale
 import kotlin.math.absoluteValue
 import kotlin.math.max

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerScreen.kt
@@ -45,7 +45,7 @@ import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.viewmodel.BPAlbumViewModel
 import org.listenbrainz.android.viewmodel.BPArtistViewModel
 import org.listenbrainz.android.viewmodel.BrainzPlayerViewModel
-import org.listenbrainz.android.viewmodel.PlaylistViewModel
+import org.listenbrainz.shared.viewmodel.PlaylistViewModel
 import org.listenbrainz.shared.viewmodel.SongViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/PlaylistScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/PlaylistScreen.kt
@@ -43,7 +43,7 @@ import org.listenbrainz.android.ui.components.ListenCardSmall
 import org.listenbrainz.android.ui.components.forwardingPainter
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.viewmodel.BrainzPlayerViewModel
-import org.listenbrainz.android.viewmodel.PlaylistViewModel
+import org.listenbrainz.shared.viewmodel.PlaylistViewModel
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @ExperimentalMaterial3Api

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/SongScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/SongScreen.kt
@@ -40,7 +40,7 @@ import org.listenbrainz.shared.model.PlayableType
 import org.listenbrainz.android.ui.components.BPLibraryEmptyMessage
 import org.listenbrainz.android.ui.components.forwardingPainter
 import org.listenbrainz.android.viewmodel.BrainzPlayerViewModel
-import org.listenbrainz.android.viewmodel.PlaylistViewModel
+import org.listenbrainz.shared.viewmodel.PlaylistViewModel
 import org.listenbrainz.shared.viewmodel.SongViewModel
 
 @OptIn(ExperimentalMaterialApi::class)

--- a/app/src/main/java/org/listenbrainz/android/util/LocalMusicSource.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/LocalMusicSource.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.listenbrainz.android.model.State
 import org.listenbrainz.android.repository.brainzplayer.BPAlbumRepository
-import org.listenbrainz.android.repository.brainzplayer.PlaylistRepository
+import org.listenbrainz.shared.repository.brainzplayer.PlaylistRepository
 import org.listenbrainz.shared.repository.brainzplayer.SongRepository
 
 class LocalMusicSource(

--- a/app/src/main/java/org/listenbrainz/android/viewmodel/BrainzPlayerViewModel.kt
+++ b/app/src/main/java/org/listenbrainz/android/viewmodel/BrainzPlayerViewModel.kt
@@ -41,7 +41,7 @@ import org.listenbrainz.shared.model.Playlist.Companion.currentlyPlaying
 import org.listenbrainz.android.model.RepeatMode
 import org.listenbrainz.shared.model.Song
 import org.listenbrainz.android.repository.brainzplayer.BPAlbumRepository
-import org.listenbrainz.android.repository.brainzplayer.PlaylistRepository
+import org.listenbrainz.shared.repository.brainzplayer.PlaylistRepository
 import org.listenbrainz.shared.repository.brainzplayer.SongRepository
 import org.listenbrainz.shared.repository.AppPreferences
 import org.listenbrainz.android.service.BrainzPlayerService

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedRepositoryModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedRepositoryModule.kt
@@ -19,6 +19,8 @@ import org.listenbrainz.shared.service.ListensService
 import org.listenbrainz.shared.service.UserService
 import org.listenbrainz.shared.repository.brainzplayer.SongRepository
 import org.listenbrainz.shared.repository.brainzplayer.SongRepositoryImpl
+import org.listenbrainz.shared.repository.brainzplayer.PlaylistRepository
+import org.listenbrainz.shared.repository.brainzplayer.PlaylistRepositoryImpl
 
 val sharedRepositoryModule = module {
     single<SocketRepository> { SocketRepositoryImpl(get<HttpClient>(named(SHARED_HTTP_CLIENT)),get()) }
@@ -38,4 +40,5 @@ val sharedRepositoryModule = module {
         )
     }
     single<SongRepository> { SongRepositoryImpl(get(),get()) }
+    single<PlaylistRepository> { PlaylistRepositoryImpl(get()) }
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
@@ -10,6 +10,7 @@ import org.listenbrainz.shared.viewmodel.AlbumViewModel
 import org.listenbrainz.shared.viewmodel.ArtistViewModel
 import org.listenbrainz.shared.viewmodel.LoginViewModel
 import org.listenbrainz.shared.viewmodel.ListensViewModel
+import org.listenbrainz.shared.viewmodel.PlaylistViewModel
 import org.listenbrainz.shared.viewmodel.SettingsViewModel
 import org.listenbrainz.shared.viewmodel.SongViewModel
 
@@ -23,4 +24,5 @@ val sharedViewModelModule = module {
     viewModel { AlbumViewModel(get(),get(named(IO_DISPATCHER))) }
     viewModel { ListensViewModel(get(),get(),get(),get(),get(named(DEFAULT_DISPATCHER))) }
     viewModel { SongViewModel(get(),get(named(IO_DISPATCHER))) }
+    viewModel { PlaylistViewModel(get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER))) }
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/brainzplayer/PlaylistRepository.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/brainzplayer/PlaylistRepository.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android.repository.brainzplayer
+package org.listenbrainz.shared.repository.brainzplayer
 
 import kotlinx.coroutines.flow.Flow
 import org.listenbrainz.shared.model.Playlist

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/brainzplayer/PlaylistRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/brainzplayer/PlaylistRepositoryImpl.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android.repository.brainzplayer
+package org.listenbrainz.shared.repository.brainzplayer
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/viewmodel/PlaylistViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/viewmodel/PlaylistViewModel.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android.viewmodel
+package org.listenbrainz.shared.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -8,6 +8,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import org.listenbrainz.shared.repository.brainzplayer.PlaylistRepository
+import org.listenbrainz.shared.model.Playlist
 import org.listenbrainz.android.repository.brainzplayer.PlaylistRepository
 import org.listenbrainz.shared.model.Playlist
 import org.listenbrainz.shared.model.Playlist.Companion.currentlyPlaying
@@ -26,7 +28,10 @@ class PlaylistViewModel(
         viewModelScope.launch(Dispatchers.Default) {
             playlists.collectLatest {
                 if (it.isEmpty()){
-                    playlistRepository.insertPlaylists(listOf(currentlyPlaying, favourite))
+                    playlistRepository.insertPlaylists(listOf(
+                        Playlist.currentlyPlaying,
+                        Playlist.favourite
+                    ))
                 }
             }
         }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/viewmodel/PlaylistViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/viewmodel/PlaylistViewModel.kt
@@ -10,8 +10,6 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import org.listenbrainz.shared.repository.brainzplayer.PlaylistRepository
 import org.listenbrainz.shared.model.Playlist
-import org.listenbrainz.android.repository.brainzplayer.PlaylistRepository
-import org.listenbrainz.shared.model.Playlist
 import org.listenbrainz.shared.model.Playlist.Companion.currentlyPlaying
 import org.listenbrainz.shared.model.Playlist.Companion.favourite
 import org.listenbrainz.shared.model.Song


### PR DESCRIPTION
## Base PR:- #752 
#### Rebased with the latest upstream/cmp branch, and this branch includes all commits from the base branch

---

This PR fixes #709  migrates `PlaylistViewModel` from `androidApp` module to shared module

## Key Changes:- 
1. Moved `PlaylistViewModel` to shared/commonMain/viewmodel/ using kmp lifecycle dependencies.
2. Moved `PlaylistRepository` to shared module with its impl as well.
3. Registered the viewmodel inside `sharedViewModelModule`, repository inside `sharedRepositoryModule`.
4. Wired all the shared modules inside of `KoinModules.kt`