### PR TITLE
Migrated FeedViewmodel to shared module

### DIFF
--- a/app/src/androidTest/java/org/listenbrainz/android/UserPagesTest.kt
+++ b/app/src/androidTest/java/org/listenbrainz/android/UserPagesTest.kt
@@ -5,7 +5,6 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -21,7 +20,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.listenbrainz.android.ui.screens.profile.BaseProfileScreen
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
-import org.listenbrainz.android.viewmodel.FeedViewModel
+import org.listenbrainz.shared.viewmodel.FeedViewModel
 import org.listenbrainz.shared.viewmodel.ListensViewModel
 import org.listenbrainz.shared.viewmodel.SocialViewModel
 import org.listenbrainz.android.viewmodel.UserViewModel

--- a/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
+++ b/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
@@ -31,8 +31,6 @@ import org.koin.dsl.module
 import org.listenbrainz.android.BuildConfig
 import org.listenbrainz.android.repository.appupdates.AppUpdatesRepository
 import org.listenbrainz.android.repository.appupdates.AppUpdatesRepositoryImpl
-import org.listenbrainz.android.repository.feed.FeedRepository
-import org.listenbrainz.android.repository.feed.FeedRepositoryImpl
 import org.listenbrainz.android.repository.listenservicemanager.ListenServiceManager
 import org.listenbrainz.android.repository.listenservicemanager.ListenServiceManagerImpl
 import org.listenbrainz.android.repository.user.UserRepository
@@ -42,8 +40,6 @@ import org.listenbrainz.android.repository.yim.YimRepositoryImpl
 import org.listenbrainz.android.repository.yim23.Yim23Repository
 import org.listenbrainz.android.repository.yim23.Yim23RepositoryImpl
 import org.listenbrainz.android.service.BrainzPlayerServiceConnection
-import org.listenbrainz.android.service.FeedServiceKtor
-import org.listenbrainz.android.service.FeedServiceKtorImpl
 import org.listenbrainz.android.service.GithubAppUpdatesService
 import org.listenbrainz.android.service.GithubUpdatesDownloadService
 import org.listenbrainz.android.service.Yim23Service
@@ -61,7 +57,6 @@ import org.listenbrainz.android.viewmodel.AboutViewModel
 import org.listenbrainz.android.viewmodel.AppUpdatesViewModel
 import org.listenbrainz.android.viewmodel.BrainzPlayerViewModel
 import org.listenbrainz.android.viewmodel.DashBoardViewModel
-import org.listenbrainz.android.viewmodel.FeedViewModel
 import org.listenbrainz.android.viewmodel.SearchViewModel
 import org.listenbrainz.android.viewmodel.UserViewModel
 import org.listenbrainz.android.viewmodel.Yim23ViewModel
@@ -176,8 +171,6 @@ val networkModule = module {
             .createYim23Service()
     }
 
