### PR TITLE
Migrated UserViewmodel to shared module

### DIFF
--- a/app/src/androidTest/java/org/listenbrainz/android/UserPagesTest.kt
+++ b/app/src/androidTest/java/org/listenbrainz/android/UserPagesTest.kt
@@ -23,7 +23,7 @@ import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.shared.viewmodel.FeedViewModel
 import org.listenbrainz.shared.viewmodel.ListensViewModel
 import org.listenbrainz.shared.viewmodel.SocialViewModel
-import org.listenbrainz.android.viewmodel.UserViewModel
+import org.listenbrainz.shared.viewmodel.UserViewModel
 import org.listenbrainz.sharedtest.mocks.MockAppPreferences
 import org.listenbrainz.sharedtest.mocks.MockFeedRepository
 import org.listenbrainz.sharedtest.mocks.MockListensRepository

--- a/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
+++ b/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
@@ -55,7 +55,6 @@ import org.listenbrainz.android.viewmodel.AboutViewModel
 import org.listenbrainz.android.viewmodel.AppUpdatesViewModel
 import org.listenbrainz.android.viewmodel.BrainzPlayerViewModel
 import org.listenbrainz.android.viewmodel.DashBoardViewModel
-import org.listenbrainz.android.viewmodel.UserViewModel
 import org.listenbrainz.android.viewmodel.Yim23ViewModel
 import org.listenbrainz.android.viewmodel.YimViewModel
 import org.listenbrainz.shared.di.DEFAULT_DISPATCHER

--- a/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
+++ b/app/src/main/java/org/listenbrainz/android/di/KoinModules.kt
@@ -33,8 +33,6 @@ import org.listenbrainz.android.repository.appupdates.AppUpdatesRepository
 import org.listenbrainz.android.repository.appupdates.AppUpdatesRepositoryImpl
 import org.listenbrainz.android.repository.listenservicemanager.ListenServiceManager
 import org.listenbrainz.android.repository.listenservicemanager.ListenServiceManagerImpl
-import org.listenbrainz.android.repository.user.UserRepository
-import org.listenbrainz.android.repository.user.UserRepositoryImpl
 import org.listenbrainz.android.repository.yim.YimRepository
 import org.listenbrainz.android.repository.yim.YimRepositoryImpl
 import org.listenbrainz.android.repository.yim23.Yim23Repository
