### PR TITLE
Migrated BPAlbumViewModel to shared module

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
+++ b/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
@@ -32,8 +32,8 @@ import org.koin.dsl.module
 import org.listenbrainz.android.BuildConfig
 import org.listenbrainz.android.repository.appupdates.AppUpdatesRepository
 import org.listenbrainz.android.repository.appupdates.AppUpdatesRepositoryImpl
-import org.listenbrainz.android.repository.brainzplayer.BPAlbumRepository
-import org.listenbrainz.android.repository.brainzplayer.BPAlbumRepositoryImpl
+import org.listenbrainz.shared.repository.brainzplayer.BPAlbumRepository
+import org.listenbrainz.shared.repository.brainzplayer.BPAlbumRepositoryImpl
 import org.listenbrainz.android.repository.brainzplayer.BPArtistRepository
 import org.listenbrainz.android.repository.brainzplayer.BPArtistRepositoryImpl
 import org.listenbrainz.shared.repository.brainzplayer.SongRepository
@@ -73,7 +73,7 @@ import org.listenbrainz.android.util.LocalMusicSource
 import org.listenbrainz.android.util.MusicSource
 import org.listenbrainz.android.viewmodel.AboutViewModel
 import org.listenbrainz.android.viewmodel.AppUpdatesViewModel
-import org.listenbrainz.android.viewmodel.BPAlbumViewModel
+import org.listenbrainz.shared.viewmodel.BPAlbumViewModel
 import org.listenbrainz.android.viewmodel.BPArtistViewModel
 import org.listenbrainz.android.viewmodel.BrainzPlayerViewModel
 import org.listenbrainz.android.viewmodel.DashBoardViewModel