-    single<FeedServiceKtor> { FeedServiceKtorImpl(get()) }
-
     single<GithubAppUpdatesService> {
         val httpClient = HttpClient(OkHttp) {
             expectSuccess = true
@@ -251,7 +244,6 @@ val appModule = module {
 val repositoryModule = module {
 
     // API Repositories
-    single<FeedRepository> { FeedRepositoryImpl(get()) }
     single<UserRepository> { UserRepositoryImpl(get(), get()) }
     single<YimRepository> { YimRepositoryImpl(get()) }
     single<Yim23Repository> { Yim23RepositoryImpl(get()) }
@@ -287,7 +279,6 @@ val playerModule = module {
 val viewModelModule = module {
     viewModel { DashBoardViewModel(get(), get(), get(), get(named(IO_DISPATCHER)),get()) }
     viewModel { AppUpdatesViewModel(get(), get(), get()) }
-    viewModel { FeedViewModel(get(), get(), get(), get(), get(), get(named(IO_DISPATCHER)), get(named(DEFAULT_DISPATCHER))) }
     viewModel { UserViewModel(get(), get(), get(), get(), get(), get(named(IO_DISPATCHER))) }
     viewModel { YimViewModel(get(), get(), get(named(IO_DISPATCHER)), get(named(DEFAULT_DISPATCHER))) }
     viewModel { Yim23ViewModel(get(), get(), get(), get(named(IO_DISPATCHER)), get(named(DEFAULT_DISPATCHER))) }

--- a/app/src/main/java/org/listenbrainz/android/model/feed/FeedEventContent.kt
+++ b/app/src/main/java/org/listenbrainz/android/model/feed/FeedEventContent.kt
@@ -1,0 +1,151 @@
+package org.listenbrainz.android.model.feed
+
+import androidx.compose.runtime.Composable
+import org.listenbrainz.android.ui.screens.feed.events.FollowFeedLayout
+import org.listenbrainz.android.ui.screens.feed.events.ListenFeedLayout
+import org.listenbrainz.android.ui.screens.feed.events.ListenLikeFeedLayout
+import org.listenbrainz.android.ui.screens.feed.events.NotificationFeedLayout
+import org.listenbrainz.android.ui.screens.feed.events.PersonalRecommendationFeedLayout
+import org.listenbrainz.android.ui.screens.feed.events.PinFeedLayout
+import org.listenbrainz.android.ui.screens.feed.events.RecordingRecommendationFeedLayout
+import org.listenbrainz.android.ui.screens.feed.events.ReviewFeedLayout
+import org.listenbrainz.android.ui.screens.feed.events.UnknownFeedLayout
+import org.listenbrainz.shared.model.feed.FeedEvent
+import org.listenbrainz.shared.model.feed.FeedEventType
+import org.listenbrainz.shared.model.feed.FeedEventType.FOLLOW
+import org.listenbrainz.shared.model.feed.FeedEventType.LIKE
+import org.listenbrainz.shared.model.feed.FeedEventType.LISTEN
+import org.listenbrainz.shared.model.feed.FeedEventType.NOTIFICATION
+import org.listenbrainz.shared.model.feed.FeedEventType.PERSONAL_RECORDING_RECOMMENDATION
+import org.listenbrainz.shared.model.feed.FeedEventType.RECORDING_PIN
+import org.listenbrainz.shared.model.feed.FeedEventType.RECORDING_RECOMMENDATION
+import org.listenbrainz.shared.model.feed.FeedEventType.REVIEW
+import org.listenbrainz.shared.model.feed.FeedEventType.UNKNOWN
+
+
+/**
+ * @param parentUser This is used to display pronouns of the user in a feed event. If the event is of
+ * the logged in users, "You" is displayed, else normal name is displayed.*/
+@Composable
+fun FeedEventContent(
+    type: FeedEventType,
+    event: FeedEvent,
+    parentUser: String,
+    isHidden: Boolean,
+    onDeleteOrHide: () -> Unit,
+    onDropdownClick: () -> Unit,
+    dropDownState: Int?,
+    index: Int,
+    onOpenInMusicBrainz: () -> Unit,
+    onRecommend: () -> Unit,
+    onPersonallyRecommend: () -> Unit,
+    onReview: () -> Unit,
+    onPin: () -> Unit,
+    onClick: () -> Unit,
+    goToUserPage: (String) -> Unit,
+    goToArtistPage: (String) -> Unit,
+){
+    when (type){
+        RECORDING_RECOMMENDATION -> RecordingRecommendationFeedLayout(
+            event = event,
+            parentUser = parentUser,
+            isHidden = isHidden,
+            onDeleteOrHide = onDeleteOrHide,
+            onDropdownClick = onDropdownClick,
+            onClick = onClick,
+            dropdownState = dropDownState,
+            index = index,
+            onOpenInMusicBrainz = onOpenInMusicBrainz,
+            onPin = onPin,
+            onReview = onReview,
+            onPersonallyRecommend = onPersonallyRecommend,
+            onRecommend = onRecommend,
+            goToUserPage = goToUserPage,
+            goToArtistPage = goToArtistPage
+        )
+        PERSONAL_RECORDING_RECOMMENDATION -> PersonalRecommendationFeedLayout(
+            event = event,
+            parentUser = parentUser,
+            onDeleteOrHide = onDeleteOrHide,
+            onDropdownClick = onDropdownClick,
+            onClick = onClick,
+            dropdownState = dropDownState,
+            index = index,
+            onOpenInMusicBrainz = onOpenInMusicBrainz,
+            onPin = onPin,
+            onReview = onReview,
+            onPersonallyRecommend = onPersonallyRecommend,
+            onRecommend = onRecommend,
+            goToUserPage = goToUserPage,
+            goToArtistPage = goToArtistPage
+        )
+        RECORDING_PIN -> PinFeedLayout(
+            event = event,
+            isHidden = isHidden,
+            parentUser = parentUser,
+            onDeleteOrHide = onDeleteOrHide,
+            onDropdownClick = onDropdownClick,
+            onClick = onClick,
+            dropdownState = dropDownState,
+            index = index,
+            onOpenInMusicBrainz = onOpenInMusicBrainz,
+            onPin = onPin,
+            onReview = onReview,
+            onPersonallyRecommend = onPersonallyRecommend,
+            onRecommend = onRecommend,
+            goToUserPage = goToUserPage,
+            goToArtistPage = goToArtistPage
+        )
+        LIKE -> ListenLikeFeedLayout(
+            event = event,
+            parentUser = parentUser,
+            onDeleteOrHide = onDeleteOrHide,
+            onDropdownClick = onDropdownClick,
+            onClick = onClick,
+            dropdownState = dropDownState,
+            index = index,
+            onOpenInMusicBrainz = onOpenInMusicBrainz,
+            onPin = onPin,
+            onReview = onReview,
+            onPersonallyRecommend = onPersonallyRecommend,
+            onRecommend = onRecommend,
+            goToUserPage = goToUserPage,
+            goToArtistPage = goToArtistPage
+        )
+        LISTEN -> ListenFeedLayout(
+            event = event,
+            parentUser = parentUser,
+            onDeleteOrHide = onDeleteOrHide,
+            onDropdownClick = onDropdownClick,
+            onClick = onClick,
+            dropdownState = dropDownState,
+            index = index,
+            onOpenInMusicBrainz = onOpenInMusicBrainz,
+            onPin = onPin,
+            onReview = onReview,
+            onPersonallyRecommend = onPersonallyRecommend,
+            onRecommend = onRecommend,
+            goToUserPage = goToUserPage,
+            goToArtistPage = goToArtistPage
+        )
+        FOLLOW -> FollowFeedLayout(event = event, parentUser = parentUser, goToUserPage = goToUserPage)
+        NOTIFICATION -> NotificationFeedLayout(event = event, onDeleteOrHide = onDeleteOrHide, goToUserPage = goToUserPage)
+        REVIEW -> ReviewFeedLayout(
+            event = event,
+            parentUser = parentUser,
+            onDeleteOrHide = onDeleteOrHide,
+            onDropdownClick = onDropdownClick,
+            onClick = onClick,
+            dropdownState = dropDownState,
+            index = index,
+            onOpenInMusicBrainz = onOpenInMusicBrainz,
+            onPin = onPin,
+            onReview = onReview,
+            onPersonallyRecommend = onPersonallyRecommend,
+            onRecommend = onRecommend,
+            goToUserPage = goToUserPage,
+            goToArtistPage = goToArtistPage
+        )
+        UNKNOWN -> UnknownFeedLayout(event = event)
+    }
+}

--- a/app/src/main/java/org/listenbrainz/android/ui/components/ListenCardSmall.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/components/ListenCardSmall.kt
@@ -42,7 +42,7 @@ import org.listenbrainz.shared.model.AdditionalInfo
 import org.listenbrainz.shared.model.Metadata
 import org.listenbrainz.shared.model.ResponseError
 import org.listenbrainz.shared.model.TrackMetadata
-import org.listenbrainz.android.model.feed.FeedEventType
+import org.listenbrainz.shared.model.feed.FeedEventType
 import org.listenbrainz.shared.model.feed.FeedListenArtist
 import org.listenbrainz.android.ui.screens.feed.SocialDropdownDefault
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/feed/BaseFeedLayout.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/feed/BaseFeedLayout.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Constraints
@@ -45,11 +46,12 @@ import androidx.compose.ui.unit.sp
 import org.listenbrainz.android.R
 import org.listenbrainz.shared.model.Metadata
 import org.listenbrainz.shared.model.feed.FeedEvent
-import org.listenbrainz.android.model.feed.FeedEventType
-import org.listenbrainz.android.model.feed.FeedEventType.Companion.getTimeStringForFeed
-import org.listenbrainz.android.model.feed.FeedEventType.Companion.isActionDelete
+import org.listenbrainz.shared.model.feed.FeedEventType
+import org.listenbrainz.shared.model.feed.FeedEventType.Companion.getTimeStringForFeed
+import org.listenbrainz.shared.model.feed.FeedEventType.Companion.isActionDelete
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.util.PreviewSurface
+import org.listenbrainz.android.util.toDrawableRes
 
 @Composable
 fun BaseFeedLayout(
@@ -120,7 +122,15 @@ fun BaseFeedLayout(
                     eventType.Tagline(
                         event = event,
                         parentUser = parentUser,
-                        goToUserPage = goToUserPage
+                        goToUserPage = goToUserPage,
+                        linkStyle = SpanStyle(
+                            color = ListenBrainzTheme.colorScheme.lbSignature,
+                            fontWeight = FontWeight.Bold
+                        ),
+                        normalStyle = SpanStyle(
+                            color = ListenBrainzTheme.colorScheme.text,
+                            fontWeight = FontWeight.Light
+                        )
                     )
                 } else {
                     Text(
@@ -258,7 +268,7 @@ private fun DynamicHorizontalLine(Content: @Composable () -> Unit) {
 private fun EventIcon(eventType: FeedEventType) {
     Image(
         modifier = Modifier.size(19.dp),
-        painter = painterResource(id = eventType.icon),
+        painter = painterResource(id = eventType.icon.toDrawableRes()),
         contentDescription = eventType.name
     )
 }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/feed/FeedScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/feed/FeedScreen.kt
@@ -97,10 +97,8 @@ import org.listenbrainz.android.ui.navigation.TopBarActions
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.util.PreviewSurface
 import org.listenbrainz.android.util.Utils
-import org.listenbrainz.android.viewmodel.FeedViewModel
-import org.listenbrainz.shared.viewmodel.SocialViewModel
 import org.listenbrainz.shared.viewmodel.FeedViewModel
-import org.listenbrainz.android.viewmodel.SocialViewModel
+import org.listenbrainz.shared.viewmodel.SocialViewModel
 import org.listenbrainz.shared.ui.screens.feed.FeedUiEventData
 import org.listenbrainz.shared.ui.screens.feed.FeedUiEventItem
 import org.listenbrainz.shared.ui.screens.feed.FeedUiState

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/feed/FeedScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/feed/FeedScreen.kt
@@ -75,11 +75,12 @@ import com.valentinilk.shimmer.rememberShimmer
 import com.valentinilk.shimmer.shimmer
 import kotlinx.coroutines.flow.flow
 import org.koin.androidx.compose.koinViewModel
+import org.listenbrainz.android.model.feed.FeedEventContent
 import org.listenbrainz.shared.model.AppNavigationItem
 import org.listenbrainz.shared.model.Metadata
-import org.listenbrainz.android.model.feed.FeedCallbacks
+import org.listenbrainz.shared.model.feed.FeedCallbacks
 import org.listenbrainz.shared.model.feed.FeedEvent
-import org.listenbrainz.android.model.feed.FeedEventType
+import org.listenbrainz.shared.model.feed.FeedEventType
 import org.listenbrainz.shared.model.feed.FeedListenArtist
 import org.listenbrainz.shared.model.feed.ReviewEntityType
 import org.listenbrainz.android.ui.components.ErrorBar
@@ -98,6 +99,11 @@ import org.listenbrainz.android.util.PreviewSurface
 import org.listenbrainz.android.util.Utils
 import org.listenbrainz.android.viewmodel.FeedViewModel
 import org.listenbrainz.shared.viewmodel.SocialViewModel
+import org.listenbrainz.shared.viewmodel.FeedViewModel
+import org.listenbrainz.android.viewmodel.SocialViewModel
+import org.listenbrainz.shared.ui.screens.feed.FeedUiEventData
+import org.listenbrainz.shared.ui.screens.feed.FeedUiEventItem
+import org.listenbrainz.shared.ui.screens.feed.FeedUiState
 
 @Composable
 fun FeedScreen(
@@ -520,7 +526,8 @@ private fun MyFeed(
                         enter = expandVertically(),
                         exit = shrinkVertically()
                     ) {
-                        eventType.Content(
+                        FeedEventContent(
+                            type = eventType,
                             event = event,
                             parentUser = parentUser,
                             isHidden = uiState.isHiddenMap[event.id] == true,
@@ -553,7 +560,7 @@ private fun MyFeed(
                                 uriHandler.openUri(
                                     "https://musicbrainz.org/recording/${
                                         event.metadata.trackMetadata?.mbidMapping?.recordingMbid
-                                            ?: return@Content
+                                            ?: return@FeedEventContent
                                     }"
                                 )
                                 dropdownItemIndex.value = null

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/FollowFeedLayout.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/FollowFeedLayout.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import org.listenbrainz.shared.model.Metadata
 import org.listenbrainz.shared.model.feed.FeedEvent
-import org.listenbrainz.android.model.feed.FeedEventType
+import org.listenbrainz.shared.model.feed.FeedEventType
 import org.listenbrainz.android.ui.screens.feed.BaseFeedLayout
 import org.listenbrainz.android.util.PreviewSurface
 

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/ListenFeedLayout.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/ListenFeedLayout.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.tooling.preview.Preview
 import org.listenbrainz.shared.model.Metadata
 import org.listenbrainz.shared.model.feed.FeedEvent
-import org.listenbrainz.android.model.feed.FeedEventType
+import org.listenbrainz.shared.model.feed.FeedEventType
 import org.listenbrainz.shared.model.feed.FeedListenArtist
 import org.listenbrainz.android.ui.components.ListenCardSmall
 import org.listenbrainz.android.ui.screens.feed.BaseFeedLayout

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/ListenLikeFeedLayout.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/ListenLikeFeedLayout.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.tooling.preview.Preview
 import org.listenbrainz.shared.model.Metadata
 import org.listenbrainz.shared.model.feed.FeedEvent
-import org.listenbrainz.android.model.feed.FeedEventType
+import org.listenbrainz.shared.model.feed.FeedEventType
 import org.listenbrainz.shared.model.feed.FeedListenArtist
 import org.listenbrainz.android.ui.components.ListenCardSmall
 import org.listenbrainz.android.ui.screens.feed.BaseFeedLayout

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/NotificationFeedLayout.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/NotificationFeedLayout.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import org.listenbrainz.shared.model.Metadata
 import org.listenbrainz.shared.model.feed.FeedEvent
-import org.listenbrainz.android.model.feed.FeedEventType
+import org.listenbrainz.shared.model.feed.FeedEventType
 import org.listenbrainz.android.ui.screens.feed.BaseFeedLayout
 import org.listenbrainz.android.util.PreviewSurface
 

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/PersonalRecommendationFeedLayout.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/PersonalRecommendationFeedLayout.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.listenbrainz.shared.model.Metadata
 import org.listenbrainz.shared.model.feed.FeedEvent
-import org.listenbrainz.android.model.feed.FeedEventType
+import org.listenbrainz.shared.model.feed.FeedEventType
 import org.listenbrainz.shared.model.feed.FeedListenArtist
 import org.listenbrainz.android.ui.components.ListenCardSmall
 import org.listenbrainz.android.ui.components.dialogs.UserTag
@@ -25,7 +25,6 @@ import org.listenbrainz.android.ui.screens.feed.BaseFeedLayout
 import org.listenbrainz.android.ui.screens.feed.SocialDropdown
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.util.PreviewSurface
-import org.listenbrainz.android.util.Utils
 
 @Composable
 fun PersonalRecommendationFeedLayout(

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/PinFeedLayout.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/PinFeedLayout.kt
@@ -8,14 +8,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.tooling.preview.Preview
 import org.listenbrainz.shared.model.Metadata
 import org.listenbrainz.shared.model.feed.FeedEvent
-import org.listenbrainz.android.model.feed.FeedEventType
+import org.listenbrainz.shared.model.feed.FeedEventType
 import org.listenbrainz.shared.model.feed.FeedListenArtist
 import org.listenbrainz.android.ui.components.ListenCardSmall
 import org.listenbrainz.android.ui.screens.feed.BaseFeedLayout
 import org.listenbrainz.android.ui.screens.feed.SocialDropdown
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.util.PreviewSurface
-import org.listenbrainz.android.util.Utils
 
 @Composable
 fun PinFeedLayout(

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/RecordingRecommendationFeedLayout.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/RecordingRecommendationFeedLayout.kt
@@ -6,13 +6,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.tooling.preview.Preview
 import org.listenbrainz.shared.model.Metadata
 import org.listenbrainz.shared.model.feed.FeedEvent
-import org.listenbrainz.android.model.feed.FeedEventType
+import org.listenbrainz.shared.model.feed.FeedEventType
 import org.listenbrainz.shared.model.feed.FeedListenArtist
 import org.listenbrainz.android.ui.components.ListenCardSmall
 import org.listenbrainz.android.ui.screens.feed.BaseFeedLayout
 import org.listenbrainz.android.ui.screens.feed.SocialDropdown
 import org.listenbrainz.android.util.PreviewSurface
-import org.listenbrainz.android.util.Utils
 
 @Composable
 fun RecordingRecommendationFeedLayout(

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/ReviewFeedLayout.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/ReviewFeedLayout.kt
@@ -27,14 +27,13 @@ import org.listenbrainz.android.ui.components.ratingbar.RatingBarStyle
 import org.listenbrainz.android.R
 import org.listenbrainz.shared.model.Metadata
 import org.listenbrainz.shared.model.feed.FeedEvent
-import org.listenbrainz.android.model.feed.FeedEventType
+import org.listenbrainz.shared.model.feed.FeedEventType
 import org.listenbrainz.shared.model.feed.FeedListenArtist
 import org.listenbrainz.android.ui.components.ListenCardSmall
 import org.listenbrainz.android.ui.screens.feed.BaseFeedLayout
 import org.listenbrainz.android.ui.screens.feed.SocialDropdown
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.util.PreviewSurface
-import org.listenbrainz.android.util.Utils
 
 @Composable
 fun ReviewFeedLayout(

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/UnknownFeedLayout.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/feed/events/UnknownFeedLayout.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import org.listenbrainz.shared.model.Metadata
 import org.listenbrainz.shared.model.feed.FeedEvent
-import org.listenbrainz.android.model.feed.FeedEventType
+import org.listenbrainz.shared.model.feed.FeedEventType
 import org.listenbrainz.android.ui.screens.feed.BaseFeedLayout
 import org.listenbrainz.android.util.PreviewSurface
 

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/BaseProfileScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/BaseProfileScreen.kt
@@ -48,7 +48,7 @@ import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.ui.theme.lb_orange
 import org.listenbrainz.android.ui.theme.lb_purple
 import org.listenbrainz.android.ui.theme.new_app_bg_light
-import org.listenbrainz.android.viewmodel.FeedViewModel
+import org.listenbrainz.shared.viewmodel.FeedViewModel
 import org.listenbrainz.shared.viewmodel.ListensViewModel
 import org.listenbrainz.shared.viewmodel.PlaylistDataViewModel
 import org.listenbrainz.shared.viewmodel.SocialViewModel

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/taste/TasteScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/taste/TasteScreen.kt
@@ -66,7 +66,7 @@ import org.listenbrainz.android.ui.screens.profile.listens.headerTextVerticalPad
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.util.PreviewSurface
 import org.listenbrainz.shared.util.Utils.getCoverArtUrl
-import org.listenbrainz.android.viewmodel.FeedViewModel
+import org.listenbrainz.shared.viewmodel.FeedViewModel
 import org.listenbrainz.shared.viewmodel.SocialViewModel
 import org.listenbrainz.android.viewmodel.UserViewModel
 

--- a/app/src/main/java/org/listenbrainz/android/util/AppDrawableProvider.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/AppDrawableProvider.kt
@@ -1,0 +1,23 @@
+package org.listenbrainz.android.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import org.listenbrainz.android.R
+import org.listenbrainz.shared.util.DrawableResource
+
+@Composable
+fun DrawableResource.toDrawableRes(): Int{
+    return remember(this){
+        when(this){
+            DrawableResource.FEED_SEND -> R.drawable.feed_send
+            DrawableResource.FEED_PIN -> R.drawable.feed_pin
+            DrawableResource.FEED_LOVE -> R.drawable.feed_love
+            DrawableResource.FEED_LISTEN -> R.drawable.feed_listen
+            DrawableResource.FEED_FOLLOW -> R.drawable.feed_follow
+            DrawableResource.FEED_NOTIFICATION -> R.drawable.feed_notification
+            DrawableResource.FEED_REVIEW -> R.drawable.feed_review
+            DrawableResource.FEED_UNKNOWN -> R.drawable.feed_unknown
+        }
+    }
+}
+

--- a/app/src/main/java/org/listenbrainz/android/util/Utils.kt
+++ b/app/src/main/java/org/listenbrainz/android/util/Utils.kt
@@ -118,17 +118,7 @@ object Utils {
             Toast.makeText(context, R.string.toast_feedback_fail, Toast.LENGTH_LONG).show()
         }
     }
-    
-    fun getArticle(str: String): String {
-        return when (str.first()){
-            'a' -> "an"
-            'e' -> "an"
-            'i' -> "an"
-            'o' -> "an"
-            'u' -> "an"
-            else -> "a"
-        }
-    }
+
 
     @Composable
     fun LaunchedEffectUnit(block: suspend CoroutineScope.() -> Unit) = LaunchedEffect(Unit, block)

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -173,6 +173,7 @@ kotlin {
                 implementation(libs.kmpalette.androidx.palette)
                 // Paging
                 implementation(libs.androidx.paging.common)
+                implementation(libs.androidx.paging.common)
             }
         }
 

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -173,7 +173,6 @@ kotlin {
                 implementation(libs.kmpalette.androidx.palette)
                 // Paging
                 implementation(libs.androidx.paging.common)
-                implementation(libs.androidx.paging.common)
             }
         }
 

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedNetworkServiceModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedNetworkServiceModule.kt
@@ -52,6 +52,8 @@ import org.listenbrainz.shared.util.Constants.LISTENBRAINZ_API_BASE_URL
 import org.listenbrainz.shared.util.Constants.MB_BASE_URL
 import kotlin.time.Duration.Companion.milliseconds
 import org.listenbrainz.shared.service.BlogService
+import org.listenbrainz.shared.service.FeedServiceKtor
+import org.listenbrainz.shared.service.FeedServiceKtorImpl
 import org.listenbrainz.shared.service.createBlogService
 import org.listenbrainz.shared.util.Log
 
@@ -232,6 +234,14 @@ val sharedNetworkServiceModule = module {
             .createPlaylistService()
     }
 
+    single<FeedServiceKtor> {
+        val baseClient = get<HttpClient>(named(SHARED_HTTP_CLIENT)).config {
+            defaultRequest {
+                url(LISTENBRAINZ_API_BASE_URL)
+            }
+        }
+        FeedServiceKtorImpl(baseClient)
+    }
 }
 
 val sharedDispatcherModule = module {

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedRepositoryModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedRepositoryModule.kt
@@ -12,6 +12,8 @@ import org.listenbrainz.shared.provideListensRepositoryImpl
 import org.listenbrainz.shared.repository.AppPreferences
 import org.listenbrainz.shared.repository.artist.ArtistRepository
 import org.listenbrainz.shared.repository.artist.ArtistRepositoryImpl
+import org.listenbrainz.shared.repository.feed.FeedRepository
+import org.listenbrainz.shared.repository.feed.FeedRepositoryImpl
 import org.listenbrainz.shared.repository.listens.ListensRepository
 import org.listenbrainz.shared.repository.socket.SocketRepository
 import org.listenbrainz.shared.repository.socket.SocketRepositoryImpl
@@ -52,4 +54,5 @@ val sharedRepositoryModule = module {
     single<BPAlbumRepository> { BPAlbumRepositoryImpl(get(),get(),get()) }
     single<BPArtistRepository> { BPArtistRepositoryImpl(get(),get(),get()) }
     single<PlaylistDataRepository> { PlaylistDataRepositoryImpl(get(),get(),get(),get(named(IO_DISPATCHER))) }
+    single<FeedRepository> { FeedRepositoryImpl(get()) }
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
@@ -10,6 +10,7 @@ import org.listenbrainz.shared.viewmodel.FeaturesViewModel
 import org.listenbrainz.shared.viewmodel.AlbumViewModel
 import org.listenbrainz.shared.viewmodel.ArtistViewModel
 import org.listenbrainz.shared.viewmodel.BPArtistViewModel
+import org.listenbrainz.shared.viewmodel.FeedViewModel
 import org.listenbrainz.shared.viewmodel.LoginViewModel
 import org.listenbrainz.shared.viewmodel.ListeningNowViewModel
 import org.listenbrainz.shared.viewmodel.ListensViewModel
@@ -36,4 +37,5 @@ val sharedViewModelModule = module {
     viewModel { ListeningNowViewModel(get(),get(),get(),get(named(IO_DISPATCHER))) }
     viewModel { PlaylistDataViewModel(get(),get(),get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER)),get<StringProvider>()) }
     viewModel { SocialViewModel(get(),get(),get(),get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER)),get<StringProvider>()) }
+    viewModel { FeedViewModel(get(),get(),get(),get(),get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER))) }
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/model/feed/FeedCallbacks.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/model/feed/FeedCallbacks.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android.model.feed
+package org.listenbrainz.shared.model.feed
 
 import androidx.compose.runtime.Immutable
 import org.listenbrainz.shared.model.feed.FeedEvent

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/model/feed/FeedData.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/model/feed/FeedData.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android.model.feed
+package org.listenbrainz.shared.model.feed
 
 import androidx.compose.runtime.Immutable
 import kotlinx.serialization.Serializable

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/model/feed/FeedEventDeletionData.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/model/feed/FeedEventDeletionData.kt
@@ -1,10 +1,10 @@
-package org.listenbrainz.android.model.feed
+package org.listenbrainz.shared.model.feed
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class FeedEventVisibilityData (
+data class FeedEventDeletionData (
     @SerialName("event_type") val eventType : String? = null,
-    @SerialName("event_id") val eventId   : String? = null
+    @SerialName("id") val eventId   : String? = null
 )

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/model/feed/FeedEventType.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/model/feed/FeedEventType.kt
@@ -1,6 +1,5 @@
-package org.listenbrainz.android.model.feed
+package org.listenbrainz.shared.model.feed
 
-import androidx.annotation.DrawableRes
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
@@ -13,21 +12,13 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
-import org.listenbrainz.android.R
-import org.listenbrainz.android.ui.screens.feed.events.FollowFeedLayout
-import org.listenbrainz.android.ui.screens.feed.events.ListenFeedLayout
-import org.listenbrainz.android.ui.screens.feed.events.ListenLikeFeedLayout
-import org.listenbrainz.android.ui.screens.feed.events.NotificationFeedLayout
-import org.listenbrainz.android.ui.screens.feed.events.PersonalRecommendationFeedLayout
-import org.listenbrainz.android.ui.screens.feed.events.PinFeedLayout
-import org.listenbrainz.android.ui.screens.feed.events.RecordingRecommendationFeedLayout
-import org.listenbrainz.android.ui.screens.feed.events.ReviewFeedLayout
-import org.listenbrainz.android.ui.screens.feed.events.UnknownFeedLayout
-import org.listenbrainz.android.ui.theme.ListenBrainzTheme
+import org.listenbrainz.shared.util.DrawableResource
 import org.listenbrainz.shared.util.Log
 import org.listenbrainz.shared.util.TypeConverter
-import org.listenbrainz.android.util.Utils.getArticle
-import org.listenbrainz.shared.model.feed.FeedEvent
+import org.listenbrainz.shared.util.Utils.getArticle
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.microseconds
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * @param icon Feed icon for the event, **must** be of width 19 dp.
@@ -36,7 +27,7 @@ import org.listenbrainz.shared.model.feed.FeedEvent
 @Immutable
 enum class FeedEventType (
     val type: String,
-    @DrawableRes val icon: Int,
+    val icon: DrawableResource,
     val isPlayable: Boolean = true,
     val isDeletable: Boolean = false,
     val isHideable: Boolean = false,
@@ -44,200 +35,67 @@ enum class FeedEventType (
     
     RECORDING_RECOMMENDATION(
         type = "recording_recommendation",
-        icon = R.drawable.feed_send,
+        icon = DrawableResource.FEED_SEND,
         isDeletable = true,
         isHideable = true,
     ),
     
     PERSONAL_RECORDING_RECOMMENDATION(
         type = "personal_recording_recommendation",
-        icon = R.drawable.feed_send,
+        icon = DrawableResource.FEED_SEND,
     ),
     
     RECORDING_PIN(
         type = "recording_pin",
-        icon = R.drawable.feed_pin,
+        icon = DrawableResource.FEED_PIN,
         isDeletable = true,
         isHideable = true,
     ),
     
     LIKE(
         type = "like",
-        icon = R.drawable.feed_love,
+        icon = DrawableResource.FEED_LOVE,
     ),
     
     LISTEN(
         type = "listen",
-        icon = R.drawable.feed_listen,
+        icon = DrawableResource.FEED_LISTEN,
     ),
     
     FOLLOW(
         type = "follow",
-        icon = R.drawable.feed_follow,
+        icon = DrawableResource.FEED_FOLLOW,
         isPlayable = false,
     ),
     
     NOTIFICATION(
         type = "notification",
-        icon = R.drawable.feed_notification,
+        icon = DrawableResource.FEED_NOTIFICATION,
         isPlayable = false,
         isDeletable = true,
     ),
     
     REVIEW (
         type = "critiquebrainz_review",
-        icon = R.drawable.feed_review,
+        icon = DrawableResource.FEED_REVIEW,
     ),
     
     /** In case a new event is added in future that had not been published to the app. */
     UNKNOWN(
         type = "update_app",
-        icon = R.drawable.feed_unknown,
+        icon = DrawableResource.FEED_UNKNOWN,
         isPlayable = false,
     );
-    
-    /**
-     * @param parentUser This is used to display pronouns of the user in a feed event. If the event is of
-     * the logged in users, "You" is displayed, else normal name is displayed.*/
-    @Composable
-    fun Content(
-        event: FeedEvent,
-        parentUser: String,
-        isHidden: Boolean,
-        onDeleteOrHide: () -> Unit,
-        onDropdownClick: () -> Unit,
-        dropDownState: Int?,
-        index: Int,
-        onOpenInMusicBrainz: () -> Unit,
-        onRecommend: () -> Unit,
-        onPersonallyRecommend: () -> Unit,
-        onReview: () -> Unit,
-        onPin: () -> Unit,
-        onClick: () -> Unit,
-        goToUserPage: (String) -> Unit,
-        goToArtistPage: (String) -> Unit,
-    ){
-        when (this){
-            RECORDING_RECOMMENDATION -> RecordingRecommendationFeedLayout(
-                event = event,
-                parentUser = parentUser,
-                isHidden = isHidden,
-                onDeleteOrHide = onDeleteOrHide,
-                onDropdownClick = onDropdownClick,
-                onClick = onClick,
-                dropdownState = dropDownState,
-                index = index,
-                onOpenInMusicBrainz = onOpenInMusicBrainz,
-                onPin = onPin,
-                onReview = onReview,
-                onPersonallyRecommend = onPersonallyRecommend,
-                onRecommend = onRecommend,
-                goToUserPage = goToUserPage,
-                goToArtistPage = goToArtistPage
-            )
-            PERSONAL_RECORDING_RECOMMENDATION -> PersonalRecommendationFeedLayout(
-                event = event,
-                parentUser = parentUser,
-                onDeleteOrHide = onDeleteOrHide,
-                onDropdownClick = onDropdownClick,
-                onClick = onClick,
-                dropdownState = dropDownState,
-                index = index,
-                onOpenInMusicBrainz = onOpenInMusicBrainz,
-                onPin = onPin,
-                onReview = onReview,
-                onPersonallyRecommend = onPersonallyRecommend,
-                onRecommend = onRecommend,
-                goToUserPage = goToUserPage,
-                goToArtistPage = goToArtistPage
-            )
-            RECORDING_PIN -> PinFeedLayout(
-                event = event,
-                isHidden = isHidden,
-                parentUser = parentUser,
-                onDeleteOrHide = onDeleteOrHide,
-                onDropdownClick = onDropdownClick,
-                onClick = onClick,
-                dropdownState = dropDownState,
-                index = index,
-                onOpenInMusicBrainz = onOpenInMusicBrainz,
-                onPin = onPin,
-                onReview = onReview,
-                onPersonallyRecommend = onPersonallyRecommend,
-                onRecommend = onRecommend,
-                goToUserPage = goToUserPage,
-                goToArtistPage = goToArtistPage
-            )
-            LIKE -> ListenLikeFeedLayout(
-                event = event,
-                parentUser = parentUser,
-                onDeleteOrHide = onDeleteOrHide,
-                onDropdownClick = onDropdownClick,
-                onClick = onClick,
-                dropdownState = dropDownState,
-                index = index,
-                onOpenInMusicBrainz = onOpenInMusicBrainz,
-                onPin = onPin,
-                onReview = onReview,
-                onPersonallyRecommend = onPersonallyRecommend,
-                onRecommend = onRecommend,
-                goToUserPage = goToUserPage,
-                goToArtistPage = goToArtistPage
-            )
-            LISTEN -> ListenFeedLayout(
-                event = event,
-                parentUser = parentUser,
-                onDeleteOrHide = onDeleteOrHide,
-                onDropdownClick = onDropdownClick,
-                onClick = onClick,
-                dropdownState = dropDownState,
-                index = index,
-                onOpenInMusicBrainz = onOpenInMusicBrainz,
-                onPin = onPin,
-                onReview = onReview,
-                onPersonallyRecommend = onPersonallyRecommend,
-                onRecommend = onRecommend,
-                goToUserPage = goToUserPage,
-                goToArtistPage = goToArtistPage
-            )
-            FOLLOW -> FollowFeedLayout(event = event, parentUser = parentUser, goToUserPage = goToUserPage)
-            NOTIFICATION -> NotificationFeedLayout(event = event, onDeleteOrHide = onDeleteOrHide, goToUserPage = goToUserPage)
-            REVIEW -> ReviewFeedLayout(
-                event = event,
-                parentUser = parentUser,
-                onDeleteOrHide = onDeleteOrHide,
-                onDropdownClick = onDropdownClick,
-                onClick = onClick,
-                dropdownState = dropDownState,
-                index = index,
-                onOpenInMusicBrainz = onOpenInMusicBrainz,
-                onPin = onPin,
-                onReview = onReview,
-                onPersonallyRecommend = onPersonallyRecommend,
-                onRecommend = onRecommend,
-                goToUserPage = goToUserPage,
-                goToArtistPage = goToArtistPage
-            )
-            UNKNOWN -> UnknownFeedLayout(event = event)
-        }
-    }
     
     @Composable
     fun Tagline(
         modifier: Modifier = Modifier,
         event: FeedEvent,
         parentUser: String,
+        linkStyle: SpanStyle,
+        normalStyle: SpanStyle,
         goToUserPage: (String) -> Unit
     ) {
-        val linkStyle = SpanStyle(
-            color = ListenBrainzTheme.colorScheme.lbSignature,
-            fontWeight = FontWeight.Bold
-        )
-    
-        val normalStyle = SpanStyle(
-            color = ListenBrainzTheme.colorScheme.text,
-            fontWeight = FontWeight.Light
-        )
     
         val uriHandler = LocalUriHandler.current
         
@@ -453,7 +311,7 @@ enum class FeedEventType (
         /** @param createdMus is the time event was created in **Microseconds**.*/
         fun getTimeStringForFeed(createdMus: Long): String {
     
-            val differenceInSeconds = (System.currentTimeMillis() - createdMus*1000)/1000
+            val differenceInSeconds = Clock.System.now().epochSeconds - createdMus.microseconds.inWholeSeconds
             val differenceInMinutes = differenceInSeconds / 60
             val differenceInHours = differenceInMinutes / 60
             

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/model/feed/FeedEventType.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/model/feed/FeedEventType.kt
@@ -17,8 +17,6 @@ import org.listenbrainz.shared.util.Log
 import org.listenbrainz.shared.util.TypeConverter
 import org.listenbrainz.shared.util.Utils.getArticle
 import kotlin.time.Clock
-import kotlin.time.Duration.Companion.microseconds
-import kotlin.time.Duration.Companion.seconds
 
 /**
  * @param icon Feed icon for the event, **must** be of width 19 dp.
@@ -308,10 +306,10 @@ enum class FeedEventType (
         fun isUserSelf(event: FeedEvent, parentUser: String): Boolean =
             event.username == parentUser
         
-        /** @param createdMus is the time event was created in **Microseconds**.*/
-        fun getTimeStringForFeed(createdMus: Long): String {
+        /** @param createdSeconds is the time event was created in **Seconds**.*/
+        fun getTimeStringForFeed(createdSeconds: Long): String {
     
-            val differenceInSeconds = Clock.System.now().epochSeconds - createdMus.microseconds.inWholeSeconds
+            val differenceInSeconds = Clock.System.now().epochSeconds - createdSeconds
             val differenceInMinutes = differenceInSeconds / 60
             val differenceInHours = differenceInMinutes / 60
             
@@ -320,7 +318,7 @@ enum class FeedEventType (
                 differenceInSeconds in 1..59 -> "$differenceInSeconds second${showPlural(differenceInSeconds)} ago"
                 differenceInMinutes in 1..59 -> "$differenceInMinutes minute${showPlural(differenceInMinutes)} ago"
                 differenceInHours in 1..23 -> "$differenceInHours hour${showPlural(differenceInHours)} ago"
-                else -> TypeConverter.stringFromEpochTime(createdMus)
+                else -> TypeConverter.stringFromEpochSeconds(createdSeconds)
             }
         }
         

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/model/feed/FeedEventVisibilityData.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/model/feed/FeedEventVisibilityData.kt
@@ -1,10 +1,10 @@
-package org.listenbrainz.android.model.feed
+package org.listenbrainz.shared.model.feed
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class FeedEventDeletionData (
+data class FeedEventVisibilityData (
     @SerialName("event_type") val eventType : String? = null,
-    @SerialName("id") val eventId   : String? = null
+    @SerialName("event_id") val eventId   : String? = null
 )

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/model/feed/FeedPayload.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/model/feed/FeedPayload.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android.model.feed
+package org.listenbrainz.shared.model.feed
 
 import androidx.compose.runtime.Immutable
 import kotlinx.serialization.SerialName

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/feed/FeedRepository.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/feed/FeedRepository.kt
@@ -1,9 +1,9 @@
-package org.listenbrainz.android.repository.feed
+package org.listenbrainz.shared.repository.feed
 
 import org.listenbrainz.shared.model.SocialResponse
-import org.listenbrainz.android.model.feed.FeedData
-import org.listenbrainz.android.model.feed.FeedEventDeletionData
-import org.listenbrainz.android.model.feed.FeedEventVisibilityData
+import org.listenbrainz.shared.model.feed.FeedData
+import org.listenbrainz.shared.model.feed.FeedEventDeletionData
+import org.listenbrainz.shared.model.feed.FeedEventVisibilityData
 import org.listenbrainz.shared.util.Resource
 
 interface FeedRepository {

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/feed/FeedRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/feed/FeedRepositoryImpl.kt
@@ -1,11 +1,11 @@
-package org.listenbrainz.android.repository.feed
+package org.listenbrainz.shared.repository.feed
 
 import org.listenbrainz.shared.model.ResponseError
 import org.listenbrainz.shared.model.SocialResponse
-import org.listenbrainz.android.model.feed.FeedData
-import org.listenbrainz.android.model.feed.FeedEventDeletionData
-import org.listenbrainz.android.model.feed.FeedEventVisibilityData
-import org.listenbrainz.android.service.FeedServiceKtor
+import org.listenbrainz.shared.model.feed.FeedData
+import org.listenbrainz.shared.model.feed.FeedEventDeletionData
+import org.listenbrainz.shared.model.feed.FeedEventVisibilityData
+import org.listenbrainz.shared.service.FeedServiceKtor
 import org.listenbrainz.shared.util.Resource
 import org.listenbrainz.shared.util.Utils.parseResponse
 

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/service/FeedServiceKtor.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/service/FeedServiceKtor.kt
@@ -1,9 +1,9 @@
-package org.listenbrainz.android.service
+package org.listenbrainz.shared.service
 
 import org.listenbrainz.shared.model.SocialResponse
-import org.listenbrainz.android.model.feed.FeedData
-import org.listenbrainz.android.model.feed.FeedEventDeletionData
-import org.listenbrainz.android.model.feed.FeedEventVisibilityData
+import org.listenbrainz.shared.model.feed.FeedData
+import org.listenbrainz.shared.model.feed.FeedEventDeletionData
+import org.listenbrainz.shared.model.feed.FeedEventVisibilityData
 
 interface FeedServiceKtor {
 

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/service/FeedServiceKtorImpl.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/service/FeedServiceKtorImpl.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android.service
+package org.listenbrainz.shared.service
 
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -8,9 +8,9 @@ import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import org.listenbrainz.shared.model.SocialResponse
-import org.listenbrainz.android.model.feed.FeedData
-import org.listenbrainz.android.model.feed.FeedEventDeletionData
-import org.listenbrainz.android.model.feed.FeedEventVisibilityData
+import org.listenbrainz.shared.model.feed.FeedData
+import org.listenbrainz.shared.model.feed.FeedEventDeletionData
+import org.listenbrainz.shared.model.feed.FeedEventVisibilityData
 
 
 class FeedServiceKtorImpl(

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/ui/screens/feed/FeedUiState.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/ui/screens/feed/FeedUiState.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android.ui.screens.feed
+package org.listenbrainz.shared.ui.screens.feed
 
 import androidx.compose.runtime.Stable
 import androidx.paging.PagingData
@@ -6,7 +6,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import org.listenbrainz.shared.model.ResponseError
 import org.listenbrainz.shared.model.feed.FeedEvent
-import org.listenbrainz.android.model.feed.FeedEventType
+import org.listenbrainz.shared.model.feed.FeedEventType
 
 /** Top most state wrapper for Feed Screen.*/
 @Stable

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/ui/screens/feed/FollowListensPagingSource.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/ui/screens/feed/FollowListensPagingSource.kt
@@ -1,25 +1,25 @@
-package org.listenbrainz.android.ui.screens.feed
+package org.listenbrainz.shared.ui.screens.feed
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import org.listenbrainz.shared.model.ResponseError
-import org.listenbrainz.android.model.feed.FeedData
-import org.listenbrainz.android.model.feed.FeedEventType
-import org.listenbrainz.android.repository.feed.FeedRepository
+import org.listenbrainz.shared.model.feed.FeedData
+import org.listenbrainz.shared.model.feed.FeedEventType
+import org.listenbrainz.shared.repository.feed.FeedRepository
 import org.listenbrainz.shared.util.Resource
+import kotlin.time.Clock
 
-class MyFeedPagingSource (
+class FollowListensPagingSource(
     private val username: suspend () -> String,
-    private val addEntryToMap: (Int, Boolean) -> Unit,
     private val onError: (error: ResponseError?) -> Unit,
     private val feedRepository: FeedRepository,
     private val ioDispatcher: CoroutineDispatcher
 ): PagingSource<Long, FeedUiEventItem>() {
-
+    
     override fun getRefreshKey(state: PagingState<Long, FeedUiEventItem>): Long {
-        return System.currentTimeMillis() / 1000
+        return (Clock.System.now().epochSeconds)
     }
     
     override suspend fun load(params: LoadParams<Long>): LoadResult<Long, FeedUiEventItem> {
@@ -32,14 +32,12 @@ class MyFeedPagingSource (
         }
         
         val result = withContext(ioDispatcher) {
-            feedRepository.getFeedEvents(username = username, maxTs = params.key, count = params.loadSize)
+            feedRepository.getFeedFollowListens(username = username, maxTs = params.key, count = params.loadSize)
         }
         
         return when (result.status) {
             Resource.Status.SUCCESS -> {
-                
                 val processedEvents = processFeedEvents(result.data)
-
                 val nextKey = processedEvents.lastOrNull()?.event?.created?.let { newKey ->
                     // Termination condition.
                     if (params.key != null && newKey >= params.key!!)
@@ -50,9 +48,8 @@ class MyFeedPagingSource (
                         )
                     else
                         newKey
-                    
                 }
-
+                
                 LoadResult.Page(
                     data = processedEvents,
                     prevKey = null,
@@ -63,31 +60,28 @@ class MyFeedPagingSource (
                 onError(result.error)
                 LoadResult.Error(Exception(result.error?.toast))
             }
-            
         }
-        
     }
     
-    private fun processFeedEvents(feedData: FeedData?): List<FeedUiEventItem> {
+    companion object {
         
-        return mutableListOf<FeedUiEventItem>().apply {
+        /** Converts [feedData] to list of [FeedUiEventItem] for presentation.*/
+        fun processFeedEvents(feedData: FeedData?): List<FeedUiEventItem> {
+        
+            return mutableListOf<FeedUiEventItem>().apply {
             
-            feedData?.payload?.events?.forEach { event ->
-                
-                // Add the entry to map.
-                if (event.hidden == true) {
-                    event.id?.let { addEntryToMap(it, true) }
-                }
-                
-                add(
-                    FeedUiEventItem(
-                        event = event,
-                        eventType = FeedEventType.resolveEvent(event),
-                        parentUser = feedData.payload.userId
+                feedData?.payload?.events?.forEach { event ->
+                    add(
+                        FeedUiEventItem(
+                            event = event,
+                            eventType = FeedEventType.resolveEvent(event),
+                            parentUser = feedData.payload.userId
+                        )
                     )
-                )
+                }
             }
         }
     }
+    
     
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/ui/screens/feed/MyFeedPagingSource.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/ui/screens/feed/MyFeedPagingSource.kt
@@ -1,22 +1,26 @@
-package org.listenbrainz.android.ui.screens.feed
+package org.listenbrainz.shared.ui.screens.feed
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import org.listenbrainz.shared.model.ResponseError
-import org.listenbrainz.android.repository.feed.FeedRepository
+import org.listenbrainz.shared.model.feed.FeedData
+import org.listenbrainz.shared.model.feed.FeedEventType
+import org.listenbrainz.shared.repository.feed.FeedRepository
 import org.listenbrainz.shared.util.Resource
+import kotlin.time.Clock
 
-class SimilarListensPagingSource(
+class MyFeedPagingSource (
     private val username: suspend () -> String,
+    private val addEntryToMap: (Int, Boolean) -> Unit,
     private val onError: (error: ResponseError?) -> Unit,
     private val feedRepository: FeedRepository,
     private val ioDispatcher: CoroutineDispatcher
 ): PagingSource<Long, FeedUiEventItem>() {
-    
-    override fun getRefreshKey(state: PagingState<Long, FeedUiEventItem>): Long? {
-        return System.currentTimeMillis() / 1000
+
+    override fun getRefreshKey(state: PagingState<Long, FeedUiEventItem>): Long {
+        return Clock.System.now().epochSeconds
     }
     
     override suspend fun load(params: LoadParams<Long>): LoadResult<Long, FeedUiEventItem> {
@@ -29,13 +33,14 @@ class SimilarListensPagingSource(
         }
         
         val result = withContext(ioDispatcher) {
-            feedRepository.getFeedSimilarListens(username = username, maxTs = params.key, count = params.loadSize)
+            feedRepository.getFeedEvents(username = username, maxTs = params.key, count = params.loadSize)
         }
         
         return when (result.status) {
             Resource.Status.SUCCESS -> {
                 
-                val processedEvents = FollowListensPagingSource.processFeedEvents(result.data)
+                val processedEvents = processFeedEvents(result.data)
+
                 val nextKey = processedEvents.lastOrNull()?.event?.created?.let { newKey ->
                     // Termination condition.
                     if (params.key != null && newKey >= params.key!!)
@@ -46,9 +51,9 @@ class SimilarListensPagingSource(
                         )
                     else
                         newKey
-        
+                    
                 }
-                
+
                 LoadResult.Page(
                     data = processedEvents,
                     prevKey = null,
@@ -63,4 +68,27 @@ class SimilarListensPagingSource(
         }
         
     }
+    
+    private fun processFeedEvents(feedData: FeedData?): List<FeedUiEventItem> {
+        
+        return mutableListOf<FeedUiEventItem>().apply {
+            
+            feedData?.payload?.events?.forEach { event ->
+                
+                // Add the entry to map.
+                if (event.hidden == true) {
+                    event.id?.let { addEntryToMap(it, true) }
+                }
+                
+                add(
+                    FeedUiEventItem(
+                        event = event,
+                        eventType = FeedEventType.resolveEvent(event),
+                        parentUser = feedData.payload.userId
+                    )
+                )
+            }
+        }
+    }
+    
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/ui/screens/feed/SimilarListensPagingSource.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/ui/screens/feed/SimilarListensPagingSource.kt
@@ -1,24 +1,23 @@
-package org.listenbrainz.android.ui.screens.feed
+package org.listenbrainz.shared.ui.screens.feed
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import org.listenbrainz.shared.model.ResponseError
-import org.listenbrainz.android.model.feed.FeedData
-import org.listenbrainz.android.model.feed.FeedEventType
-import org.listenbrainz.android.repository.feed.FeedRepository
+import org.listenbrainz.shared.repository.feed.FeedRepository
 import org.listenbrainz.shared.util.Resource
+import kotlin.time.Clock
 
-class FollowListensPagingSource(
+class SimilarListensPagingSource(
     private val username: suspend () -> String,
     private val onError: (error: ResponseError?) -> Unit,
     private val feedRepository: FeedRepository,
     private val ioDispatcher: CoroutineDispatcher
 ): PagingSource<Long, FeedUiEventItem>() {
     
-    override fun getRefreshKey(state: PagingState<Long, FeedUiEventItem>): Long {
-        return (System.currentTimeMillis() / 1000)
+    override fun getRefreshKey(state: PagingState<Long, FeedUiEventItem>): Long? {
+        return Clock.System.now().epochSeconds
     }
     
     override suspend fun load(params: LoadParams<Long>): LoadResult<Long, FeedUiEventItem> {
@@ -31,12 +30,13 @@ class FollowListensPagingSource(
         }
         
         val result = withContext(ioDispatcher) {
-            feedRepository.getFeedFollowListens(username = username, maxTs = params.key, count = params.loadSize)
+            feedRepository.getFeedSimilarListens(username = username, maxTs = params.key, count = params.loadSize)
         }
         
         return when (result.status) {
             Resource.Status.SUCCESS -> {
-                val processedEvents = processFeedEvents(result.data)
+                
+                val processedEvents = FollowListensPagingSource.processFeedEvents(result.data)
                 val nextKey = processedEvents.lastOrNull()?.event?.created?.let { newKey ->
                     // Termination condition.
                     if (params.key != null && newKey >= params.key!!)
@@ -47,6 +47,7 @@ class FollowListensPagingSource(
                         )
                     else
                         newKey
+        
                 }
                 
                 LoadResult.Page(
@@ -59,28 +60,8 @@ class FollowListensPagingSource(
                 onError(result.error)
                 LoadResult.Error(Exception(result.error?.toast))
             }
-        }
-    }
-    
-    companion object {
-        
-        /** Converts [feedData] to list of [FeedUiEventItem] for presentation.*/
-        fun processFeedEvents(feedData: FeedData?): List<FeedUiEventItem> {
-        
-            return mutableListOf<FeedUiEventItem>().apply {
             
-                feedData?.payload?.events?.forEach { event ->
-                    add(
-                        FeedUiEventItem(
-                            event = event,
-                            eventType = FeedEventType.resolveEvent(event),
-                            parentUser = feedData.payload.userId
-                        )
-                    )
-                }
-            }
         }
+        
     }
-    
-    
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/util/DrawableProvider.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/util/DrawableProvider.kt
@@ -1,0 +1,12 @@
+package org.listenbrainz.shared.util
+
+enum class DrawableResource {
+    FEED_SEND,
+    FEED_PIN,
+    FEED_LOVE,
+    FEED_LISTEN,
+    FEED_FOLLOW,
+    FEED_NOTIFICATION,
+    FEED_REVIEW,
+    FEED_UNKNOWN,
+}

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/util/TypeConverter.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/util/TypeConverter.kt
@@ -93,7 +93,7 @@ object TypeConverter {
         }
     }
 
-    fun stringFromEpochTime(microSeconds: Long, dateFormat: DateTimeFormat<LocalDateTime> = LocalDateTime.Format {
+    fun stringFromEpochSeconds(epochSeconds: Long, dateFormat: DateTimeFormat<LocalDateTime> = LocalDateTime.Format {
         monthName(MonthNames.ENGLISH_ABBREVIATED)
         char(' ')
         dayOfMonth(Padding.ZERO)
@@ -105,7 +105,7 @@ object TypeConverter {
         char(' ')
         amPmMarker("AM","PM")
     }): String {
-        val instant = Instant.fromEpochMilliseconds(microSeconds / 1000)
+        val instant = Instant.fromEpochSeconds(epochSeconds)
         val localDateTime = instant.toLocalDateTime(TimeZone.currentSystemDefault())
         return localDateTime.format(dateFormat)
     }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/util/Utils.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/util/Utils.kt
@@ -117,6 +117,17 @@ object Utils {
         if (caaReleaseMbid == null || caaId == null) return null
         return "https://archive.org/download/mbid-${caaReleaseMbid}/mbid-${caaReleaseMbid}-${caaId}_thumb${size}.jpg"
     }
+
+    fun getArticle(str: String): String {
+        return when (str.first()){
+            'a' -> "an"
+            'e' -> "an"
+            'i' -> "an"
+            'o' -> "an"
+            'u' -> "an"
+            else -> "a"
+        }
+    }
 }
 
 expect object PlatformUtils {

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/viewmodel/FeedViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/viewmodel/FeedViewModel.kt
@@ -1,6 +1,5 @@
-package org.listenbrainz.android.viewmodel
+package org.listenbrainz.shared.viewmodel
 
-import android.net.Uri
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.lifecycle.viewModelScope
@@ -23,29 +22,26 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.listenbrainz.shared.model.LinkedService
 import org.listenbrainz.shared.model.ResponseError
 import org.listenbrainz.shared.model.feed.FeedEvent
-import org.listenbrainz.android.model.feed.FeedEventDeletionData
-import org.listenbrainz.android.model.feed.FeedEventType
-import org.listenbrainz.android.model.feed.FeedEventType.Companion.isActionDelete
-import org.listenbrainz.android.model.feed.FeedEventVisibilityData
-import org.listenbrainz.android.repository.feed.FeedRepository
-import org.listenbrainz.android.repository.feed.FeedRepository.Companion.FeedEventCount
-import org.listenbrainz.android.repository.feed.FeedRepository.Companion.FeedListensCount
-import org.listenbrainz.shared.repository.listens.ListensRepository
+import org.listenbrainz.shared.model.feed.FeedEventDeletionData
+import org.listenbrainz.shared.model.feed.FeedEventType
+import org.listenbrainz.shared.model.feed.FeedEventVisibilityData
 import org.listenbrainz.shared.repository.AppPreferences
+import org.listenbrainz.shared.repository.feed.FeedRepository
+import org.listenbrainz.shared.repository.listens.ListensRepository
 import org.listenbrainz.shared.repository.remoteplayer.RemotePlaybackHandler
 import org.listenbrainz.shared.repository.social.SocialRepository
-import org.listenbrainz.android.ui.screens.feed.FeedUiEventData
-import org.listenbrainz.android.ui.screens.feed.FeedUiEventItem
-import org.listenbrainz.android.ui.screens.feed.FeedUiState
-import org.listenbrainz.android.ui.screens.feed.FollowListensPagingSource
-import org.listenbrainz.android.ui.screens.feed.MyFeedPagingSource
-import org.listenbrainz.android.ui.screens.feed.SimilarListensPagingSource
-import org.listenbrainz.shared.model.LinkedService
-import org.listenbrainz.shared.viewmodel.BaseViewModel
+import org.listenbrainz.shared.ui.screens.feed.FeedUiEventData
+import org.listenbrainz.shared.ui.screens.feed.FeedUiEventItem
+import org.listenbrainz.shared.ui.screens.feed.FeedUiState
+import org.listenbrainz.shared.ui.screens.feed.FollowListensPagingSource
+import org.listenbrainz.shared.ui.screens.feed.MyFeedPagingSource
+import org.listenbrainz.shared.ui.screens.feed.SimilarListensPagingSource
 import org.listenbrainz.shared.util.Log
 import org.listenbrainz.shared.util.Resource
+import kotlin.collections.get
 
 class FeedViewModel(
     private val feedRepository: FeedRepository,
@@ -55,50 +51,56 @@ class FeedViewModel(
     private val remotePlaybackHandler: RemotePlaybackHandler,
     private val ioDispatcher: CoroutineDispatcher,
     private val defaultDispatcher: CoroutineDispatcher,
-    private val logger:Log = Log
+    private val logger: Log = Log
 ): BaseViewModel<FeedUiState>() {
-    
+
     // Search follower flow
     private val inputSearchFollowerQuery = MutableStateFlow("")
     @OptIn(FlowPreview::class)
     private val searchFollowerQuery = inputSearchFollowerQuery.asStateFlow().debounce(500).distinctUntilChanged()
     private val searchFollowerResult = MutableStateFlow<List<String>>(emptyList())
-    
+
     // My Feed
     private val myFeedPager: Flow<PagingData<FeedUiEventItem>> = Pager(
-        PagingConfig(pageSize = FeedEventCount),
+        PagingConfig(pageSize = FeedRepository.FeedEventCount),
         initialKey = null
     ) { createNewMyFeedPagingSource() }
         .flow
         .cachedIn(viewModelScope)
-    
+
     private val isDeletedMap: SnapshotStateMap<Int, Boolean> = mutableStateMapOf()
     private val isHiddenMap: SnapshotStateMap<Int, Boolean> = mutableStateMapOf()
-    private val myFeedFlow = MutableStateFlow(FeedUiEventData(isHiddenMap, isDeletedMap, myFeedPager))
-    
-    
+    private val myFeedFlow = MutableStateFlow(
+        FeedUiEventData(
+            isHiddenMap,
+            isDeletedMap,
+            myFeedPager
+        )
+    )
+
+
     // Follow Listens
     private val followListensPager: Flow<PagingData<FeedUiEventItem>> = Pager(
-        PagingConfig(pageSize = FeedListensCount),
+        PagingConfig(pageSize = FeedRepository.FeedListensCount),
         initialKey = null
     ) { createNewFollowListensPagingSource() }
         .flow
         .cachedIn(viewModelScope)
     private val followListensFlow = MutableStateFlow(FeedUiEventData(eventList = followListensPager))
-    
-    
+
+
     // Similar Listens
     private val similarListensPager: Flow<PagingData<FeedUiEventItem>> = Pager(
-        PagingConfig(pageSize = FeedListensCount),
+        PagingConfig(pageSize = FeedRepository.FeedListensCount),
         initialKey = null
     ) { createNewSimilarListensPagingSource() }
         .flow
         .cachedIn(viewModelScope)
     private val similarListensFlow = MutableStateFlow(FeedUiEventData(eventList = similarListensPager))
-    
+
     // Exposed UI state
     override val uiState = createUiStateFlow()
-    
+
     override fun createUiStateFlow(): StateFlow<FeedUiState> {
         return combine(
             myFeedFlow,
@@ -118,7 +120,7 @@ class FeedViewModel(
                 FeedUiState()
             )
     }
-    
+
     private fun createNewMyFeedPagingSource(): MyFeedPagingSource =
         MyFeedPagingSource(
             username = { appPreferences.username.get() },
@@ -131,7 +133,7 @@ class FeedViewModel(
             feedRepository = feedRepository,
             ioDispatcher = ioDispatcher
         )
-    
+
     private fun createNewFollowListensPagingSource(): FollowListensPagingSource =
         FollowListensPagingSource(
             username = { appPreferences.username.get() } ,
@@ -141,21 +143,22 @@ class FeedViewModel(
             feedRepository = feedRepository,
             ioDispatcher = ioDispatcher
         )
-    
+
     private fun createNewSimilarListensPagingSource(): SimilarListensPagingSource =
         SimilarListensPagingSource(
             username = { appPreferences.username.get() },
-            onError =  { error ->
+            onError = { error ->
                 emitError(error)
             },
             feedRepository = feedRepository,
             ioDispatcher = ioDispatcher
         )
-    
+
     fun play(event: FeedEvent) {
         val spotifyId = event.metadata.trackMetadata?.additionalInfo?.spotifyId
         if (spotifyId != null){
-            Uri.parse(spotifyId).lastPathSegment?.let { trackId ->
+            val trackId = spotifyId.substringBefore("?").substringAfterLast('/').substringAfterLast(':')
+            if(trackId.isNotBlank()){
                 remotePlaybackHandler.playUri(trackId){
                     playFromYoutubeMusic(event)
                 }
@@ -164,7 +167,7 @@ class FeedViewModel(
             playFromYoutubeMusic(event)
         }
     }
-    
+
     private fun playFromYoutubeMusic(event: FeedEvent) {
         viewModelScope.launch {
             val trackMetadata = event.metadata.trackMetadata
@@ -179,7 +182,7 @@ class FeedViewModel(
                             )
                         }
                     }
-                    
+
                     if (result.isFailed) {
                         emitError(ResponseError.RemotePlayerError(actualResponse = "Could not play the requested track."))
                     }
@@ -190,13 +193,13 @@ class FeedViewModel(
             }
         }
     }
-    
+
     fun searchUser(query: String){
         viewModelScope.launch {
             inputSearchFollowerQuery.emit(query)
         }
     }
-    
+
     suspend fun isCritiqueBrainzLinked(): Boolean? {
         val result = listensRepository.getLinkedServices(
             appPreferences.lbAccessToken.get(),
@@ -207,11 +210,11 @@ class FeedViewModel(
         }
         return result.data?.toLinkedServicesList()?.contains(LinkedService.CRITIQUEBRAINZ)
     }
-    
+
     fun hideOrDeleteEvent(event: FeedEvent, eventType: FeedEventType, parentUser: String) {
-        
+
         viewModelScope.launch(defaultDispatcher) {
-            if (isActionDelete(event, eventType, parentUser)){
+            if (FeedEventType.isActionDelete(event, eventType, parentUser)){
                 deleteEvent(event.id!!, event.type)
             } else if (isHiddenMap[event.id] == true){
                 unhideEvent(data = FeedEventVisibilityData(event.type, event.id.toString()))
@@ -219,7 +222,7 @@ class FeedViewModel(
                 // null means false
                 hideEvent(data = FeedEventVisibilityData(event.type, event.id.toString()))
             }
-            
+
         }
     }
 
@@ -250,14 +253,14 @@ class FeedViewModel(
     }
 
     private suspend fun hideEvent(data: FeedEventVisibilityData) {
-        
+
         // Optimistically toggle
         toggleHiddenStatus(data)
-        
+
         val result = withContext(ioDispatcher) {
             feedRepository.hideEvent(appPreferences.username.get(), data)
         }
-        
+
         when (result.status) {
             Resource.Status.FAILED -> {
                 // Toggle back on failure.
@@ -266,18 +269,18 @@ class FeedViewModel(
             }
             else -> Unit
         }
-        
+
     }
-    
+
     private suspend fun unhideEvent(data: FeedEventVisibilityData) {
-        
+
         // Optimistically toggle
         toggleHiddenStatus(data)
-        
+
         val result = withContext(ioDispatcher) {
             feedRepository.unhideEvent(appPreferences.username.get(), data)
         }
-        
+
         when (result.status) {
             Resource.Status.FAILED -> {
                 // Toggle back on failure.
@@ -286,9 +289,9 @@ class FeedViewModel(
             }
             else -> Unit
         }
-        
+
     }
-    
+
     private suspend fun toggleHiddenStatus(data: FeedEventVisibilityData) {
         try {
             val currentState = isHiddenMap[data.eventId!!.toInt()]

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/viewmodel/FeedViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/viewmodel/FeedViewModel.kt
@@ -41,7 +41,6 @@ import org.listenbrainz.shared.ui.screens.feed.MyFeedPagingSource
 import org.listenbrainz.shared.ui.screens.feed.SimilarListensPagingSource
 import org.listenbrainz.shared.util.Log
 import org.listenbrainz.shared.util.Resource
-import kotlin.collections.get
 
 class FeedViewModel(
     private val feedRepository: FeedRepository,

--- a/sharedTest/src/main/java/org/listenbrainz/sharedtest/mocks/MockFeedRepository.kt
+++ b/sharedTest/src/main/java/org/listenbrainz/sharedtest/mocks/MockFeedRepository.kt
@@ -1,10 +1,10 @@
 package org.listenbrainz.sharedtest.mocks
 
 import org.listenbrainz.shared.model.SocialResponse
-import org.listenbrainz.android.model.feed.FeedData
-import org.listenbrainz.android.model.feed.FeedEventDeletionData
-import org.listenbrainz.android.model.feed.FeedEventVisibilityData
-import org.listenbrainz.android.repository.feed.FeedRepository
+import org.listenbrainz.shared.model.feed.FeedData
+import org.listenbrainz.shared.model.feed.FeedEventDeletionData
+import org.listenbrainz.shared.model.feed.FeedEventVisibilityData
+import org.listenbrainz.shared.repository.feed.FeedRepository
 import org.listenbrainz.shared.util.Resource
 
 class MockFeedRepository : FeedRepository {


### PR DESCRIPTION
## Base PR:- #732 
#### Rebased with the latest upstream/cmp branch, and this branch consists all the commits from the base branch.

---
This PR fixes #697  migrates `FeedViewModel` from app module to `shared` module

## Key Changes:- 
1. Moved `getArticle` utility function to shared `Utils`.
2. Added a drawable resource provider `AppDrawableProvider` for temporary usage in app module for easily accessing the res in shared module.
3. Migrated feed and other related data models to shared module.
4. Moved `FeedServiceKtor` and its impl to shared module and registered them inside `sharedNetworkServiceModule`.
5. Moved `FeedRepository`  and its impl to shared module and registered it inside `sharedRepositoryModule`.
6. Added paging dependencies inside shared build.gradle file.
7. Moved `MyFeedPagingSource`, `FollowListensPagingSource` and `SimilarListensPagingSource` to shared module.
8. Moved `FeedViewModel` to shared/commonMain/viewmodel/ using kmp lifecycle dependencies and registered it inside `sharedViewModelModule`.