### PR TITLE
Migrated BPArtistViewModel to shared module

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
+++ b/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
@@ -284,8 +284,6 @@ val appModule = module {
 }
 
 val repositoryModule = module {
-    // BrainzPlayer Repositories
-    single<BPArtistRepository> { BPArtistRepositoryImpl(get(),get(),get()) }
 
     // API Repositories
     single<FeedRepository> { FeedRepositoryImpl(get()) }

--- a/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
+++ b/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
@@ -34,8 +34,8 @@ import org.listenbrainz.android.repository.appupdates.AppUpdatesRepository
 import org.listenbrainz.android.repository.appupdates.AppUpdatesRepositoryImpl
 import org.listenbrainz.shared.repository.brainzplayer.BPAlbumRepository
 import org.listenbrainz.shared.repository.brainzplayer.BPAlbumRepositoryImpl
-import org.listenbrainz.android.repository.brainzplayer.BPArtistRepository
-import org.listenbrainz.android.repository.brainzplayer.BPArtistRepositoryImpl
+import org.listenbrainz.shared.repository.brainzplayer.BPArtistRepository
+import org.listenbrainz.shared.repository.brainzplayer.BPArtistRepositoryImpl
 import org.listenbrainz.shared.repository.brainzplayer.SongRepository
 import org.listenbrainz.shared.repository.brainzplayer.SongRepositoryImpl
 import org.listenbrainz.android.repository.feed.FeedRepository
@@ -73,7 +73,7 @@ import org.listenbrainz.android.util.MusicSource
 import org.listenbrainz.android.viewmodel.AboutViewModel
 import org.listenbrainz.android.viewmodel.AppUpdatesViewModel
 import org.listenbrainz.shared.viewmodel.BPAlbumViewModel
-import org.listenbrainz.android.viewmodel.BPArtistViewModel
+import org.listenbrainz.shared.viewmodel.BPArtistViewModel
 import org.listenbrainz.android.viewmodel.BrainzPlayerViewModel
 import org.listenbrainz.android.viewmodel.DashBoardViewModel
 import org.listenbrainz.android.viewmodel.FeedViewModel
@@ -335,7 +335,6 @@ val viewModelModule = module {
     viewModel { NewsListViewModel(get(), get(named(IO_DISPATCHER))) }
     viewModel { SearchViewModel(get(),get(),get(),get(),get(), get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER))) }
     viewModel { BrainzPlayerViewModel(get(), get(), get(), get(), get(), get(named(IO_DISPATCHER))) }
-    viewModel { BPArtistViewModel(get(), get(named(IO_DISPATCHER))) }
     viewModel { AboutViewModel() }
     viewModel { LoginViewModel(get()) }
 }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/ArtistScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/ArtistScreen.kt
@@ -50,7 +50,7 @@ import org.listenbrainz.android.ui.components.ListenCardSmall
 import org.listenbrainz.android.ui.components.forwardingPainter
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.shared.viewmodel.BPAlbumViewModel
-import org.listenbrainz.android.viewmodel.BPArtistViewModel
+import org.listenbrainz.shared.viewmodel.BPArtistViewModel
 import org.listenbrainz.android.viewmodel.BrainzPlayerViewModel
 
 

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerScreen.kt
@@ -43,7 +43,7 @@ import org.listenbrainz.android.ui.screens.brainzplayer.overview.RecentPlaysScre
 import org.listenbrainz.android.ui.screens.brainzplayer.overview.SongsOverviewScreen
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.shared.viewmodel.BPAlbumViewModel
-import org.listenbrainz.android.viewmodel.BPArtistViewModel
+import org.listenbrainz.shared.viewmodel.BPArtistViewModel
 import org.listenbrainz.android.viewmodel.BrainzPlayerViewModel
 import org.listenbrainz.shared.viewmodel.PlaylistViewModel
 import org.listenbrainz.shared.viewmodel.SongViewModel

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedRepositoryModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedRepositoryModule.kt
@@ -25,6 +25,8 @@ import org.listenbrainz.shared.repository.social.SocialRepository
 import org.listenbrainz.shared.repository.social.SocialRepositoryImpl
 import org.listenbrainz.shared.repository.brainzplayer.BPAlbumRepository
 import org.listenbrainz.shared.repository.brainzplayer.BPAlbumRepositoryImpl