@@ -295,7 +295,6 @@ val appModule = module {
 
 val repositoryModule = module {
     // BrainzPlayer Repositories
-    single<BPAlbumRepository> { BPAlbumRepositoryImpl(get(),get()) }
     single<BPArtistRepository> { BPArtistRepositoryImpl(get(),get()) }
 
     // API Repositories
@@ -347,7 +346,6 @@ val viewModelModule = module {
     viewModel { NewsListViewModel(get(), get(named(IO_DISPATCHER))) }
     viewModel { SearchViewModel(get(),get(),get(),get(),get(), get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER))) }
     viewModel { BrainzPlayerViewModel(get(), get(), get(), get(), get(), get(named(IO_DISPATCHER))) }
-    viewModel { BPAlbumViewModel(get(), get(named(IO_DISPATCHER))) }
     viewModel { BPArtistViewModel(get(), get(named(IO_DISPATCHER))) }
     viewModel { AboutViewModel() }
     viewModel { LoginViewModel(get()) }

--- a/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
+++ b/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
@@ -295,7 +295,7 @@ val appModule = module {
 
 val repositoryModule = module {
     // BrainzPlayer Repositories
-    single<BPArtistRepository> { BPArtistRepositoryImpl(get(),get()) }
+    single<BPArtistRepository> { BPArtistRepositoryImpl(get(),get(),get()) }
 
     // API Repositories
     single<FeedRepository> { FeedRepositoryImpl(get()) }

--- a/app/src/main/java/org/listenbrainz/android/repository/brainzplayer/BPArtistRepositoryImpl.kt
+++ b/app/src/main/java/org/listenbrainz/android/repository/brainzplayer/BPArtistRepositoryImpl.kt
@@ -10,7 +10,7 @@ import org.listenbrainz.shared.model.Album
 import org.listenbrainz.shared.model.Artist
 import org.listenbrainz.shared.model.Song
 import org.listenbrainz.shared.model.dao.ArtistDao
-import org.listenbrainz.android.util.AlbumsData
+import org.listenbrainz.shared.util.AlbumsData
 import org.listenbrainz.shared.util.SongsData
 import org.listenbrainz.shared.util.Transformer.toAlbumEntity
 import org.listenbrainz.shared.util.Transformer.toArtist
@@ -19,7 +19,8 @@ import org.listenbrainz.shared.util.Transformer.toSongEntity
 
 class BPArtistRepositoryImpl(
     private val artistDao: ArtistDao,
-    private val songsData: SongsData
+    private val songsData: SongsData,
+    private val albumsData: AlbumsData
 ) : BPArtistRepository {
     override fun getArtist(artistID: String): Flow<Artist> {
         val artist = artistDao.getArtistEntity(artistID)
@@ -37,7 +38,7 @@ class BPArtistRepositoryImpl(
             }
     
     override suspend fun addArtists(userRequestedRefresh: Boolean): Boolean {
-        val artists = AlbumsData.fetchAlbums(userRequestedRefresh)
+        val artists = albumsData.fetchAlbums(userRequestedRefresh)
             .map {
                 it.toArtistEntity()
             }
@@ -91,7 +92,7 @@ class BPArtistRepositoryImpl(
     }
     
     override suspend fun addAllAlbumsOfArtist(artist: Artist): List<Album> {
-        return AlbumsData.fetchAlbums().filter {
+        return albumsData.fetchAlbums().filter {
             it.artist == artist.name
         }
             .map {

--- a/app/src/main/java/org/listenbrainz/android/service/BrainzPlayerService.kt
+++ b/app/src/main/java/org/listenbrainz/android/service/BrainzPlayerService.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.flow.first
 import org.listenbrainz.shared.model.Playable
 import org.listenbrainz.shared.model.Playable.Companion.EMPTY_PLAYABLE
 import org.listenbrainz.shared.model.PlayableType
-import org.listenbrainz.android.repository.brainzplayer.BPAlbumRepository
+import org.listenbrainz.shared.repository.brainzplayer.BPAlbumRepository
 import org.listenbrainz.shared.repository.AppPreferences
 import org.listenbrainz.shared.repository.brainzplayer.PlaylistRepository
 import org.listenbrainz.shared.repository.brainzplayer.SongRepository

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/AlbumScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/AlbumScreen.kt
@@ -45,7 +45,7 @@ import org.listenbrainz.android.ui.components.BPLibraryEmptyMessage
 import org.listenbrainz.android.ui.components.ListenCardSmall
 import org.listenbrainz.android.ui.components.forwardingPainter
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
-import org.listenbrainz.android.viewmodel.BPAlbumViewModel
+import org.listenbrainz.shared.viewmodel.BPAlbumViewModel
 import org.listenbrainz.android.viewmodel.BrainzPlayerViewModel
 
 

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/ArtistScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/ArtistScreen.kt
@@ -49,7 +49,7 @@ import org.listenbrainz.android.ui.components.BPLibraryEmptyMessage
 import org.listenbrainz.android.ui.components.ListenCardSmall
 import org.listenbrainz.android.ui.components.forwardingPainter
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
-import org.listenbrainz.android.viewmodel.BPAlbumViewModel
+import org.listenbrainz.shared.viewmodel.BPAlbumViewModel
 import org.listenbrainz.android.viewmodel.BPArtistViewModel
 import org.listenbrainz.android.viewmodel.BrainzPlayerViewModel
 

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerScreen.kt
@@ -42,7 +42,7 @@ import org.listenbrainz.android.ui.screens.brainzplayer.overview.OverviewScreen
 import org.listenbrainz.android.ui.screens.brainzplayer.overview.RecentPlaysScreen
 import org.listenbrainz.android.ui.screens.brainzplayer.overview.SongsOverviewScreen
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
-import org.listenbrainz.android.viewmodel.BPAlbumViewModel
+import org.listenbrainz.shared.viewmodel.BPAlbumViewModel
 import org.listenbrainz.android.viewmodel.BPArtistViewModel
 import org.listenbrainz.android.viewmodel.BrainzPlayerViewModel
 import org.listenbrainz.shared.viewmodel.PlaylistViewModel

--- a/app/src/main/java/org/listenbrainz/android/util/LocalMusicSource.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/LocalMusicSource.kt
@@ -8,7 +8,7 @@ import com.google.android.exoplayer2.MediaItem
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.listenbrainz.android.model.State
-import org.listenbrainz.android.repository.brainzplayer.BPAlbumRepository
+import org.listenbrainz.shared.repository.brainzplayer.BPAlbumRepository
 import org.listenbrainz.shared.repository.brainzplayer.PlaylistRepository
 import org.listenbrainz.shared.repository.brainzplayer.SongRepository
 

--- a/app/src/main/java/org/listenbrainz/android/viewmodel/BrainzPlayerViewModel.kt
+++ b/app/src/main/java/org/listenbrainz/android/viewmodel/BrainzPlayerViewModel.kt
@@ -40,7 +40,7 @@ import org.listenbrainz.shared.model.PlayableType
 import org.listenbrainz.shared.model.Playlist.Companion.currentlyPlaying
 import org.listenbrainz.android.model.RepeatMode
 import org.listenbrainz.shared.model.Song
-import org.listenbrainz.android.repository.brainzplayer.BPAlbumRepository
+import org.listenbrainz.shared.repository.brainzplayer.BPAlbumRepository
 import org.listenbrainz.shared.repository.brainzplayer.PlaylistRepository
 import org.listenbrainz.shared.repository.brainzplayer.SongRepository
 import org.listenbrainz.shared.repository.AppPreferences

--- a/shared/src/androidMain/kotlin/org/listenbrainz/shared/Platform.android.kt
+++ b/shared/src/androidMain/kotlin/org/listenbrainz/shared/Platform.android.kt
@@ -27,6 +27,8 @@ import org.listenbrainz.shared.service.YouTubeApiService
 import org.listenbrainz.shared.di.database.BrainzPlayerDatabase
 import org.listenbrainz.shared.util.AndroidSongsData
 import org.listenbrainz.shared.util.SongsData
+import org.listenbrainz.shared.util.AlbumsData
+import org.listenbrainz.shared.util.AndroidAlbumsData
 
 actual fun platform() = "Android"
 
@@ -98,4 +100,8 @@ actual fun getListensSubmissionDatabase(appContext: PlatformContext): RoomDataba
 
 actual fun provideSongData(context: PlatformContext): SongsData {
     return AndroidSongsData(context)
+}
+
+actual fun provideAlbumsData(context: PlatformContext): AlbumsData {
+    return AndroidAlbumsData(context)
 }

--- a/shared/src/androidMain/kotlin/org/listenbrainz/shared/util/AndroidAlbumsData.kt
+++ b/shared/src/androidMain/kotlin/org/listenbrainz/shared/util/AndroidAlbumsData.kt
@@ -1,20 +1,14 @@
-package org.listenbrainz.android.util
+package org.listenbrainz.shared.util
 
 import android.os.Build
 import android.provider.MediaStore
-import org.listenbrainz.android.application.App.Companion.context
 import org.listenbrainz.shared.model.Album
-object AlbumsData {
-    
-    /** Runtime cache to improve performance
-     *  Not using on device caching as songs need to be refreshed frequently.*/
-    private var albumsListCache = listOf<Album>()
-    
-    /** Fetch albums from device. Heavy task, so perform in `Dispacthers.IO`.*/
-    fun fetchAlbums(userRequestedRefresh: Boolean = false): List<Album> {
-        if(albumsListCache.isNotEmpty() && !userRequestedRefresh){
-            return albumsListCache
-        }
+import org.listenbrainz.shared.repository.PlatformContext
+
+class AndroidAlbumsData(
+    private val context: PlatformContext
+): AlbumsData(){
+    override fun albums(): List<Album> {
         val albums = mutableListOf<Album>()
         val collection =
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
@@ -50,8 +44,6 @@ object AlbumsData {
                 albums.add(Album(albumId, albumName, artistName, albumArt))
             }
         }
-        albumsListCache = albums.distinct()
-        return albumsListCache
+        return albums.distinct()
     }
-    
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/Platform.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/Platform.kt
@@ -16,6 +16,7 @@ import org.listenbrainz.shared.service.UserService
 import org.listenbrainz.shared.service.YouTubeApiService
 import org.listenbrainz.shared.di.database.BrainzPlayerDatabase
 import org.listenbrainz.shared.util.SongsData
+import org.listenbrainz.shared.util.AlbumsData
 
 expect fun platform(): String
 
@@ -53,3 +54,7 @@ expect fun getListensSubmissionDatabase(
 expect fun provideSongData(
     context: PlatformContext
 ): SongsData
+
+expect fun provideAlbumsData(
+    context: PlatformContext
+): AlbumsData

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedAppModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedAppModule.kt
@@ -10,6 +10,9 @@ import org.listenbrainz.shared.provideLogSubmitter
 import org.listenbrainz.shared.provideLogger
 import org.listenbrainz.shared.util.BuildInfo
 import org.listenbrainz.shared.util.LogSubmitter
+import org.listenbrainz.shared.provideAlbumsData
+import org.listenbrainz.shared.util.AlbumsData
+
 
 val platformModule = module {
     single<LogSubmitter>{
@@ -25,5 +28,8 @@ val platformModule = module {
     }
     single<SongsData>{
         provideSongData(get())
+    }
+    single<AlbumsData>{
+        provideAlbumsData(get())
     }
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedRepositoryModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedRepositoryModule.kt
@@ -21,6 +21,8 @@ import org.listenbrainz.shared.repository.brainzplayer.SongRepository
 import org.listenbrainz.shared.repository.brainzplayer.SongRepositoryImpl
 import org.listenbrainz.shared.repository.brainzplayer.PlaylistRepository
 import org.listenbrainz.shared.repository.brainzplayer.PlaylistRepositoryImpl
+import org.listenbrainz.shared.repository.brainzplayer.BPAlbumRepository
+import org.listenbrainz.shared.repository.brainzplayer.BPAlbumRepositoryImpl
 
 val sharedRepositoryModule = module {
     single<SocketRepository> { SocketRepositoryImpl(get<HttpClient>(named(SHARED_HTTP_CLIENT)),get()) }
@@ -41,4 +43,5 @@ val sharedRepositoryModule = module {
     }
     single<SongRepository> { SongRepositoryImpl(get(),get()) }
     single<PlaylistRepository> { PlaylistRepositoryImpl(get()) }
+    single<BPAlbumRepository> { BPAlbumRepositoryImpl(get(),get(),get()) }
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
@@ -11,6 +11,7 @@ import org.listenbrainz.shared.viewmodel.ArtistViewModel
 import org.listenbrainz.shared.viewmodel.LoginViewModel
 import org.listenbrainz.shared.viewmodel.ListensViewModel
 import org.listenbrainz.shared.viewmodel.PlaylistViewModel
+import org.listenbrainz.shared.viewmodel.BPAlbumViewModel
 import org.listenbrainz.shared.viewmodel.SettingsViewModel
 import org.listenbrainz.shared.viewmodel.SongViewModel
 
@@ -25,4 +26,5 @@ val sharedViewModelModule = module {
     viewModel { ListensViewModel(get(),get(),get(),get(),get(named(DEFAULT_DISPATCHER))) }
     viewModel { SongViewModel(get(),get(named(IO_DISPATCHER))) }
     viewModel { PlaylistViewModel(get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER))) }
+    viewModel { BPAlbumViewModel(get(),get(named(IO_DISPATCHER))) }
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/brainzplayer/BPAlbumRepository.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/brainzplayer/BPAlbumRepository.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android.repository.brainzplayer
+package org.listenbrainz.shared.repository.brainzplayer
 
 import kotlinx.coroutines.flow.Flow
 import org.listenbrainz.shared.model.Album

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/brainzplayer/BPAlbumRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/brainzplayer/BPAlbumRepositoryImpl.kt
@@ -1,6 +1,7 @@
-package org.listenbrainz.android.repository.brainzplayer
+package org.listenbrainz.shared.repository.brainzplayer
 
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
@@ -12,7 +13,7 @@ import kotlinx.coroutines.withContext
 import org.listenbrainz.shared.model.Album
 import org.listenbrainz.shared.model.Song
 import org.listenbrainz.shared.model.dao.AlbumDao
-import org.listenbrainz.android.util.AlbumsData
+import org.listenbrainz.shared.util.AlbumsData
 import org.listenbrainz.shared.util.SongsData
 import org.listenbrainz.shared.util.Transformer.toAlbum
 import org.listenbrainz.shared.util.Transformer.toAlbumEntity
@@ -21,6 +22,7 @@ import org.listenbrainz.shared.util.Transformer.toAlbumEntity
 
 class BPAlbumRepositoryImpl(
     private val albumDao: AlbumDao,
+    private val albumsData: AlbumsData,
     private val songsData: SongsData
 ): BPAlbumRepository {
     override fun getAlbums(): Flow<List<Album>> =
@@ -37,7 +39,7 @@ class BPAlbumRepositoryImpl(
     
     
     override suspend fun addAlbums(userRequestedRefresh: Boolean): Boolean {
-        val albums = AlbumsData.fetchAlbums(userRequestedRefresh).map {
+        val albums = albumsData.fetchAlbums(userRequestedRefresh).map {
             it.toAlbumEntity()
         }
         

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/util/AlbumsData.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/util/AlbumsData.kt
@@ -1,0 +1,22 @@
+package org.listenbrainz.shared.util
+
+import org.listenbrainz.shared.model.Album
+
+abstract class AlbumsData {
+
+    /** Runtime cache to improve performance
+     *  Not using on device caching as songs need to be refreshed frequently.*/
+    private var albumsListCache = listOf<Album>()
+
+    protected abstract fun albums(): List<Album>
+
+    /** Fetch albums from device. Heavy task, so perform in `Dispacthers.IO`.*/
+    fun fetchAlbums(userRequestedRefresh: Boolean = false): List<Album> {
+        if(albumsListCache.isNotEmpty() && !userRequestedRefresh){
+            return albumsListCache
+        }
+        albumsListCache = albums()
+        return albumsListCache
+    }
+
+}

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/viewmodel/BPAlbumViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/viewmodel/BPAlbumViewModel.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android.viewmodel
+package org.listenbrainz.shared.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -11,22 +11,22 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.listenbrainz.shared.model.Album
 import org.listenbrainz.shared.model.Song
-import org.listenbrainz.android.repository.brainzplayer.BPAlbumRepository
+import org.listenbrainz.shared.repository.brainzplayer.BPAlbumRepository
 
 class BPAlbumViewModel(
     private val bpAlbumRepository: BPAlbumRepository,
     private val ioDispatcher: CoroutineDispatcher
 ) : ViewModel() {
     val albums = bpAlbumRepository.getAlbums()
-    
+
     // Refreshing variables.
     private val _isRefreshing = MutableStateFlow(false)
     val isRefreshing = _isRefreshing.asStateFlow()
-    
+
     init {
         fetchAlbumsFromDevice()
     }
-    
+
     fun fetchAlbumsFromDevice(userRequestedRefresh: Boolean = false) {
         viewModelScope.launch(ioDispatcher) {
             if (userRequestedRefresh){
@@ -44,7 +44,7 @@ class BPAlbumViewModel(
             }
         }
     }
-    
+
     fun getAlbumFromID(albumID: Long): Flow<Album> {
         return bpAlbumRepository.getAlbum(albumID)
     }

--- a/shared/src/iosMain/kotlin/org/listenbrainz/shared/Platform.ios.kt
+++ b/shared/src/iosMain/kotlin/org/listenbrainz/shared/Platform.ios.kt
@@ -30,6 +30,8 @@ import platform.posix.err
 import org.listenbrainz.shared.di.database.BrainzPlayerDatabase
 import org.listenbrainz.shared.util.IosSongsData
 import org.listenbrainz.shared.util.SongsData
+import org.listenbrainz.shared.util.AlbumsData
+import org.listenbrainz.shared.util.IosAlbumsData
 import platform.Foundation.NSFileManager
 
 actual fun platform() = "iOS"
@@ -112,4 +114,8 @@ actual fun getListensSubmissionDatabase(appContext: PlatformContext): RoomDataba
 
 actual fun provideSongData(context: PlatformContext): SongsData {
     return IosSongsData()
+}
+
+actual fun provideAlbumsData(context: PlatformContext): AlbumsData {
+    return IosAlbumsData()
 }

--- a/shared/src/iosMain/kotlin/org/listenbrainz/shared/util/IosAlbumsData.kt
+++ b/shared/src/iosMain/kotlin/org/listenbrainz/shared/util/IosAlbumsData.kt
@@ -1,6 +1,7 @@
 package org.listenbrainz.shared.util
 
 import org.listenbrainz.shared.model.Album
+import platform.Foundation.NSNumber
 import platform.MediaPlayer.MPMediaItem
 import platform.MediaPlayer.MPMediaItemCollection
 import platform.MediaPlayer.MPMediaItemPropertyAlbumPersistentID
@@ -25,7 +26,7 @@ class IosAlbumsData(): AlbumsData() {
                 continue
             }
             val mediaItem = mediaCollection.representativeItem ?: continue
-            val albumId = mediaItem.valueForProperty(MPMediaItemPropertyAlbumPersistentID) as? Long ?: 0
+            val albumId = (mediaItem.valueForProperty(MPMediaItemPropertyAlbumPersistentID) as? NSNumber)?.longLongValue ?: 0
             val albumArt = "mediaitem-art://$albumId"
             albums += Album(
                 albumId = albumId,

--- a/shared/src/iosMain/kotlin/org/listenbrainz/shared/util/IosAlbumsData.kt
+++ b/shared/src/iosMain/kotlin/org/listenbrainz/shared/util/IosAlbumsData.kt
@@ -1,0 +1,39 @@
+package org.listenbrainz.shared.util
+
+import org.listenbrainz.shared.model.Album
+import platform.MediaPlayer.MPMediaItem
+import platform.MediaPlayer.MPMediaItemCollection
+import platform.MediaPlayer.MPMediaItemPropertyAlbumPersistentID
+import platform.MediaPlayer.MPMediaItemPropertyAlbumTitle
+import platform.MediaPlayer.MPMediaItemPropertyArtist
+import platform.MediaPlayer.MPMediaLibrary
+import platform.MediaPlayer.MPMediaLibraryAuthorizationStatusAuthorized
+import platform.MediaPlayer.MPMediaQuery
+
+class IosAlbumsData(): AlbumsData() {
+    override fun albums(): List<Album> {
+       if(MPMediaLibrary.authorizationStatus() != MPMediaLibraryAuthorizationStatusAuthorized){
+           return emptyList()
+       }
+
+        val albums = mutableListOf<Album>()
+        val mediaCollections = MPMediaQuery.albumsQuery().collections ?: return emptyList()
+
+        for (collection in mediaCollections){
+            val mediaCollection = collection as? MPMediaItemCollection
+            if(mediaCollection == null){
+                continue
+            }
+            val mediaItem = mediaCollection.representativeItem ?: continue
+            val albumId = mediaItem.valueForProperty(MPMediaItemPropertyAlbumPersistentID) as? Long ?: 0
+            val albumArt = "mediaitem-art://$albumId"
+            albums += Album(
+                albumId = albumId,
+                title = mediaItem.valueForProperty(MPMediaItemPropertyAlbumTitle) as? String ?: "Album",
+                artist = mediaItem.valueForProperty(MPMediaItemPropertyArtist) as? String ?: "Artist",
+                albumArt = albumArt
+            )
+        }
+        return albums.distinct()
+    }
+}


### PR DESCRIPTION
## Base PR:- #752, #753 
#### Rebased with the latest upstream/cmp branch, and this branch includes all commits from the bp-database branch and cherry picked a commit from song viewmodel branch

---

This PR fixes #710  migrates `BPAlbumViewModel` from `androidApp` module to shared module

## Key Changes:- 
1. Moved `BPAlbumViewModel` to shared/commonMain/viewmodel/ using kmp lifecycle dependencies.
2. Moved `AlbumsData` and `SongsData` to shared module while having platform specific impl in `androidMain` and `iosMain` resp.
4. Moved `BPAlbumRepository` to shared module with its impl as well.
5. Registered the viewmodel inside `sharedViewModelModule`, repository inside `sharedRepositoryModule` and the `AlbumsData` and `SongsData` inside `platformModule` via platform specific providers.
6. Wired all the shared modules inside of `KoinModules.kt`