### PR TITLE
feat(brainzplayer): add Shuffle All to play entire library (closes #677)

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/BrainzPlayerScreen.kt
@@ -278,6 +278,9 @@ fun BrainzPlayerHomeScreen(
                     onPlayNext = { song ->
                         brainzPlayerViewModel.playNext(listOf(song))
                     },
+                    onShuffleAllClick = {
+                        brainzPlayerViewModel.shuffleAllSongs(songs)
+                    },
                 )
             }
         }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/SongsOverviewScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/SongsOverviewScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.koin.androidx.compose.koinViewModel
@@ -216,16 +217,13 @@ private fun ShuffleAllButton(
         Icon(
             imageVector = Icons.Rounded.Shuffle,
             contentDescription = null,
-            tint = Color.White
+            tint = ListenBrainzTheme.colorScheme.onLbSignature
         )
         Spacer(modifier = Modifier.width(8.dp))
         Text(
             text = "Shuffle All",
-            style = TextStyle(
-                color = Color.White,
-                fontSize = 16.sp,
-                fontFamily = FontFamily(Font(R.font.roboto_bold)),
-            )
+            fontWeight = FontWeight.Medium,
+            color = ListenBrainzTheme.colorScheme.onLbSignature
         )
     }
 }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/SongsOverviewScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/brainzplayer/overview/SongsOverviewScreen.kt
@@ -8,14 +8,23 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Shuffle
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -26,6 +35,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
@@ -52,6 +63,7 @@ fun SongsOverviewScreen(
     onAddToQueue: ((Song) -> Unit)?,
     onAddToExistingPlaylist: ((Song) -> Unit)? = null,
     onAddToNewPlaylist: ((Song) -> Unit)? = null,
+    onShuffleAllClick: (() -> Unit)? = null,
 ) {
     val songsStarting = remember { mutableStateOf<Map<Char, List<Song>>>(emptyMap()) }
 
@@ -92,6 +104,14 @@ fun SongsOverviewScreen(
                     .fillMaxSize()
                     .background(brush = ListenBrainzTheme.colorScheme.gradientBrush)
             ) {
+                if (onShuffleAllClick != null && songs.isNotEmpty()) {
+                    item {
+                        ShuffleAllButton(
+                            modifier = Modifier.padding(start = 10.dp, end = 10.dp, top = 10.dp),
+                            onClick = onShuffleAllClick
+                        )
+                    }
+                }
                 songsStarting.value.forEach { (startingLetter, songList) ->
                     if (songList.isNotEmpty()) {
                         item {
@@ -177,6 +197,39 @@ fun SongsOverviewScreen(
         }
     }
 }
+
+@Composable
+private fun ShuffleAllButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(ListenBrainzTheme.colorScheme.lbSignature)
+            .clickable { onClick() }
+            .padding(vertical = 12.dp),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = Icons.Rounded.Shuffle,
+            contentDescription = null,
+            tint = Color.White
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = "Shuffle All",
+            style = TextStyle(
+                color = Color.White,
+                fontSize = 16.sp,
+                fontFamily = FontFamily(Font(R.font.roboto_bold)),
+            )
+        )
+    }
+}
+
 fun shareAudio(context: Context, audioUri: Uri) {
     if (audioUri != Uri.EMPTY) {
         val shareIntent = Intent(Intent.ACTION_SEND).apply {

--- a/app/src/main/java/org/listenbrainz/android/viewmodel/BrainzPlayerViewModel.kt
+++ b/app/src/main/java/org/listenbrainz/android/viewmodel/BrainzPlayerViewModel.kt
@@ -211,6 +211,16 @@ class BrainzPlayerViewModel(
         transportControls?.setShuffleMode(if (isShuffled.value) SHUFFLE_MODE_NONE else SHUFFLE_MODE_ALL)
     }
 
+    /** Queue the entire [songs] library, force shuffle on and start playback from a random song. */
+    fun shuffleAllSongs(songs: List<Song>) {
+        if (songs.isEmpty()) return
+        val startIndex = songs.indices.random()
+        val startSong = songs[startIndex]
+        changePlayable(songs, PlayableType.ALL_SONGS, startSong.mediaID, startIndex)
+        if (!isShuffled.value) shuffle()
+        playOrToggleSong(startSong, toggle = true)
+    }
+
     fun repeatMode() {
         when (repeatMode.value) {
             RepeatMode.REPEAT_MODE_OFF -> brainzPlayerServiceConnection.transportControls?.setRepeatMode(


### PR DESCRIPTION
## What
Adds a "Shuffle All" button to the top of the Songs list. Tapping it queues the entire local library, force-enables shuffle mode, and starts playback from a random track — one-tap access to the whole library without picking a song or building a playlist first.

Closes #677.

## Notes
- Reuses the existing `changePlayable(ALL_SONGS, …)` + `shuffle()` plumbing; the new `BrainzPlayerViewModel.shuffleAllSongs()` only orchestrates them and guards against toggling shuffle *off* if it's already on.
- I went with an in-list button rather than the FAB the issue floats, since a FAB collides with the mini-player/backdrop sheet. Happy to switch to a FAB if you'd prefer.

## Testing
- `:app:compileGithubDebugKotlin` passes with no new warnings.