+import org.listenbrainz.shared.repository.brainzplayer.BPArtistRepository
+import org.listenbrainz.shared.repository.brainzplayer.BPArtistRepositoryImpl
 
 val sharedRepositoryModule = module {
     single<SocketRepository> { SocketRepositoryImpl(get<HttpClient>(named(SHARED_HTTP_CLIENT)),get()) }
@@ -47,4 +49,5 @@ val sharedRepositoryModule = module {
     single<PlaylistRepository> { PlaylistRepositoryImpl(get()) }
     single<SocialRepository> { SocialRepositoryImpl(get(),get()) }
     single<BPAlbumRepository> { BPAlbumRepositoryImpl(get(),get(),get()) }
+    single<BPArtistRepository> { BPArtistRepositoryImpl(get(),get(),get()) }
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
@@ -8,6 +8,7 @@ import org.listenbrainz.shared.viewmodel.CreateAccountViewModel
 import org.listenbrainz.shared.viewmodel.FeaturesViewModel
 import org.listenbrainz.shared.viewmodel.AlbumViewModel
 import org.listenbrainz.shared.viewmodel.ArtistViewModel
+import org.listenbrainz.shared.viewmodel.BPArtistViewModel
 import org.listenbrainz.shared.viewmodel.LoginViewModel
 import org.listenbrainz.shared.viewmodel.ListensViewModel
 import org.listenbrainz.shared.viewmodel.PlaylistViewModel
@@ -27,4 +28,5 @@ val sharedViewModelModule = module {
     viewModel { SongViewModel(get(),get(named(IO_DISPATCHER))) }
     viewModel { PlaylistViewModel(get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER))) }
     viewModel { BPAlbumViewModel(get(),get(named(IO_DISPATCHER))) }
+    viewModel { BPArtistViewModel(get(),get(named(IO_DISPATCHER))) }
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/brainzplayer/BPArtistRepository.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/brainzplayer/BPArtistRepository.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android.repository.brainzplayer
+package org.listenbrainz.shared.repository.brainzplayer
 
 import kotlinx.coroutines.flow.Flow
 import org.listenbrainz.shared.model.Album

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/brainzplayer/BPArtistRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/brainzplayer/BPArtistRepositoryImpl.kt
@@ -1,7 +1,8 @@
-package org.listenbrainz.android.repository.brainzplayer
+package org.listenbrainz.shared.repository.brainzplayer
 
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/viewmodel/BPArtistViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/viewmodel/BPArtistViewModel.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android.viewmodel
+package org.listenbrainz.shared.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -13,22 +13,22 @@ import kotlinx.coroutines.launch
 import org.listenbrainz.shared.model.Album
 import org.listenbrainz.shared.model.Artist
 import org.listenbrainz.shared.model.Song
-import org.listenbrainz.android.repository.brainzplayer.BPArtistRepository
+import org.listenbrainz.shared.repository.brainzplayer.BPArtistRepository
 
 class BPArtistViewModel(
     private val bpArtistRepository: BPArtistRepository,
     private val ioDispatcher: CoroutineDispatcher
 ) : ViewModel() {
     val artists = bpArtistRepository.getArtists()
-    
+
     // Refreshing variables.
     private val _isRefreshing = MutableStateFlow(false)
     val isRefreshing = _isRefreshing.asStateFlow()
-    
+
     init {
         fetchArtistsFromDevice()
     }
-    
+
     fun fetchArtistsFromDevice(userRequestedRefresh: Boolean = false){
         viewModelScope.launch(ioDispatcher) {
             if (userRequestedRefresh){
@@ -46,15 +46,15 @@ class BPArtistViewModel(
             }
         }
     }
-    
+
     fun getArtistByID(artistID: String): Flow<Artist> {
         return bpArtistRepository.getArtist(artistID)
     }
-    
+
     fun getAllSongsOfArtist(artist: Artist): Flow<List<Song>> {
         return flowOf(artist.songs)
     }
-    
+
     fun getAllAlbumsOfArtist(artist: Artist): Flow<List<Album>> {
         return flowOf(artist.albums)
     }


### PR DESCRIPTION
## Base PR:- #752, #755  
#### Rebased with the latest upstream/cmp branch, and this branch includes all commits from the bp-database branch and cherry picked a commit from album viewmodel branch

---

This PR fixes #710  migrates `BPArtistViewModel` from `androidApp` module to shared module

## Key Changes:- 
1. Moved `BPArtistViewModel` to shared/commonMain/viewmodel/ using kmp lifecycle dependencies.
2. Moved `AlbumsData` and `SongsData` to shared module while having platform specific impl in `androidMain` and `iosMain` resp.
4. Moved `BPArtistRepository` to shared module with its impl as well.
5. Registered the viewmodel inside `sharedViewModelModule`, repository inside `sharedRepositoryModule` and the `AlbumsData` and `SongsData` inside `platformModule` via platform specific providers.
6. Wired all the shared modules inside of `KoinModules.kt`