@@ -243,7 +241,6 @@ val appModule = module {
 val repositoryModule = module {
 
     // API Repositories
-    single<UserRepository> { UserRepositoryImpl(get(), get()) }
     single<YimRepository> { YimRepositoryImpl(get()) }
     single<Yim23Repository> { Yim23RepositoryImpl(get()) }
     single<AppUpdatesRepository> { AppUpdatesRepositoryImpl(get(), get(), get(named(IO_DISPATCHER))) }
@@ -278,7 +275,6 @@ val playerModule = module {
 val viewModelModule = module {
     viewModel { DashBoardViewModel(get(), get(), get(), get(named(IO_DISPATCHER)),get()) }
     viewModel { AppUpdatesViewModel(get(), get(), get()) }
-    viewModel { UserViewModel(get(), get(), get(), get(), get(), get(named(IO_DISPATCHER))) }
     viewModel { YimViewModel(get(), get(), get(named(IO_DISPATCHER)), get(named(DEFAULT_DISPATCHER))) }
     viewModel { Yim23ViewModel(get(), get(), get(), get(named(IO_DISPATCHER)), get(named(DEFAULT_DISPATCHER))) }
     viewModel { BrainzPlayerViewModel(get(), get(), get(), get(), get(), get(named(IO_DISPATCHER))) }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/BaseProfileScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/BaseProfileScreen.kt
@@ -52,7 +52,7 @@ import org.listenbrainz.shared.viewmodel.FeedViewModel
 import org.listenbrainz.shared.viewmodel.ListensViewModel
 import org.listenbrainz.shared.viewmodel.PlaylistDataViewModel
 import org.listenbrainz.shared.viewmodel.SocialViewModel
-import org.listenbrainz.android.viewmodel.UserViewModel
+import org.listenbrainz.shared.viewmodel.UserViewModel
 
 @Composable
 fun BaseProfileScreen(

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/ProfileScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -22,10 +21,8 @@ import org.listenbrainz.android.ui.components.LoadingAnimation
 import org.listenbrainz.android.ui.navigation.TopBar
 import org.listenbrainz.android.ui.navigation.TopBarActions
 import org.listenbrainz.shared.util.Constants.Strings.STATUS_LOGGED_IN
-import org.listenbrainz.android.util.Utils.toSp
-import org.listenbrainz.shared.viewmodel.ListensViewModel
 import org.listenbrainz.shared.viewmodel.SocialViewModel
-import org.listenbrainz.android.viewmodel.UserViewModel
+import org.listenbrainz.shared.viewmodel.UserViewModel
 
 @Composable
 fun ProfileScreen(

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/createdforyou/CreatedForYouScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/createdforyou/CreatedForYouScreen.kt
@@ -64,8 +64,8 @@ import org.listenbrainz.android.ui.components.ErrorBar
 import org.listenbrainz.android.ui.components.ListenCardSmallDefault
 import org.listenbrainz.android.ui.components.SuccessBar
 import org.listenbrainz.android.ui.screens.feed.RetryButton
-import org.listenbrainz.android.ui.screens.profile.CreatedForTabUIState
-import org.listenbrainz.android.ui.screens.profile.ProfileUiState
+import org.listenbrainz.shared.ui.screens.profile.CreatedForTabUIState
+import org.listenbrainz.shared.ui.screens.profile.ProfileUiState
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.shared.util.Log
 import org.listenbrainz.android.util.Utils.VerticalSpacer
@@ -73,7 +73,7 @@ import org.listenbrainz.android.util.Utils.formatDurationSeconds
 import org.listenbrainz.shared.util.Utils.getCoverArtUrl
 import org.listenbrainz.android.util.Utils.shareLink
 import org.listenbrainz.shared.viewmodel.SocialViewModel
-import org.listenbrainz.android.viewmodel.UserViewModel
+import org.listenbrainz.shared.viewmodel.UserViewModel
 
 @Composable
 fun CreatedForYouScreen(
@@ -144,7 +144,11 @@ private fun CreatedForYouScreen(
     var selectedPlaylist by remember {
         mutableStateOf<UserPlaylist?>(
             if (uiState.createdForTabUIState.createdForYouPlaylists.isNullOrEmpty()) null
-            else uiState.createdForTabUIState.createdForYouPlaylists[0].playlist
+            else {
+                uiState.createdForTabUIState.createdForYouPlaylists?.let {
+                    it[0].playlist
+                }
+            }
         )
     }
     val playlistData =
@@ -160,7 +164,11 @@ private fun CreatedForYouScreen(
         if (selectedPlaylist == null) {
             selectedPlaylist =
                 if (uiState.createdForTabUIState.createdForYouPlaylists.isNullOrEmpty()) null
-                else uiState.createdForTabUIState.createdForYouPlaylists[0].playlist
+                else {
+                    uiState.createdForTabUIState.createdForYouPlaylists?.let {
+                        it[0].playlist
+                    }
+                }
         }
     }
 
@@ -263,6 +271,7 @@ private fun CreatedForYouScreen(
                     )
                 }
             } else {
+                uiState.createdForTabUIState.createdForYouPlaylists?.let{ createdForYouPlaylists->
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
@@ -278,7 +287,7 @@ private fun CreatedForYouScreen(
                                 Spacer(modifier = Modifier.height(32.dp))
                                 PlaylistSelectionCardRow(
                                     modifier = Modifier.padding(vertical = 8.dp),
-                                    playlists = uiState.createdForTabUIState.createdForYouPlaylists.map { it.playlist },
+                                    playlists = createdForYouPlaylists.map { it.playlist },
                                     selectedPlaylist = selectedPlaylist,
                                     onPlaylistSelect = {
                                         selectedPlaylist = it
@@ -397,6 +406,7 @@ private fun CreatedForYouScreen(
                         }
                     }
                 }
+                    }
             }
         }
         PullRefreshIndicator(

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/createdforyou/CreatedForYouScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/createdforyou/CreatedForYouScreen.kt
@@ -143,12 +143,7 @@ private fun CreatedForYouScreen(
 ) {
     var selectedPlaylist by remember {
         mutableStateOf<UserPlaylist?>(
-            if (uiState.createdForTabUIState.createdForYouPlaylists.isNullOrEmpty()) null
-            else {
-                uiState.createdForTabUIState.createdForYouPlaylists?.let {
-                    it[0].playlist
-                }
-            }
+            uiState.createdForTabUIState.createdForYouPlaylists?.firstOrNull()?.playlist
         )
     }
     val playlistData =
@@ -162,13 +157,7 @@ private fun CreatedForYouScreen(
 
     LaunchedEffect(isRefreshing) {
         if (selectedPlaylist == null) {
-            selectedPlaylist =
-                if (uiState.createdForTabUIState.createdForYouPlaylists.isNullOrEmpty()) null
-                else {
-                    uiState.createdForTabUIState.createdForYouPlaylists?.let {
-                        it[0].playlist
-                    }
-                }
+            selectedPlaylist = uiState.createdForTabUIState.createdForYouPlaylists?.firstOrNull()?.playlist
         }
     }
 
@@ -272,141 +261,141 @@ private fun CreatedForYouScreen(
                 }
             } else {
                 uiState.createdForTabUIState.createdForYouPlaylists?.let{ createdForYouPlaylists->
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                ) {
-                    LazyColumn {
-                        item {
-                            Box(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .background(ListenBrainzTheme.colorScheme.background)
-                                    .padding(bottom = 12.dp)
-                            ) {
-                                Spacer(modifier = Modifier.height(32.dp))
-                                PlaylistSelectionCardRow(
-                                    modifier = Modifier.padding(vertical = 8.dp),
-                                    playlists = createdForYouPlaylists.map { it.playlist },
-                                    selectedPlaylist = selectedPlaylist,
-                                    onPlaylistSelect = {
-                                        selectedPlaylist = it
-                                    },
-                                    onSaveClick = onPlaylistSaveClick
-                                )
-                            }
-                        }
-
-                        item {
-                            Log.e(selectedPlaylist,"initial playlist selected")
-                            AnimatedContent(
-                                selectedPlaylist,
-                                modifier = Modifier
-                                    .background(brush = ListenBrainzTheme.colorScheme.userPageGradient)
-                            ) { playlist ->
-                                if (playlist == null) {
-                                    Box(
-                                        modifier = Modifier
-                                            .fillParentMaxWidth()
-                                            .padding(
-                                                horizontal = ListenBrainzTheme.paddings.horizontal,
-                                                vertical = 40.dp
-                                            ),
-                                        contentAlignment = Alignment.Center
-                                    ) {
-                                        Text(
-                                            text = "No playlist selected",
-                                            fontWeight = FontWeight.Medium,
-                                            color = ListenBrainzTheme.colorScheme.onBackground
-                                        )
-                                    }
-                                } else if (playlistData == null) {
-                                    Column(
-                                        modifier = Modifier
-                                            .fillParentMaxWidth()
-                                            .padding(
-                                                horizontal = ListenBrainzTheme.paddings.horizontal,
-                                                vertical = 40.dp
-                                            ),
-                                        horizontalAlignment = Alignment.CenterHorizontally
-                                    ) {
-                                        Text(
-                                            text = "Playlist data could not be loaded :(",
-                                            fontWeight = FontWeight.Medium,
-                                            color = ListenBrainzTheme.colorScheme.onBackground
-                                        )
-
-                                        VerticalSpacer(8.dp)
-
-                                        RetryButton {
-                                            onRetryDataFetch(playlist)
-                                        }
-                                    }
-                                } else {
-                                    PlaylistHeadingAndDescription(
-                                        title = playlistData.title ?: "No title",
-                                        tracksCount = playlistData.track.size,
-                                        lastUpdatedDate = playlistData.date ?: "No date",
-                                        description = playlistData.annotation
-                                            ?: "No description",
-                                        onPlayAllClick = {
-                                            onPlayAllClick()
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                    ) {
+                        LazyColumn {
+                            item {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .background(ListenBrainzTheme.colorScheme.background)
+                                        .padding(bottom = 12.dp)
+                                ) {
+                                    Spacer(modifier = Modifier.height(32.dp))
+                                    PlaylistSelectionCardRow(
+                                        modifier = Modifier.padding(vertical = 8.dp),
+                                        playlists = createdForYouPlaylists.map { it.playlist },
+                                        selectedPlaylist = selectedPlaylist,
+                                        onPlaylistSelect = {
+                                            selectedPlaylist = it
                                         },
-                                        onShareClick = {
-                                            onShareClick(playlist)
+                                        onSaveClick = onPlaylistSaveClick
+                                    )
+                                }
+                            }
+
+                            item {
+                                Log.e(selectedPlaylist,"initial playlist selected")
+                                AnimatedContent(
+                                    selectedPlaylist,
+                                    modifier = Modifier
+                                        .background(brush = ListenBrainzTheme.colorScheme.userPageGradient)
+                                ) { playlist ->
+                                    if (playlist == null) {
+                                        Box(
+                                            modifier = Modifier
+                                                .fillParentMaxWidth()
+                                                .padding(
+                                                    horizontal = ListenBrainzTheme.paddings.horizontal,
+                                                    vertical = 40.dp
+                                                ),
+                                            contentAlignment = Alignment.Center
+                                        ) {
+                                            Text(
+                                                text = "No playlist selected",
+                                                fontWeight = FontWeight.Medium,
+                                                color = ListenBrainzTheme.colorScheme.onBackground
+                                            )
                                         }
+                                    } else if (playlistData == null) {
+                                        Column(
+                                            modifier = Modifier
+                                                .fillParentMaxWidth()
+                                                .padding(
+                                                    horizontal = ListenBrainzTheme.paddings.horizontal,
+                                                    vertical = 40.dp
+                                                ),
+                                            horizontalAlignment = Alignment.CenterHorizontally
+                                        ) {
+                                            Text(
+                                                text = "Playlist data could not be loaded :(",
+                                                fontWeight = FontWeight.Medium,
+                                                color = ListenBrainzTheme.colorScheme.onBackground
+                                            )
+
+                                            VerticalSpacer(8.dp)
+
+                                            RetryButton {
+                                                onRetryDataFetch(playlist)
+                                            }
+                                        }
+                                    } else {
+                                        PlaylistHeadingAndDescription(
+                                            title = playlistData.title ?: "No title",
+                                            tracksCount = playlistData.track.size,
+                                            lastUpdatedDate = playlistData.date ?: "No date",
+                                            description = playlistData.annotation
+                                                ?: "No description",
+                                            onPlayAllClick = {
+                                                onPlayAllClick()
+                                            },
+                                            onShareClick = {
+                                                onShareClick(playlist)
+                                            }
+                                        )
+                                    }
+                                }
+                            }
+
+                            items(playlistData?.track?.size ?: 0) { trackIndex ->
+                                if (playlistData != null) {
+                                    val playlist = playlistData.track[trackIndex]
+                                    ListenCardSmallDefault(
+                                        modifier = Modifier.padding(
+                                            horizontal = ListenBrainzTheme.paddings.horizontal,
+                                            vertical = ListenBrainzTheme.paddings.lazyListAdjacent
+                                        ),
+                                        metadata = playlist.toMetadata(),
+                                        coverArtUrl = getCoverArtUrl(
+                                            caaReleaseMbid = playlist.extension.trackExtensionData.additionalMetadata.caaReleaseMbid,
+                                            caaId = playlist.extension.trackExtensionData.additionalMetadata.caaId
+                                        ),
+                                        onDropdownSuccess = { messsage ->
+                                            snackbarState.showSnackbar(messsage)
+                                        },
+                                        onDropdownError = { error ->
+                                            snackbarState.showSnackbar(error.toast)
+                                        },
+                                        goToArtistPage = goToArtistPage,
+                                        onClick =  {
+                                            onTrackClick(playlist)
+                                        },
+                                        trailingContent = {
+                                            Text(
+                                                modifier = Modifier
+                                                    .padding(bottom = 4.dp),
+                                                text = formatDurationSeconds(
+                                                    playlist.duration?.div(1000) ?: 0
+                                                ),
+                                                style = TextStyle(
+                                                    fontSize = 12.sp,
+                                                    fontWeight = FontWeight.Medium
+                                                ),
+                                                color = ListenBrainzTheme.colorScheme.listenText.copy(
+                                                    alpha = 0.8f
+                                                ),
+                                                maxLines = 1,
+                                                overflow = TextOverflow.Ellipsis
+                                            )
+                                        },
                                     )
                                 }
                             }
                         }
-
-                        items(playlistData?.track?.size ?: 0) { trackIndex ->
-                            if (playlistData != null) {
-                                val playlist = playlistData.track[trackIndex]
-                                ListenCardSmallDefault(
-                                    modifier = Modifier.padding(
-                                        horizontal = ListenBrainzTheme.paddings.horizontal,
-                                        vertical = ListenBrainzTheme.paddings.lazyListAdjacent
-                                    ),
-                                    metadata = playlist.toMetadata(),
-                                    coverArtUrl = getCoverArtUrl(
-                                        caaReleaseMbid = playlist.extension.trackExtensionData.additionalMetadata.caaReleaseMbid,
-                                        caaId = playlist.extension.trackExtensionData.additionalMetadata.caaId
-                                    ),
-                                    onDropdownSuccess = { messsage ->
-                                        snackbarState.showSnackbar(messsage)
-                                    },
-                                    onDropdownError = { error ->
-                                        snackbarState.showSnackbar(error.toast)
-                                    },
-                                    goToArtistPage = goToArtistPage,
-                                    onClick =  {
-                                        onTrackClick(playlist)
-                                    },
-                                    trailingContent = {
-                                        Text(
-                                            modifier = Modifier
-                                                .padding(bottom = 4.dp),
-                                            text = formatDurationSeconds(
-                                                playlist.duration?.div(1000) ?: 0
-                                            ),
-                                            style = TextStyle(
-                                                fontSize = 12.sp,
-                                                fontWeight = FontWeight.Medium
-                                            ),
-                                            color = ListenBrainzTheme.colorScheme.listenText.copy(
-                                                alpha = 0.8f
-                                            ),
-                                            maxLines = 1,
-                                            overflow = TextOverflow.Ellipsis
-                                        )
-                                    },
-                                )
-                            }
-                        }
                     }
                 }
-                    }
             }
         }
         PullRefreshIndicator(

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/listens/ListensScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/listens/ListensScreen.kt
@@ -101,7 +101,7 @@ import org.listenbrainz.android.ui.components.ListenCardSmallDefault
 import org.listenbrainz.android.ui.components.MusicBrainzButton
 import org.listenbrainz.android.ui.components.SimilarUserCard
 import org.listenbrainz.android.ui.components.SuccessBar
-import org.listenbrainz.android.ui.screens.profile.ProfileUiState
+import org.listenbrainz.shared.ui.screens.profile.ProfileUiState
 import org.listenbrainz.shared.ui.screens.settings.PreferencesUiState
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.ui.theme.app_bg_mid
@@ -115,7 +115,7 @@ import org.listenbrainz.android.util.consumeHorizontalDrag
 import org.listenbrainz.android.util.optionalSharedElement
 import org.listenbrainz.shared.viewmodel.ListensViewModel
 import org.listenbrainz.shared.viewmodel.SocialViewModel
-import org.listenbrainz.android.viewmodel.UserViewModel
+import org.listenbrainz.shared.viewmodel.UserViewModel
 import java.util.UUID
 
 @Composable
@@ -665,60 +665,62 @@ fun ListensScreen(
                         }
 
                         if (!uiState.listensTabUiState.similarUsers.isNullOrEmpty()) {
-                            item {
-                                Text(
-                                    modifier = Modifier
-                                        .headerTextVerticalPadding()
-                                        .padding(horizontal = ListenBrainzTheme.paddings.horizontal),
-                                    text = "Similar Users",
-                                    color = ListenBrainzTheme.colorScheme.text,
-                                    style = MaterialTheme.typography.bodyLarge.copy(fontSize = 22.sp),
-                                )
-                            }
-
-                            if (isRefreshing) {
-                                items(5) {
-                                    ShimmerSimilarUsersItem(shimmerInstance)
-                                    Spacer(modifier = Modifier.height(10.dp))
-                                }
-                            } else {
-                                itemsIndexed(
-                                    if (similarUsersCollapsibleState) {
-                                        uiState.listensTabUiState.similarUsers.take(5)
-                                    } else {
-                                        uiState.listensTabUiState.similarUsers
-                                    },
-                                    contentType = { _, _ -> "SimilarUserCard" }
-                                ) { index, item ->
-                                    SimilarUserCard(
-                                        index = index,
-                                        userName = item.username,
-                                        similarity = item.similarity.toFloat(),
-                                        modifier = Modifier.padding(
-                                            horizontal = 10.dp,
-                                            vertical = 4.dp
-                                        ),
-                                        goToUserPage = goToUserProfile
+                            uiState.listensTabUiState.similarUsers?.let { similarUsers->
+                                item {
+                                    Text(
+                                        modifier = Modifier
+                                            .headerTextVerticalPadding()
+                                            .padding(horizontal = ListenBrainzTheme.paddings.horizontal),
+                                        text = "Similar Users",
+                                        color = ListenBrainzTheme.colorScheme.text,
+                                        style = MaterialTheme.typography.bodyLarge.copy(fontSize = 22.sp),
                                     )
                                 }
-                            }
 
-                            item {
-                                if ((uiState.listensTabUiState.similarUsers.size) > 5) {
-                                    Row(
-                                        modifier = Modifier.fillMaxWidth(),
-                                        horizontalArrangement = Arrangement.Center
-                                    ) {
-                                        LoadMoreButton(
-                                            modifier = Modifier
-                                                .padding(horizontal = ListenBrainzTheme.paddings.horizontal)
-                                                .padding(top = 16.dp),
-                                            state = similarUsersCollapsibleState,
-                                            onClick = {
-                                                similarUsersCollapsibleState =
-                                                    !similarUsersCollapsibleState
-                                            }
+                                if (isRefreshing) {
+                                    items(5) {
+                                        ShimmerSimilarUsersItem(shimmerInstance)
+                                        Spacer(modifier = Modifier.height(10.dp))
+                                    }
+                                } else {
+                                    itemsIndexed(
+                                        if (similarUsersCollapsibleState) {
+                                            similarUsers.take(5)
+                                        } else {
+                                            similarUsers
+                                        },
+                                        contentType = { _, _ -> "SimilarUserCard" }
+                                    ) { index, item ->
+                                        SimilarUserCard(
+                                            index = index,
+                                            userName = item.username,
+                                            similarity = item.similarity.toFloat(),
+                                            modifier = Modifier.padding(
+                                                horizontal = 10.dp,
+                                                vertical = 4.dp
+                                            ),
+                                            goToUserPage = goToUserProfile
                                         )
+                                    }
+                                }
+
+                                item {
+                                    if ((similarUsers.size) > 5) {
+                                        Row(
+                                            modifier = Modifier.fillMaxWidth(),
+                                            horizontalArrangement = Arrangement.Center
+                                        ) {
+                                            LoadMoreButton(
+                                                modifier = Modifier
+                                                    .padding(horizontal = ListenBrainzTheme.paddings.horizontal)
+                                                    .padding(top = 16.dp),
+                                                state = similarUsersCollapsibleState,
+                                                onClick = {
+                                                    similarUsersCollapsibleState =
+                                                        !similarUsersCollapsibleState
+                                                }
+                                            )
+                                        }
                                     }
                                 }
                             }

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/listens/ListensScreenMockData.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/listens/ListensScreenMockData.kt
@@ -11,8 +11,8 @@ import org.listenbrainz.shared.model.SocialUiState
 import org.listenbrainz.shared.model.TrackMetadata
 import org.listenbrainz.shared.model.feed.FeedListenArtist
 import org.listenbrainz.shared.model.user.Artist
-import org.listenbrainz.android.ui.screens.profile.ListensTabUiState
-import org.listenbrainz.android.ui.screens.profile.ProfileUiState
+import org.listenbrainz.shared.ui.screens.profile.ListensTabUiState
+import org.listenbrainz.shared.ui.screens.profile.ProfileUiState
 import org.listenbrainz.shared.ui.screens.settings.PreferencesUiState
 
 /**

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/playlists/UserPlaylistScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/playlists/UserPlaylistScreen.kt
@@ -71,7 +71,7 @@ import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.ui.theme.lb_purple_night
 import org.listenbrainz.android.util.Utils.shareLink
 import org.listenbrainz.shared.viewmodel.PlaylistDataViewModel
-import org.listenbrainz.android.viewmodel.UserViewModel
+import org.listenbrainz.shared.viewmodel.UserViewModel
 
 @OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/stats/DataScope.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/stats/DataScope.kt
@@ -1,6 +1,0 @@
-package org.listenbrainz.android.ui.screens.profile.stats
-
-enum class DataScope {
-    USER,
-    GLOBAL
-}

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/stats/StatsScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/stats/StatsScreen.kt
@@ -82,8 +82,8 @@ import org.listenbrainz.android.ui.components.ListenCardSmallDefault
 import org.listenbrainz.android.ui.components.SelectionChipBar
 import org.listenbrainz.android.ui.components.SuccessBar
 import org.listenbrainz.android.ui.screens.artist.formatNumber
-import org.listenbrainz.android.ui.screens.profile.ProfileUiState
-import org.listenbrainz.android.ui.screens.profile.StatsTabUIState
+import org.listenbrainz.shared.ui.screens.profile.ProfileUiState
+import org.listenbrainz.shared.ui.screens.profile.StatsTabUIState
 import org.listenbrainz.android.ui.screens.profile.listens.LoadMoreButton
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
 import org.listenbrainz.android.util.PreviewSurface
@@ -92,7 +92,9 @@ import org.listenbrainz.android.util.Utils.Spacer
 import org.listenbrainz.shared.util.Utils.getCoverArtUrl
 import org.listenbrainz.android.util.getStringResource
 import org.listenbrainz.shared.viewmodel.SocialViewModel
-import org.listenbrainz.android.viewmodel.UserViewModel
+import org.listenbrainz.shared.viewmodel.UserViewModel
+import org.listenbrainz.shared.ui.screens.profile.stats.DataScope
+import org.listenbrainz.shared.ui.screens.profile.stats.StatsRange
 
 @Composable
 fun StatsScreen(
@@ -140,7 +142,7 @@ fun StatsScreen(
 fun StatsScreen(
     username: String?,
     uiState: ProfileUiState,
-    fetchListeningActivity: suspend (StatsRange, DataScope,Boolean) -> Unit,
+    fetchListeningActivity: suspend (StatsRange, DataScope, Boolean) -> Unit,
     fetchTopArtists: suspend (String?, Boolean) -> Unit,
     fetchTopAlbums: suspend (String?, Boolean) -> Unit,
     fetchTopSongs: suspend (String?, Boolean) -> Unit,

--- a/app/src/main/java/org/listenbrainz/android/ui/screens/profile/taste/TasteScreen.kt
+++ b/app/src/main/java/org/listenbrainz/android/ui/screens/profile/taste/TasteScreen.kt
@@ -59,8 +59,8 @@ import org.listenbrainz.android.ui.components.ErrorBar
 import org.listenbrainz.android.ui.components.ListenCardSmallDefault
 import org.listenbrainz.android.ui.components.SelectionChipBar
 import org.listenbrainz.android.ui.components.SuccessBar
-import org.listenbrainz.android.ui.screens.profile.ProfileUiState
-import org.listenbrainz.android.ui.screens.profile.TasteTabUIState
+import org.listenbrainz.shared.ui.screens.profile.ProfileUiState
+import org.listenbrainz.shared.ui.screens.profile.TasteTabUIState
 import org.listenbrainz.android.ui.screens.profile.listens.LoadMoreButton
 import org.listenbrainz.android.ui.screens.profile.listens.headerTextVerticalPadding
 import org.listenbrainz.android.ui.theme.ListenBrainzTheme
@@ -68,7 +68,7 @@ import org.listenbrainz.android.util.PreviewSurface
 import org.listenbrainz.shared.util.Utils.getCoverArtUrl
 import org.listenbrainz.shared.viewmodel.FeedViewModel
 import org.listenbrainz.shared.viewmodel.SocialViewModel
-import org.listenbrainz.android.viewmodel.UserViewModel
+import org.listenbrainz.shared.viewmodel.UserViewModel
 
 @Composable
 fun TasteScreen(

--- a/app/src/test/java/org/listenbrainz/android/user/UserRepositoryTest.kt
+++ b/app/src/test/java/org/listenbrainz/android/user/UserRepositoryTest.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
 import org.listenbrainz.android.BaseUnitTest
 import org.listenbrainz.shared.model.ResponseError
-import org.listenbrainz.android.repository.user.UserRepository
+import org.listenbrainz.shared.repository.user.UserRepository
 import org.listenbrainz.shared.util.Resource
 import org.listenbrainz.sharedtest.testdata.UserRepositoryTestData.allPinsTestData
 import org.listenbrainz.sharedtest.testdata.UserRepositoryTestData.currentPinsTestData

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedRepositoryModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedRepositoryModule.kt
@@ -31,6 +31,8 @@ import org.listenbrainz.shared.repository.brainzplayer.BPAlbumRepository
 import org.listenbrainz.shared.repository.brainzplayer.BPAlbumRepositoryImpl
 import org.listenbrainz.shared.repository.brainzplayer.BPArtistRepository
 import org.listenbrainz.shared.repository.brainzplayer.BPArtistRepositoryImpl
+import org.listenbrainz.shared.repository.user.UserRepository
+import org.listenbrainz.shared.repository.user.UserRepositoryImpl
 
 val sharedRepositoryModule = module {
     single<SocketRepository> { SocketRepositoryImpl(get<HttpClient>(named(SHARED_HTTP_CLIENT)),get()) }
@@ -55,4 +57,5 @@ val sharedRepositoryModule = module {
     single<BPArtistRepository> { BPArtistRepositoryImpl(get(),get(),get()) }
     single<PlaylistDataRepository> { PlaylistDataRepositoryImpl(get(),get(),get(),get(named(IO_DISPATCHER))) }
     single<FeedRepository> { FeedRepositoryImpl(get()) }
+    single<UserRepository> { UserRepositoryImpl(get(),get()) }
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
@@ -21,6 +21,7 @@ import org.listenbrainz.shared.viewmodel.SearchViewModel
 import org.listenbrainz.shared.viewmodel.SettingsViewModel
 import org.listenbrainz.shared.viewmodel.SongViewModel
 import org.listenbrainz.shared.viewmodel.UserViewModel
+import org.listenbrainz.shared.viewmodel.SocialViewModel
 
 val sharedViewModelModule = module {
     viewModel { SettingsViewModel(get(),get()) }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
@@ -18,6 +18,7 @@ import org.listenbrainz.shared.viewmodel.PlaylistViewModel
 import org.listenbrainz.shared.viewmodel.BPAlbumViewModel
 import org.listenbrainz.shared.viewmodel.PlaylistDataViewModel
 import org.listenbrainz.shared.viewmodel.SearchViewModel
+import org.listenbrainz.shared.viewmodel.PlaylistDataViewModel
 import org.listenbrainz.shared.viewmodel.SettingsViewModel
 import org.listenbrainz.shared.viewmodel.SongViewModel
 import org.listenbrainz.shared.viewmodel.SocialViewModel

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
@@ -18,10 +18,9 @@ import org.listenbrainz.shared.viewmodel.PlaylistViewModel
 import org.listenbrainz.shared.viewmodel.BPAlbumViewModel
 import org.listenbrainz.shared.viewmodel.PlaylistDataViewModel
 import org.listenbrainz.shared.viewmodel.SearchViewModel
-import org.listenbrainz.shared.viewmodel.PlaylistDataViewModel
 import org.listenbrainz.shared.viewmodel.SettingsViewModel
 import org.listenbrainz.shared.viewmodel.SongViewModel
-import org.listenbrainz.shared.viewmodel.SocialViewModel
+import org.listenbrainz.shared.viewmodel.UserViewModel
 
 val sharedViewModelModule = module {
     viewModel { SettingsViewModel(get(),get()) }
@@ -41,4 +40,5 @@ val sharedViewModelModule = module {
     viewModel { SocialViewModel(get(),get(),get(),get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER)),get<StringProvider>()) }
     viewModel { FeedViewModel(get(),get(),get(),get(),get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER))) }
     viewModel { SearchViewModel(get(),get(),get(),get(),get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER))) }
+    viewModel { UserViewModel(get(),get(),get(),get(),get(),get(named(IO_DISPATCHER))) }
 }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
@@ -35,7 +35,6 @@ val sharedViewModelModule = module {
     viewModel { PlaylistViewModel(get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER))) }
     viewModel { BPAlbumViewModel(get(),get(named(IO_DISPATCHER))) }
     viewModel { BPArtistViewModel(get(),get(named(IO_DISPATCHER))) }
-    viewModel { ListensViewModel(get(),get(),get(),get(),get(named(DEFAULT_DISPATCHER))) }
     viewModel { ListeningNowViewModel(get(),get(),get(),get(named(IO_DISPATCHER))) }
     viewModel { PlaylistDataViewModel(get(),get(),get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER)),get<StringProvider>()) }
     viewModel { SocialViewModel(get(),get(),get(),get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER)),get<StringProvider>()) }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/di/SharedViewModelModule.kt
@@ -35,6 +35,7 @@ val sharedViewModelModule = module {
     viewModel { PlaylistViewModel(get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER))) }
     viewModel { BPAlbumViewModel(get(),get(named(IO_DISPATCHER))) }
     viewModel { BPArtistViewModel(get(),get(named(IO_DISPATCHER))) }
+    viewModel { ListensViewModel(get(),get(),get(),get(),get(named(DEFAULT_DISPATCHER))) }
     viewModel { ListeningNowViewModel(get(),get(),get(),get(named(IO_DISPATCHER))) }
     viewModel { PlaylistDataViewModel(get(),get(),get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER)),get<StringProvider>()) }
     viewModel { SocialViewModel(get(),get(),get(),get(),get(named(IO_DISPATCHER)),get(named(DEFAULT_DISPATCHER)),get<StringProvider>()) }

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/user/UserRepository.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/user/UserRepository.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android.repository.user
+package org.listenbrainz.shared.repository.user
 
 import org.listenbrainz.shared.model.user.AllPinnedRecordings
 import org.listenbrainz.shared.model.CurrentPins

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/user/UserRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/repository/user/UserRepositoryImpl.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android.repository.user
+package org.listenbrainz.shared.repository.user
 
 import org.listenbrainz.shared.model.CurrentPins
 import org.listenbrainz.shared.model.Listens

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/ui/screens/profile/ProfileUiState.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/ui/screens/profile/ProfileUiState.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android.ui.screens.profile
+package org.listenbrainz.shared.ui.screens.profile
 
 import androidx.paging.PagingData
 import kotlinx.coroutines.flow.Flow
@@ -7,6 +7,7 @@ import org.listenbrainz.shared.model.Listen
 import org.listenbrainz.shared.model.ListenBitmap
 import org.listenbrainz.shared.model.PinnedRecording
 import org.listenbrainz.shared.model.SimilarUser
+import org.listenbrainz.shared.model.playback.SharedPlayerState
 import org.listenbrainz.shared.model.playlist.PlaylistData
 import org.listenbrainz.shared.model.user.AllPinnedRecordings
 import org.listenbrainz.shared.model.user.Artist
@@ -18,9 +19,8 @@ import org.listenbrainz.shared.model.user.UserFeedback
 import org.listenbrainz.shared.model.userPlaylist.UserPlaylist
 import org.listenbrainz.shared.model.userPlaylist.UserPlaylists
 import org.listenbrainz.shared.ui.screens.profile.listens.ListeningNowUiState
-import org.listenbrainz.android.ui.screens.profile.stats.StatsRange
-import org.listenbrainz.android.ui.screens.profile.stats.DataScope
-import org.listenbrainz.shared.model.playback.SharedPlayerState
+import org.listenbrainz.shared.ui.screens.profile.stats.DataScope
+import org.listenbrainz.shared.ui.screens.profile.stats.StatsRange
 
 data class ProfileUiState(
     val loggedInUser: String? = null,

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/ui/screens/profile/listens/UserListensPagingSource.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/ui/screens/profile/listens/UserListensPagingSource.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android.ui.screens.profile.listens
+package org.listenbrainz.shared.ui.screens.profile.listens
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
@@ -8,6 +8,7 @@ import org.listenbrainz.shared.model.Listen
 import org.listenbrainz.shared.model.ResponseError
 import org.listenbrainz.shared.repository.listens.ListensRepository
 import org.listenbrainz.shared.util.Resource
+import kotlin.time.Clock
 
 class UserListensPagingSource(
     private val username: String?,
@@ -17,7 +18,7 @@ class UserListensPagingSource(
 ) : PagingSource<Long, Listen>() {
 
     override fun getRefreshKey(state: PagingState<Long, Listen>): Long? {
-        return System.currentTimeMillis() / 1000
+        return Clock.System.now().epochSeconds
     }
 
     override suspend fun load(params: LoadParams<Long>): LoadResult<Long, Listen> {

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/ui/screens/profile/stats/DataScope.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/ui/screens/profile/stats/DataScope.kt
@@ -1,0 +1,6 @@
+package org.listenbrainz.shared.ui.screens.profile.stats
+
+enum class DataScope {
+    USER,
+    GLOBAL
+}

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/ui/screens/profile/stats/StatsRange.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/ui/screens/profile/stats/StatsRange.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android.ui.screens.profile.stats
+package org.listenbrainz.shared.ui.screens.profile.stats
 
 enum class StatsRange (val rangeString: String, val apiIdenfier: String){
     THIS_WEEK("This Week", "this_week"),

--- a/shared/src/commonMain/kotlin/org/listenbrainz/shared/viewmodel/UserViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/listenbrainz/shared/viewmodel/UserViewModel.kt
@@ -1,4 +1,4 @@
-package org.listenbrainz.android.viewmodel
+package org.listenbrainz.shared.viewmodel
 
 import androidx.lifecycle.viewModelScope
 import androidx.paging.Pager
@@ -27,21 +27,20 @@ import org.listenbrainz.shared.repository.listens.ListensRepository
 import org.listenbrainz.shared.repository.playlists.PlaylistDataRepository
 import org.listenbrainz.shared.repository.AppPreferences
 import org.listenbrainz.shared.repository.social.SocialRepository
-import org.listenbrainz.android.repository.user.UserRepository
-import org.listenbrainz.android.ui.screens.profile.CreatedForTabUIState
-import org.listenbrainz.android.ui.screens.profile.ListensTabUiState
-import org.listenbrainz.android.ui.screens.profile.PlaylistTabUIState
-import org.listenbrainz.android.ui.screens.profile.ProfileUiState
-import org.listenbrainz.android.ui.screens.profile.StatsTabUIState
-import org.listenbrainz.android.ui.screens.profile.TasteTabUIState
-import org.listenbrainz.android.ui.screens.profile.listens.UserListensPagingSource
+import org.listenbrainz.shared.repository.user.UserRepository
+import org.listenbrainz.shared.ui.screens.profile.CreatedForTabUIState
+import org.listenbrainz.shared.ui.screens.profile.ListensTabUiState
+import org.listenbrainz.shared.ui.screens.profile.PlaylistTabUIState
+import org.listenbrainz.shared.ui.screens.profile.ProfileUiState
+import org.listenbrainz.shared.ui.screens.profile.StatsTabUIState
+import org.listenbrainz.shared.ui.screens.profile.TasteTabUIState
+import org.listenbrainz.shared.ui.screens.profile.listens.UserListensPagingSource
 import org.listenbrainz.shared.ui.screens.profile.playlists.CollabPlaylistPagingSource
 import org.listenbrainz.shared.ui.screens.profile.playlists.UserPlaylistPagingSource
-import org.listenbrainz.android.ui.screens.profile.stats.StatsRange
-import org.listenbrainz.android.ui.screens.profile.stats.DataScope
+import org.listenbrainz.shared.ui.screens.profile.stats.DataScope
+import org.listenbrainz.shared.ui.screens.profile.stats.StatsRange
 import org.listenbrainz.shared.model.user.Artist
 import org.listenbrainz.shared.util.Resource
-import org.listenbrainz.shared.viewmodel.BaseViewModel
 
 class UserViewModel(
     val appPreferences: AppPreferences,
@@ -177,11 +176,11 @@ class UserViewModel(
         }
     }
 
-    private suspend fun getSimilarArtists(username: String?): List<org.listenbrainz.shared.model.user.Artist> {
+    private suspend fun getSimilarArtists(username: String?): List<Artist> {
         val currentUsername = appPreferences.username.get()
         val currentUserTopArtists = userRepository.getTopArtists(currentUsername, count = 100)
         val userTopArtists = userRepository.getTopArtists(username, count = 100)
-        val similarArtists = mutableListOf<org.listenbrainz.shared.model.user.Artist>()
+        val similarArtists = mutableListOf<Artist>()
         currentUserTopArtists.data?.payload?.artists?.map { currentUserTopArtist ->
             userTopArtists.data?.payload?.artists?.map { userTopArtist ->
                 if (currentUserTopArtist.artistName == userTopArtist.artistName) {

--- a/sharedTest/src/main/java/org/listenbrainz/sharedtest/mocks/MockUserRepository.kt
+++ b/sharedTest/src/main/java/org/listenbrainz/sharedtest/mocks/MockUserRepository.kt
@@ -10,7 +10,7 @@ import org.listenbrainz.shared.model.user.TopSongs
 import org.listenbrainz.shared.model.user.UserFeedback
 import org.listenbrainz.shared.model.user.UserListeningActivity
 import org.listenbrainz.shared.model.user.UserSimilarityPayload
-import org.listenbrainz.android.repository.user.UserRepository
+import org.listenbrainz.shared.repository.user.UserRepository
 import org.listenbrainz.shared.util.Resource
 import org.listenbrainz.sharedtest.testdata.UserRepositoryTestData.allPinsTestData
 import org.listenbrainz.sharedtest.testdata.UserRepositoryTestData.createdForYouPlaylistsTestData


### PR DESCRIPTION
## Base PR:- #758 , #760 
#### Rebased with latest upstream/cmp, and this branch consists every commit from the base branches. Needed `PlaylistDataRepository`, so had to take base #760 completely.

---
This PR fixes #702  migrates `UserViewModel` to shared module.

## Key Changes:- 
1. Moved related data models to shared module.
2. Moved `UserListensPagingSource` to shared module.
3. Moved `UserRepository` and its impl to shared module and registered it inside `sharedRepositoryModule`.
4. Moved `UserViewmodel` to shared module and registered it inside `sharedViewmodelModule`.