### PR TITLE
Migrated SearchViewmodel to shared module

### DIFF
--- a/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
+++ b/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
@@ -57,7 +57,6 @@ import org.listenbrainz.android.viewmodel.AboutViewModel
 import org.listenbrainz.android.viewmodel.AppUpdatesViewModel
 import org.listenbrainz.android.viewmodel.BrainzPlayerViewModel
 import org.listenbrainz.android.viewmodel.DashBoardViewModel
-import org.listenbrainz.android.viewmodel.SearchViewModel
 import org.listenbrainz.android.viewmodel.UserViewModel
 import org.listenbrainz.android.viewmodel.Yim23ViewModel
 import org.listenbrainz.android.viewmodel.YimViewModel
@@ -282,7 +281,6 @@ val viewModelModule = module {
     viewModel { UserViewModel(get(), get(), get(), get(), get(), get(named(IO_DISPATCHER))) }
     viewModel { YimViewModel(get(), get(), get(named(IO_DISPATCHER)), get(named(DEFAULT_DISPATCHER))) }
     viewModel { Yim23ViewModel(get(), get(), get(), get(named(IO_DISPATCHER)), get(named(DEFAULT_DISPATCHER))) }
-    viewModel { SearchViewModel(get(),get(),get(),get(),get(), get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER))) }
     viewModel { BrainzPlayerViewModel(get(), get(), get(), get(), get(), get(named(IO_DISPATCHER))) }
     viewModel { AboutViewModel() }
 }

--- a/app/src/main/java/org/listenbrainz/android/ui/components/FollowButton.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/components/FollowButton.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import org.listenbrainz.android.model.search.userSearch.UserListUiState
+import org.listenbrainz.shared.model.search.userSearch.UserListUiState
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 
 /** State of this button changes optimistically and will revert back if something goes wrong. This inversion of state is determined by

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/search/BaseSearchScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/search/BaseSearchScreen.kt
@@ -50,13 +50,13 @@ import com.valentinilk.shimmer.shimmer
 import org.koin.androidx.compose.koinViewModel
 import org.listenbrainz.shared.model.User
 import org.listenbrainz.shared.model.playlist.PlaylistTrack
-import org.listenbrainz.android.model.search.SearchData
-import org.listenbrainz.android.model.search.SearchType
+import org.listenbrainz.shared.model.search.SearchData
+import org.listenbrainz.shared.model.search.SearchType
 import org.listenbrainz.shared.model.search.albumSearch.AlbumSearchUiState
 import org.listenbrainz.shared.model.search.artistSearch.ArtistSearchUiState
 import org.listenbrainz.shared.model.search.playlistSearch.PlayListSearchUiState
-import org.listenbrainz.android.model.search.trackSearch.TrackSearchUiState
-import org.listenbrainz.android.model.search.userSearch.UserListUiState
+import org.listenbrainz.shared.model.search.trackSearch.TrackSearchUiState
+import org.listenbrainz.shared.model.search.userSearch.UserListUiState
 import org.listenbrainz.android.ui.components.FollowButton
 import org.listenbrainz.android.ui.components.ListenCardSmall
 import org.listenbrainz.android.ui.components.NavigationChips
@@ -65,7 +65,7 @@ import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.util.Utils.formatDurationSeconds
 import org.listenbrainz.shared.util.Utils.getCoverArtUrl
 import org.listenbrainz.shared.util.Utils.removeHtmlTags
-import org.listenbrainz.android.viewmodel.SearchViewModel
+import org.listenbrainz.shared.viewmodel.SearchViewModel
 import org.listenbrainz.shared.model.feed.FeedListenArtist
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/search/BrainzPlayerSearchScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/search/BrainzPlayerSearchScreen.kt
@@ -1,9 +1,6 @@
 package org.listenbrainz.android.ui.screens.search
 
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -19,8 +16,8 @@ import org.koin.androidx.compose.koinViewModel
 import org.listenbrainz.android.R
 import org.listenbrainz.shared.model.PlayableType
 import org.listenbrainz.shared.model.ResponseError
-import org.listenbrainz.android.model.search.SearchData
-import org.listenbrainz.android.model.search.SearchUiState
+import org.listenbrainz.shared.model.search.SearchData
+import org.listenbrainz.shared.model.search.SearchUiState
 import org.listenbrainz.android.ui.components.ListenCardSmallDefault
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.util.Utils.showToast

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/search/SearchScreen.kt
@@ -40,7 +40,7 @@ import androidx.compose.ui.platform.WindowInfo
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
-import org.listenbrainz.android.model.search.SearchUiState
+import org.listenbrainz.shared.model.search.SearchUiState
 import org.listenbrainz.android.ui.components.ErrorBar
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 

--- a/app/src/test/java/org/listenbrainz/android/SearchViewModelTest.kt
+++ b/app/src/test/java/org/listenbrainz/android/SearchViewModelTest.kt
@@ -12,7 +12,7 @@ import org.listenbrainz.shared.model.ResponseError
 import org.listenbrainz.shared.model.User
 import org.listenbrainz.shared.repository.social.SocialRepository
 import org.listenbrainz.shared.util.Resource
-import org.listenbrainz.android.viewmodel.SearchViewModel
+import org.listenbrainz.shared.viewmodel.SearchViewModel
 import org.listenbrainz.sharedtest.testdata.SocialRepositoryTestData.ErrorUtil.alreadyFollowingError
 import org.listenbrainz.sharedtest.testdata.SocialRepositoryTestData.ErrorUtil.cannotFollowSelfError
 import org.listenbrainz.sharedtest.testdata.SocialRepositoryTestData.testFollowUnfollowSuccessResponse

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedRepositoryModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedRepositoryModule.kt
@@ -55,6 +55,4 @@ val sharedRepositoryModule = module {
     single<BPArtistRepository> { BPArtistRepositoryImpl(get(),get(),get()) }
     single<PlaylistDataRepository> { PlaylistDataRepositoryImpl(get(),get(),get(),get(named(IO_DISPATCHER))) }
     single<FeedRepository> { FeedRepositoryImpl(get()) }
-    single<SocialRepository> { SocialRepositoryImpl(get(),get()) }
-    single<PlaylistDataRepository> { PlaylistDataRepositoryImpl(get(),get(),get(),get(named(IO_DISPATCHER))) }
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedRepositoryModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedRepositoryModule.kt
@@ -55,4 +55,5 @@ val sharedRepositoryModule = module {
     single<BPArtistRepository> { BPArtistRepositoryImpl(get(),get(),get()) }
     single<PlaylistDataRepository> { PlaylistDataRepositoryImpl(get(),get(),get(),get(named(IO_DISPATCHER))) }
     single<FeedRepository> { FeedRepositoryImpl(get()) }
+    single<SocialRepository> { SocialRepositoryImpl(get(),get()) }
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedRepositoryModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedRepositoryModule.kt
@@ -56,4 +56,5 @@ val sharedRepositoryModule = module {
     single<PlaylistDataRepository> { PlaylistDataRepositoryImpl(get(),get(),get(),get(named(IO_DISPATCHER))) }
     single<FeedRepository> { FeedRepositoryImpl(get()) }
     single<SocialRepository> { SocialRepositoryImpl(get(),get()) }
+    single<PlaylistDataRepository> { PlaylistDataRepositoryImpl(get(),get(),get(),get(named(IO_DISPATCHER))) }
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
@@ -17,6 +17,7 @@ import org.listenbrainz.shared.viewmodel.ListensViewModel
 import org.listenbrainz.shared.viewmodel.PlaylistViewModel
 import org.listenbrainz.shared.viewmodel.BPAlbumViewModel
 import org.listenbrainz.shared.viewmodel.PlaylistDataViewModel
+import org.listenbrainz.shared.viewmodel.SearchViewModel
 import org.listenbrainz.shared.viewmodel.SettingsViewModel
 import org.listenbrainz.shared.viewmodel.SongViewModel
 import org.listenbrainz.shared.viewmodel.SocialViewModel
@@ -39,4 +40,5 @@ val sharedViewModelModule = module {
     viewModel { SocialViewModel(get(),get(),get(),get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER)),get<StringProvider>()) }
     viewModel { FeedViewModel(get(),get(),get(),get(),get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER))) }
     viewModel { PlaylistDataViewModel(get(),get(),get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER))) }
+    viewModel { SearchViewModel(get(),get(),get(),get(),get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER))) }
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
@@ -39,6 +39,6 @@ val sharedViewModelModule = module {
     viewModel { PlaylistDataViewModel(get(),get(),get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER)),get<StringProvider>()) }
     viewModel { SocialViewModel(get(),get(),get(),get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER)),get<StringProvider>()) }
     viewModel { FeedViewModel(get(),get(),get(),get(),get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER))) }
-    viewModel { PlaylistDataViewModel(get(),get(),get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER))) }
+    viewModel { PlaylistDataViewModel(get(),get(),get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER)),get<StringProvider>()) }
     viewModel { SearchViewModel(get(),get(),get(),get(),get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER))) }
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
@@ -39,6 +39,5 @@ val sharedViewModelModule = module {
     viewModel { PlaylistDataViewModel(get(),get(),get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER)),get<StringProvider>()) }
     viewModel { SocialViewModel(get(),get(),get(),get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER)),get<StringProvider>()) }
     viewModel { FeedViewModel(get(),get(),get(),get(),get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER))) }
-    viewModel { PlaylistDataViewModel(get(),get(),get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER)),get<StringProvider>()) }
     viewModel { SearchViewModel(get(),get(),get(),get(),get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER))) }
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
@@ -38,4 +38,5 @@ val sharedViewModelModule = module {
     viewModel { PlaylistDataViewModel(get(),get(),get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER)),get<StringProvider>()) }
     viewModel { SocialViewModel(get(),get(),get(),get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER)),get<StringProvider>()) }
     viewModel { FeedViewModel(get(),get(),get(),get(),get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER))) }
+    viewModel { PlaylistDataViewModel(get(),get(),get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER))) }
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/model/search/SearchType.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/model/search/SearchType.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android.model.search
+package org.listenbrainz.shared.model.search
 
 enum class SearchType(
     val title: String,

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/model/search/SearchUiState.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/model/search/SearchUiState.kt
@@ -1,11 +1,11 @@
-package org.listenbrainz.android.model.search
+package org.listenbrainz.shared.model.search
 
 import org.listenbrainz.shared.model.ResponseError
-import org.listenbrainz.android.model.search.userSearch.UserListUiState
+import org.listenbrainz.shared.model.search.userSearch.UserListUiState
 import org.listenbrainz.shared.model.search.albumSearch.AlbumSearchUiState
 import org.listenbrainz.shared.model.search.artistSearch.ArtistSearchUiState
 import org.listenbrainz.shared.model.search.playlistSearch.PlayListSearchUiState
-import org.listenbrainz.android.model.search.trackSearch.TrackSearchUiState
+import org.listenbrainz.shared.model.search.trackSearch.TrackSearchUiState
 import org.listenbrainz.shared.model.Song
 
 data class SearchUiState(

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/model/search/trackSearch/TrackSearchUiState.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/model/search/trackSearch/TrackSearchUiState.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android.model.search.trackSearch
+package org.listenbrainz.shared.model.search.trackSearch
 
 import org.listenbrainz.shared.model.playlist.PlaylistTrack
 

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/model/search/userSearch/UserListUiState.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/model/search/userSearch/UserListUiState.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android.model.search.userSearch
+package org.listenbrainz.shared.model.search.userSearch
 
 import kotlinx.serialization.Serializable
 import org.listenbrainz.shared.model.User

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/viewmodel/SearchViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/viewmodel/SearchViewModel.kt
@@ -1,9 +1,7 @@
-package org.listenbrainz.android.viewmodel
+package org.listenbrainz.shared.viewmodel
 
-import android.net.Uri
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -19,33 +17,31 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.listenbrainz.shared.model.search.artistSearch.ArtistSearchUiState
-import org.listenbrainz.shared.model.search.artistSearch.ArtistUiModel
-import org.listenbrainz.shared.model.search.playlistSearch.PlayListSearchUiState
-import org.listenbrainz.shared.model.search.playlistSearch.PlaylistUiModel
 import org.listenbrainz.shared.model.ResponseError
 import org.listenbrainz.shared.model.TrackMetadata
-import org.listenbrainz.android.model.search.SearchData
-import org.listenbrainz.android.model.search.SearchType
-import org.listenbrainz.android.model.search.SearchUiState
-import org.listenbrainz.android.model.search.trackSearch.TrackSearchUiState
 import org.listenbrainz.shared.model.User
-import org.listenbrainz.android.model.search.userSearch.UserListUiState
 import org.listenbrainz.shared.model.albumSearch.toUiModel
 import org.listenbrainz.shared.model.artistSearch.toUiModel
 import org.listenbrainz.shared.model.playlist.PlaylistTrack
 import org.listenbrainz.shared.model.playlist.toUiModel
+import org.listenbrainz.shared.model.search.SearchData
+import org.listenbrainz.shared.model.search.SearchType
+import org.listenbrainz.shared.model.search.SearchUiState
 import org.listenbrainz.shared.model.search.albumSearch.AlbumSearchUiState
 import org.listenbrainz.shared.model.search.albumSearch.AlbumUiModel
+import org.listenbrainz.shared.model.search.artistSearch.ArtistSearchUiState
+import org.listenbrainz.shared.model.search.artistSearch.ArtistUiModel
+import org.listenbrainz.shared.model.search.playlistSearch.PlayListSearchUiState
+import org.listenbrainz.shared.model.search.playlistSearch.PlaylistUiModel
+import org.listenbrainz.shared.model.search.trackSearch.TrackSearchUiState
+import org.listenbrainz.shared.model.search.userSearch.UserListUiState
 import org.listenbrainz.shared.repository.album.AlbumRepository
 import org.listenbrainz.shared.repository.artist.ArtistRepository
 import org.listenbrainz.shared.repository.playlists.PlaylistDataRepository
 import org.listenbrainz.shared.repository.remoteplayer.RemotePlaybackHandler
 import org.listenbrainz.shared.repository.social.SocialRepository
 import org.listenbrainz.shared.util.Resource
-import org.listenbrainz.shared.util.Log
-import org.listenbrainz.shared.viewmodel.FollowUnfollowModel
-
+import kotlin.coroutines.cancellation.CancellationException
 
 class SearchViewModel(
     private val userRepository: SocialRepository,
@@ -61,7 +57,7 @@ class SearchViewModel(
 
     @OptIn(FlowPreview::class)
     private val queryFlow = _inputQueryFlow.asStateFlow().map { it.text }.debounce(500).distinctUntilChanged()
-    
+
     // Result flows
     private val userListFlow = MutableStateFlow<List<User>>(emptyList())
     private val playlistFlow = MutableStateFlow<List<PlaylistUiModel>>(emptyList())
@@ -382,7 +378,8 @@ class SearchViewModel(
     fun playListen(trackMetadata: TrackMetadata) {
         val spotifyId = trackMetadata.additionalInfo?.spotifyId
         if (spotifyId != null){
-            Uri.parse(spotifyId).lastPathSegment?.let { trackId ->
+            val trackId= spotifyId.substringBefore("?").substringAfterLast("/").substringAfterLast(":")
+            if(trackId.isNotBlank()){
                 remotePlaybackHandler.playUri(
                     trackId = trackId,
                     onFailure = { playFromYoutubeMusic(trackMetadata) }
@@ -400,7 +397,7 @@ class SearchViewModel(
                     withContext(ioDispatcher) {
                         searchYoutubeMusicVideoId(
                             trackMetadata.trackName
-                                ?: return@withContext Resource.failure(ResponseError.DoesNotExist()),
+                                ?: return@withContext Resource.Companion.failure(ResponseError.DoesNotExist()),
                             trackMetadata.artistName.orEmpty()
                         )
                     }


### PR DESCRIPTION
## Base PR:- #758 , #760 
#### Rebased with latest upstream/cmp, and this branch consists every commit from the base branches. Needed `PlaylistDataRepository`, so had to take base #760 completely.

---
This PR fixes #698 migrates `SearchViewModel` to shared module.

## Key Changes:- 
1. Moved search data models to shared module.
2. Moved `SearchViewmodel` to shared module and registered it inside `sharedViewmodelModule`.